### PR TITLE
Continue revival with local node, desktop spike, and split credentials

### DIFF
--- a/.github/workflows/desktop-spike.yaml
+++ b/.github/workflows/desktop-spike.yaml
@@ -27,6 +27,11 @@ jobs:
           python-version: "3.12"
           cache: pip
           cache-dependency-path: spikes/desktop/pyproject.toml
+      - name: Install Linux Qt runtime libraries
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends --yes libdbus-1-3 libegl1 libgl1 libxkbcommon0
       # Each shell gets a clean runner so an installed alternative cannot leak modules into
       # PyInstaller analysis and distort the bundle-size comparison.
       - name: Install one experimental shell

--- a/.github/workflows/desktop-spike.yaml
+++ b/.github/workflows/desktop-spike.yaml
@@ -1,0 +1,45 @@
+name: Desktop shell spike
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/desktop-spike.yaml"
+      - "docs/adr/0002-desktop-shell-spike.md"
+      - "spikes/desktop/**"
+  workflow_dispatch:
+
+jobs:
+  package:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        shell: [pyside, webview]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    defaults:
+      run:
+        working-directory: spikes/desktop
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: spikes/desktop/pyproject.toml
+      # Each shell gets a clean runner so an installed alternative cannot leak modules into
+      # PyInstaller analysis and distort the bundle-size comparison.
+      - name: Install one experimental shell
+        run: python -m pip install -e ".[dev,${{ matrix.shell }}]"
+      - name: Run shared protocol acceptance tests
+        run: |
+          python -m unittest discover -s tests -v
+          communityai-desktop-spike --self-test
+      - name: Build and smoke independent bundle
+        run: python build_spike.py --shell ${{ matrix.shell }}
+      - name: Upload unsigned experiment bundles and metrics
+        uses: actions/upload-artifact@v6
+        with:
+          name: desktop-spike-${{ matrix.os }}-${{ matrix.shell }}
+          path: spikes/desktop/dist/desktop-spike
+          retention-days: 7

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -60,12 +60,16 @@ jobs:
             tests/test_join_token.py \
             tests/test_kv_cache_strategy.py \
             tests/test_loading_diagnostics.py \
+            tests/test_model_manager.py \
             tests/test_model_manifest.py \
+            tests/test_node_config.py \
+            tests/test_node.py \
             tests/test_openai_api.py \
             tests/test_paged_cache.py \
             tests/test_priority_pool.py \
             tests/test_process_lifetime.py \
             tests/test_protocol_identity.py \
+            tests/test_route_health.py \
             tests/test_server_registry.py \
             tests/test_startup_guard.py \
             tests/test_tied_embeddings_from_pretrained.py

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -42,16 +42,20 @@ jobs:
           # Free-tier runners have ~2 vCPUs, which cannot sustain a live inference swarm: the
           # upstream suite launched multiple servers (some running a --throughput auto benchmark),
           # starved the CPU, and the client tests retried for many minutes and effectively hung.
-          # The tests below are pure, synthetic, single-process bit-exact checks -- no DHT, no
-          # server, no model download, no network -- so they finish in seconds and still guard the
+          # The tests below are offline synthetic checks -- no live DHT, model download, or
+          # external network. The node gates additionally use a loopback-only HTTP listener and
+          # short isolated sleeper/crash subprocesses. They still finish quickly and guard the
           # parts of this fork most likely to regress (KV cache, paged cache, per-arch blocks,
           # attention wiring, join tokens, device portability). The swarm/network tests
           # (test_full_model, test_remote_sequential, ...) require MODEL_NAME/INITIAL_PEERS and a
           # running swarm; the maintainer exercises those on real hardware.
           pytest -v --durations=0 --durations-min=1.0 \
             tests/test_attn_implementation.py \
+            tests/test_api_keys.py \
             tests/test_cache.py \
             tests/test_deepseek_v3.py \
+            tests/test_discovery.py \
+            tests/test_edge_benchmark.py \
             tests/test_device_portability.py \
             tests/test_gemma4_block.py \
             tests/test_gemma4_multimodal_loading.py \
@@ -65,6 +69,7 @@ jobs:
             tests/test_node_config.py \
             tests/test_node.py \
             tests/test_openai_api.py \
+            tests/test_official_openai_client.py \
             tests/test_paged_cache.py \
             tests/test_priority_pool.py \
             tests/test_process_lifetime.py \
@@ -72,7 +77,8 @@ jobs:
             tests/test_route_health.py \
             tests/test_server_registry.py \
             tests/test_startup_guard.py \
-            tests/test_tied_embeddings_from_pretrained.py
+            tests/test_tied_embeddings_from_pretrained.py \
+            tests/test_worker_supervisor.py
 
       - name: Generate pinned TinyLlama manifest (macOS gate)
         if: matrix.os == 'macos'

--- a/Dockerfile.fly-smoke
+++ b/Dockerfile.fly-smoke
@@ -21,6 +21,7 @@ COPY scripts/install.sh ./scripts/install.sh
 
 # Exercise the supported Linux installer itself while building the smoke image.
 RUN DRIFT_DEVICE=cpu sh scripts/install.sh \
+    && uv pip install --python /workspace/.venv/bin/python ".[api,benchmark]" "openai>=2,<3" \
     && rm -rf /root/.cache/uv
 
 FROM python:3.12-slim-bookworm

--- a/README.md
+++ b/README.md
@@ -175,15 +175,21 @@ drift node --config ./community-node.json
 ```
 
 The default OpenAI URL is `http://127.0.0.1:8080/v1`. If `--api_key` is omitted,
-the command creates a persistent key in `~/.drift/node/local-api.key` and logs only
-that path. The same bearer key authenticates the versioned local status endpoint:
+the command creates a persistent client key in `~/.drift/node/local-api.key` and
+logs only that path. It separately creates the privileged local control credential
+in `~/.drift/node/control-api.key`:
 
 ```bash
-curl -H "Authorization: Bearer $(cat ~/.drift/node/local-api.key)" \
+curl -H "Authorization: Bearer $(cat ~/.drift/node/control-api.key)" \
     http://127.0.0.1:8080/control/v1/status
 ```
 
-Binding beyond loopback requires both an API key and the explicit
+OpenAI client keys authorize only `/v1/*`; the control credential authorizes only
+`/control/v1/*`. An existing installation keeps its `local-api.key` for AI clients
+and receives the separate control key on its first upgraded start. A headless
+operator may select another private control file with `--control_key_path`.
+
+Binding beyond loopback requires both key classes and the explicit
 `--allow_network` acknowledgement. Authenticated status includes model lifecycle,
 runtime-budget, active-request, and loaded-route coverage data; idle models can be
 unloaded through the control API. The boundary and deferred work are recorded in

--- a/README.md
+++ b/README.md
@@ -153,6 +153,42 @@ print(client.chat.completions.create(
 
 Generation is serialized (`--max_concurrent`, default 1) since each in-flight request holds a server-side attention cache. API requests use finite failover by default: each swarm RPC waits at most 30 seconds and each step gets at most three route attempts. Operators can tune `--request_timeout` and `--max_retries` for slower hardware.
 
+### 5. Persistent local node (milestone 4 preview)
+
+`drift node` keeps a stable authenticated API on loopback, registers exact
+`ModelManifest v1` identities, and lazily loads tokenizer and client-side weights
+on first use. A manifest name, declared API alias, or full `sha256:<digest>` selects
+that exact swarm; an unknown `model` is rejected instead of being silently
+substituted.
+
+```bash
+drift node ./tinyllama-manifest.json \
+    --initial_peers /ip4/203.0.113.10/tcp/31337/p2p/QmXXX...
+```
+
+For multiple models, use the strict, secret-free
+[`NodeConfig v1`](docs/NODE_CONFIG_V1.md). It registers every model without eager
+artifact downloads and enforces a hard `max_loaded_models` residency limit:
+
+```bash
+drift node --config ./community-node.json
+```
+
+The default OpenAI URL is `http://127.0.0.1:8080/v1`. If `--api_key` is omitted,
+the command creates a persistent key in `~/.drift/node/local-api.key` and logs only
+that path. The same bearer key authenticates the versioned local status endpoint:
+
+```bash
+curl -H "Authorization: Bearer $(cat ~/.drift/node/local-api.key)" \
+    http://127.0.0.1:8080/control/v1/status
+```
+
+Binding beyond loopback requires both an API key and the explicit
+`--allow_network` acknowledgement. Authenticated status includes model lifecycle,
+runtime-budget, active-request, and loaded-route coverage data; idle models can be
+unloaded through the control API. The boundary and deferred work are recorded in
+[`docs/adr/0001-unified-local-node.md`](docs/adr/0001-unified-local-node.md).
+
 ## Installation
 
 The [Quickstart](#quickstart) install scripts (`scripts/install.sh` / `scripts/install.ps1`) are the easiest path — they detect your accelerator, install a matching PyTorch build, and provide the `drift` command. The rest of this section covers installing manually.
@@ -165,7 +201,7 @@ cd CommunityAI
 uv sync --extra dev
 ```
 
-This installs the `drift` command (`drift up`, `drift server`, `drift dht`, `drift api`); each is also runnable as `python -m drift.cli <command>`.
+This installs the `drift` command (`drift up`, `drift server`, `drift dht`, `drift api`, `drift node`); each is also runnable as `python -m drift.cli <command>`.
 
 ### Windows native setup
 

--- a/docs/NODE_CONFIG_V1.md
+++ b/docs/NODE_CONFIG_V1.md
@@ -1,0 +1,89 @@
+# Local node configuration v1
+
+`drift node --config <path>` registers multiple exact `ModelManifest v1`
+swarm identities behind one localhost OpenAI endpoint. Configuration is parsed and
+validated completely before the HTTP listener starts. Model artifacts remain lazy:
+registration does not download tokenizers or client-side weights.
+
+## Format
+
+```json
+{
+  "schema_version": 1,
+  "max_loaded_models": 1,
+  "models": [
+    {
+      "manifest": "manifests/tinyllama.json",
+      "initial_peers": [
+        "/ip4/203.0.113.10/tcp/31337/p2p/QmExample"
+      ],
+      "cache_dir": "cache/tinyllama",
+      "revocation_files": ["trust/revoked.json"],
+      "request_timeout": 30,
+      "max_retries": 3
+    }
+  ]
+}
+```
+
+Paths are resolved relative to the configuration file, not the process working
+directory. `cache_dir`, `revocation_files`, `request_timeout`, and `max_retries`
+are optional. Their defaults are `null`, an empty list, 30 seconds, and three
+attempts respectively.
+
+The parser rejects unknown fields, duplicate JSON keys, non-finite numbers,
+duplicate manifest paths, empty peer sets, and invalid resource limits. Every
+manifest is loaded and runtime-validated at startup. Names, aliases, and manifest
+digests must be unique case-insensitively across the entire node.
+
+Provider tokens, local API keys, and identity private keys are deliberately absent
+from this format. A Hugging Face token may currently be supplied with the process
+secret mechanism or the existing `--token` compatibility option. The generated
+localhost API key remains in the node's dedicated secret file unless explicitly
+supplied by the operator.
+
+## Runtime residency
+
+`max_loaded_models` is a hard limit on simultaneous client runtimes. A request
+loads its exact model lazily and holds a lease for the full generation, including
+an executor thread that outlives a cancelled HTTP request. When the limit is full,
+the manager evicts the least-recently-used idle runtime. It waits rather than
+closing a runtime with an active request.
+
+An authenticated control client may explicitly unload an idle model:
+
+```text
+POST /control/v1/models/unload
+Authorization: Bearer <local key>
+Content-Type: application/json
+
+{"model":"configured name, alias, or sha256 digest"}
+```
+
+The endpoint returns HTTP 409 while the selected runtime has active requests. A
+successful unload closes its route manager and DHT before returning. Configuration
+and verified on-disk artifacts remain, so a later inference request can load it
+again.
+
+## Route status
+
+For a loaded client, the authenticated status endpoint reports the last routing
+snapshot already verified by its sequence manager: covered and missing blocks,
+per-block replica counts, minimum replicas, peer count, and observation age. Status
+reads do not trigger downloads, DHT refreshes, or probes. A loaded runtime with
+unknown or incomplete coverage is reported as `degraded`; complete coverage is
+reported as `ready`.
+
+An unloaded model has no active sequence manager, so its route is currently
+reported as unknown. Lightweight coverage discovery for every configured but
+unloaded model remains a separate milestone-4 slice.
+
+## Single-model shorthand
+
+The original preview command remains supported and creates an equivalent in-memory
+configuration with a one-runtime budget:
+
+```bash
+drift node ./tinyllama-manifest.json \
+    --initial_peers /ip4/203.0.113.10/tcp/31337/p2p/QmExample
+```

--- a/docs/NODE_CONFIG_V1.md
+++ b/docs/NODE_CONFIG_V1.md
@@ -11,6 +11,8 @@ registration does not download tokenizers or client-side weights.
 {
   "schema_version": 1,
   "max_loaded_models": 1,
+  "discovery_update_period": 30,
+  "discovery_startup_timeout": 15,
   "models": [
     {
       "manifest": "manifests/tinyllama.json",
@@ -22,25 +24,49 @@ registration does not download tokenizers or client-side weights.
       "request_timeout": 30,
       "max_retries": 3
     }
+  ],
+  "workers": [
+    {
+      "id": "tinyllama-full",
+      "model": "tinyllama",
+      "identity_path": "identities/tinyllama.key",
+      "num_blocks": 8,
+      "enabled": false,
+      "auto_restart": true,
+      "restart_backoff": 5,
+      "device": "cpu",
+      "cache_dir": "worker-cache/tinyllama",
+      "throughput": 1.0,
+      "port": 31337
+    }
   ]
 }
 ```
 
 Paths are resolved relative to the configuration file, not the process working
-directory. `cache_dir`, `revocation_files`, `request_timeout`, and `max_retries`
-are optional. Their defaults are `null`, an empty list, 30 seconds, and three
-attempts respectively.
+directory. Model `cache_dir`, `revocation_files`, `request_timeout`, and
+`max_retries` are optional. Their defaults are `null`, an empty list, 30 seconds,
+and three attempts respectively. Discovery timing defaults to 30 seconds between
+queries and a 15-second DHT startup timeout.
+
+Workers reference a configured model by name, alias, or manifest digest and run as
+isolated `drift server` child processes. Each declares exactly one of `num_blocks`
+or an explicit `block_indices` range such as `0:4`. Worker IDs are unique. Optional
+fields configure enabled-at-start, automatic crash restart, the restart delay,
+device, cache/disk limits, throughput, port, and public address. A worker failure
+does not stop the node API.
 
 The parser rejects unknown fields, duplicate JSON keys, non-finite numbers,
 duplicate manifest paths, empty peer sets, and invalid resource limits. Every
 manifest is loaded and runtime-validated at startup. Names, aliases, and manifest
 digests must be unique case-insensitively across the entire node.
 
-Provider tokens, local API keys, and identity private keys are deliberately absent
+Provider tokens, local API keys, and identity private material are deliberately absent
 from this format. A Hugging Face token may currently be supplied with the process
 secret mechanism or the existing `--token` compatibility option. The generated
-localhost API key remains in the node's dedicated secret file unless explicitly
-supplied by the operator.
+localhost bootstrap key remains in the node's dedicated secret file unless
+explicitly supplied by the operator. Labeled key records are stored beneath the
+node data directory as metadata and domain-separated hashes only.
 
 ## Runtime residency
 
@@ -74,9 +100,54 @@ reads do not trigger downloads, DHT refreshes, or probes. A loaded runtime with
 unknown or incomplete coverage is reported as `degraded`; complete coverage is
 reported as `ready`.
 
-An unloaded model has no active sequence manager, so its route is currently
-reported as unknown. Lightweight coverage discovery for every configured but
-unloaded model remains a separate milestone-4 slice.
+For unloaded models, background discovery queries signed DHT announcements using
+the exact manifest digest, execution profile, revocations, and replay guard. Models
+with the same ordered bootstrap-peer set share one client-mode TLS DHT. Status can
+therefore report complete, incomplete, or unknown coverage without downloading a
+tokenizer or model weight. A discovery failure is observable but does not prevent
+the API from serving already loaded models.
+
+## Worker and key controls
+
+Authenticated control clients can inspect and operate configured workers:
+
+```text
+GET  /control/v1/workers
+POST /control/v1/workers/{id}/start
+POST /control/v1/workers/{id}/pause
+POST /control/v1/workers/{id}/restart
+```
+
+Worker snapshots distinguish paused, starting, running, stopping, and crashed
+states and include restart and bounded recent-log diagnostics. Key lifecycle uses:
+
+```text
+GET    /control/v1/keys
+POST   /control/v1/keys        {"label":"Laptop client"}
+PATCH  /control/v1/keys/{id}   {"label":"Renamed client"}
+DELETE /control/v1/keys/{id}
+```
+
+Creation returns the plaintext 256-bit key once. Listing and relabeling never return
+it, and revocation takes effect for subsequent requests immediately. Revoked keys
+remain as labeled audit metadata rather than being silently erased. The last active
+key cannot be revoked, preventing accidental lockout.
+
+## Edge measurement
+
+Measure a manifested client against a complete route with a dedicated empty cache:
+
+```bash
+drift edge-benchmark manifests/tinyllama.json \
+    --initial_peers /ip4/203.0.113.10/tcp/31337/p2p/QmExample \
+    --cache_dir ./edge-benchmark-cache \
+    --output ./tinyllama-edge.json
+```
+
+The versioned JSON captures cold cache growth, de-duplicated embedding/head
+parameter storage, process-tree RSS and accelerator allocations, load and first
+token latency, and post-first-token decode rate. A nonempty cache is rejected unless
+`--allow_warm_cache` is supplied so an accidental warm run cannot be labeled cold.
 
 ## Single-model shorthand
 

--- a/docs/NODE_CONFIG_V1.md
+++ b/docs/NODE_CONFIG_V1.md
@@ -61,12 +61,17 @@ duplicate manifest paths, empty peer sets, and invalid resource limits. Every
 manifest is loaded and runtime-validated at startup. Names, aliases, and manifest
 digests must be unique case-insensitively across the entire node.
 
-Provider tokens, local API keys, and identity private material are deliberately absent
-from this format. A Hugging Face token may currently be supplied with the process
-secret mechanism or the existing `--token` compatibility option. The generated
-localhost bootstrap key remains in the node's dedicated secret file unless
-explicitly supplied by the operator. Labeled key records are stored beneath the
-node data directory as metadata and domain-separated hashes only.
+Provider tokens, local API keys, control credentials, and identity private material
+are deliberately absent from this format. A Hugging Face token may currently be
+supplied with the process secret mechanism or the existing `--token` compatibility
+option. The generated OpenAI bootstrap key remains in `local-api.key`; the privileged
+control credential is separately generated in `control-api.key` or read from
+`--control_key_path`. Labeled OpenAI key records are stored beneath the node data
+directory as metadata and domain-separated hashes only.
+
+An existing explicit control file must contain the `drift_control_` key class with
+at least 256 bits of URL-safe random material. A client key file cannot be reused as
+the control credential.
 
 ## Runtime residency
 
@@ -80,7 +85,7 @@ An authenticated control client may explicitly unload an idle model:
 
 ```text
 POST /control/v1/models/unload
-Authorization: Bearer <local key>
+Authorization: Bearer <control key>
 Content-Type: application/json
 
 {"model":"configured name, alias, or sha256 digest"}
@@ -109,7 +114,8 @@ the API from serving already loaded models.
 
 ## Worker and key controls
 
-Authenticated control clients can inspect and operate configured workers:
+Control endpoints reject OpenAI client keys. The privileged control credential can
+inspect and operate configured workers:
 
 ```text
 GET  /control/v1/workers
@@ -128,10 +134,12 @@ PATCH  /control/v1/keys/{id}   {"label":"Renamed client"}
 DELETE /control/v1/keys/{id}
 ```
 
-Creation returns the plaintext 256-bit key once. Listing and relabeling never return
-it, and revocation takes effect for subsequent requests immediately. Revoked keys
-remain as labeled audit metadata rather than being silently erased. The last active
-key cannot be revoked, preventing accidental lockout.
+Creation returns the plaintext 256-bit OpenAI client key once. Listing and relabeling
+never return it, and revocation takes effect for subsequent inference requests
+immediately. Revoked keys remain as labeled audit metadata rather than being silently
+erased. The last active client key cannot be revoked, preventing accidental inference
+lockout. A client key cannot call these controls, and the control credential cannot
+call `/v1/*`.
 
 ## Edge measurement
 

--- a/docs/REVIVAL.md
+++ b/docs/REVIVAL.md
@@ -15,6 +15,30 @@ following remotes are configured in the local revival checkout:
 - `nakshatra`: an active, independent llama.cpp/GGUF distributed-inference effort
   that we will track for discovery, transport, and reliability ideas.
 
+## Current status (2026-08-22)
+
+Milestones 1 through 4 are complete. The revival has exact cross-platform inference
+parity, real multi-machine failure recovery, signed manifest and artifact integrity,
+and a persistent multi-model local node with an authenticated OpenAI-compatible API,
+supervised contribution workers, and measured edge behavior.
+
+Milestone 5 is active. Its architectural foundation is now fixed:
+
+- PySide 6 is the selected product shell; both spike alternatives passed packaged UI
+  smokes on Windows, Linux, and macOS before the decision was recorded in
+  [`ADR 0002`](adr/0002-desktop-shell-spike.md).
+- The desktop remains a client and lifecycle supervisor of the standalone local node;
+  model, DHT, and worker runtimes do not move into the GUI process.
+- Privileged control credentials and revocable OpenAI client keys are separate
+  authorization domains. An inference key cannot manage workers or keys, and the
+  control credential cannot perform inference.
+
+The immediate objective is to promote the shared spike client and acceptance contract
+into the production PySide application, then complete native credential ownership,
+onboarding and process lifecycle, contribution policies and budgets, accessibility and
+resource measurements, and signed installer/update/rollback validation. Milestones 6
+through 8 remain planned after this desktop foundation.
+
 ## Scope and product destination
 
 Inference is the product. Distributed training and fine-tuning are compatibility
@@ -375,29 +399,37 @@ proof-of-work, staking, or blockchain consensus into inference routing.
    used 16,384,000 bytes for local embedding/head parameters and 11,773,110 bytes of
    cold cache growth; this model fits the current local-logits edge design, while
    larger selectable models still require their own published measurements.
-5. **Desktop application and contribution controls.** Ship signed installers for
-   Windows, Linux, and macOS; complete first-run onboarding; manage keys in native
-   credential stores; show endpoint, model, route and contribution health; enforce
-   VRAM/storage/bandwidth/power/schedule budgets; implement model allow/prefer/deny
-   policy; pause safely; integrate background startup and updates; and clearly
-   disclose prompt visibility. Perform a short implementation spike before choosing
-   between a Python-native Qt/PySide shell and a webview shell with a Python sidecar.
-   The decision must consider GPU-process isolation, installer/update signing, tray
-   and service integration, accessibility, bundle size, and cross-platform CI.
+5. **Desktop application and contribution controls — in progress.** Build the selected
+   PySide desktop and ship signed installers for Windows, Linux, and macOS; complete
+   first-run onboarding; manage keys in native credential stores; show endpoint, model,
+   route and contribution health; enforce VRAM/storage/bandwidth/power/schedule budgets;
+   implement model allow/prefer/deny policy; pause safely; integrate background startup
+   and updates; and clearly disclose prompt visibility. The completed implementation
+   spike compared a Python-native Qt/PySide shell with a webview shell and considered
+   process isolation, installer/update signing, tray and service integration,
+   accessibility, bundle size, and cross-platform CI.
 
-   The shell comparison and its fixed acceptance criteria are tracked in
-   [`ADR 0002`](adr/0002-desktop-shell-spike.md). All six clean Windows, Linux, and
-   macOS package/UI-smoke jobs passed; PySide 6 is selected for product implementation
-   because it has the more consistent cross-platform runtime and avoids pywebview's
-   948 MB Linux Qt bundle and additional JavaScript bridge. The shared protocol client
-   and acceptance contract will be promoted from the spike.
+   **Completed foundation.** The shell comparison and its fixed acceptance criteria
+   are tracked in [`ADR 0002`](adr/0002-desktop-shell-spike.md). All six clean Windows,
+   Linux, and macOS package/UI-smoke jobs passed. PySide 6 is selected for product
+   implementation because it has the more consistent cross-platform runtime and avoids
+   pywebview's 948 MB Linux Qt bundle and additional JavaScript bridge. The pywebview
+   prototype remains evidence, not a second product frontend.
 
-   The first production security prerequisite is implemented: managed OpenAI client
+   The first production security prerequisite is also complete: managed OpenAI client
    keys authorize only `/v1/*`, while a distinct privileged control credential
    authorizes only `/control/v1/*`. Headless nodes generate separate private files,
-   startup rejects overlaps, and upgraded installations retain their existing client
-   key while receiving a new control key. Native credential-store ownership remains
-   part of the selected desktop implementation.
+   startup rejects missing, duplicate, or overlapping control keys, and upgraded
+   installations retain their existing client key while receiving a new control key.
+
+   **Next implementation sequence.** Promote the shell-neutral node client and
+   acceptance contract into a production PySide package; move the control credential
+   from the private-file bridge into native OS credential stores; add first-run setup,
+   single-instance behavior, node supervision, login startup, reconnect, and clean
+   shutdown; enforce contribution budgets and allow/prefer/deny policy in the node rather
+   than only in the GUI; then measure startup/RSS and crash isolation and complete
+   keyboard/screen-reader, signed installer, upgrade, rollback, uninstall, and retained-
+   data gates on all three operating systems.
 6. **Decentralized discovery and autonomous allocation.** Operate multiple
    independent bootstrap and relay peers; add peer caching, user-supplied seeds and
    LAN discovery; define threshold-signed, forkable catalogs; publish privacy-safe
@@ -427,7 +459,7 @@ Detailed baseline evidence and the remaining gates are recorded in
 The following questions require written architecture decisions and prototypes; they
 must not be settled accidentally by the first GUI implementation:
 
-| Decision | Starting hypothesis | Evidence required |
+| Decision | Current position | Evidence required |
 | --- | --- | --- |
 | Desktop shell | Resolved in ADR 0002: implement the product shell in PySide 6 while preserving the standalone node boundary. | Signed installer prototypes on all three OSes, upgrade/rollback, tray/service behavior, accessibility, crash isolation, and startup/RSS measurements remain release gates. |
 | Thin edge | Keep embeddings/head local where affordable; add remote ingress/egress roles only for devices that miss published budgets. | Per-model RAM/disk/latency data, token parity, logits/sampling trade-offs, privacy analysis, and failover tests. |

--- a/docs/REVIVAL.md
+++ b/docs/REVIVAL.md
@@ -386,9 +386,11 @@ proof-of-work, staking, or blockchain consensus into inference routing.
    and service integration, accessibility, bundle size, and cross-platform CI.
 
    The shell comparison and its fixed acceptance criteria are tracked in
-   [`ADR 0002`](adr/0002-desktop-shell-spike.md). The checked-in prototypes keep
-   both UI processes outside the model runtime and package each alternative in a
-   clean environment so their measurements remain comparable.
+   [`ADR 0002`](adr/0002-desktop-shell-spike.md). All six clean Windows, Linux, and
+   macOS package/UI-smoke jobs passed; PySide 6 is selected for product implementation
+   because it has the more consistent cross-platform runtime and avoids pywebview's
+   948 MB Linux Qt bundle and additional JavaScript bridge. The shared protocol client
+   and acceptance contract will be promoted from the spike.
 
    The first production security prerequisite is implemented: managed OpenAI client
    keys authorize only `/v1/*`, while a distinct privileged control credential
@@ -427,7 +429,7 @@ must not be settled accidentally by the first GUI implementation:
 
 | Decision | Starting hypothesis | Evidence required |
 | --- | --- | --- |
-| Desktop shell | Prefer the smallest design that can reuse the Python core while preserving process isolation; compare PySide with a sidecar-based shell. | Signed installer prototypes on all three OSes, upgrade/rollback, tray/service behavior, accessibility, crash isolation, and package size. |
+| Desktop shell | Resolved in ADR 0002: implement the product shell in PySide 6 while preserving the standalone node boundary. | Signed installer prototypes on all three OSes, upgrade/rollback, tray/service behavior, accessibility, crash isolation, and startup/RSS measurements remain release gates. |
 | Thin edge | Keep embeddings/head local where affordable; add remote ingress/egress roles only for devices that miss published budgets. | Per-model RAM/disk/latency data, token parity, logits/sampling trade-offs, privacy analysis, and failover tests. |
 | Catalog governance | Threshold-signed and forkable catalogs, with trust roots selected by each installation. | Key compromise/rotation drill, rollback protection, alternative-catalog interoperability, and malicious-manifest rejection. |
 | Demand signal | Coarse signed aggregates and observed route pressure, never request contents. | Sybil/spam simulation, privacy review, convergence under bursty demand, and proof that one attacker cannot trigger a network-wide download storm. |

--- a/docs/REVIVAL.md
+++ b/docs/REVIVAL.md
@@ -384,6 +384,11 @@ proof-of-work, staking, or blockchain consensus into inference routing.
    between a Python-native Qt/PySide shell and a webview shell with a Python sidecar.
    The decision must consider GPU-process isolation, installer/update signing, tray
    and service integration, accessibility, bundle size, and cross-platform CI.
+
+   The shell comparison and its fixed acceptance criteria are tracked in
+   [`ADR 0002`](adr/0002-desktop-shell-spike.md). The checked-in prototypes keep
+   both UI processes outside the model runtime and package each alternative in a
+   clean environment so their measurements remain comparable.
 6. **Decentralized discovery and autonomous allocation.** Operate multiple
    independent bootstrap and relay peers; add peer caching, user-supplied seeds and
    LAN discovery; define threshold-signed, forkable catalogs; publish privacy-safe

--- a/docs/REVIVAL.md
+++ b/docs/REVIVAL.md
@@ -342,6 +342,24 @@ proof-of-work, staking, or blockchain consensus into inference routing.
    lifecycle, route/coverage status, bounded concurrency, and clean shutdown. Measure
    the current client-side embedding/head cost and decide the thin-edge protocol.
    Validate compatibility with representative OpenAI clients before adding a GUI.
+
+   The first vertical slice is implemented according to
+   [`ADR 0001`](adr/0001-unified-local-node.md): `drift node` owns a stable,
+   authenticated loopback API; registers one exact manifest; lazily and safely loads
+   its client runtime through a thread-safe model manager; resolves manifest names,
+   API aliases, and digests without fallback; reports versioned authenticated status;
+   generates a persistent local key when needed; refuses accidental non-loopback
+   binding; and cleans up the client route manager and DHT on shutdown. The existing
+   single-model `drift api` surface now uses the same selection path and rejects a
+   mismatched request model.
+
+   The second slice adds strict secret-free
+   [`NodeConfig v1`](NODE_CONFIG_V1.md), bounded
+   runtime residency, request-scoped leases, least-recently-used idle eviction,
+   authenticated safe unload, and coverage observations from loaded route managers.
+   An HTTP cancellation cannot release or evict a runtime while its executor thread
+   is still generating. Lightweight coverage discovery for unloaded models, worker
+   supervision, full key CRUD, edge measurements, and compatibility validation remain.
 5. **Desktop application and contribution controls.** Ship signed installers for
    Windows, Linux, and macOS; complete first-run onboarding; manage keys in native
    credential stores; show endpoint, model, route and contribution health; enforce

--- a/docs/REVIVAL.md
+++ b/docs/REVIVAL.md
@@ -389,6 +389,13 @@ proof-of-work, staking, or blockchain consensus into inference routing.
    [`ADR 0002`](adr/0002-desktop-shell-spike.md). The checked-in prototypes keep
    both UI processes outside the model runtime and package each alternative in a
    clean environment so their measurements remain comparable.
+
+   The first production security prerequisite is implemented: managed OpenAI client
+   keys authorize only `/v1/*`, while a distinct privileged control credential
+   authorizes only `/control/v1/*`. Headless nodes generate separate private files,
+   startup rejects overlaps, and upgraded installations retain their existing client
+   key while receiving a new control key. Native credential-store ownership remains
+   part of the selected desktop implementation.
 6. **Decentralized discovery and autonomous allocation.** Operate multiple
    independent bootstrap and relay peers; add peer caching, user-supplied seeds and
    LAN discovery; define threshold-signed, forkable catalogs; publish privacy-safe

--- a/docs/REVIVAL.md
+++ b/docs/REVIVAL.md
@@ -336,7 +336,7 @@ proof-of-work, staking, or blockchain consensus into inference routing.
    manifest, resumed a real Hub artifact at byte 2,097,152 with HTTP 206, served all
    eight blocks through a signed manifested identity, and matched the stock token
    output exactly. This closes the milestone's cross-platform validation gate.
-4. **Unified local node and multi-model OpenAI API.** Introduce the persistent node
+4. **Unified local node and multi-model OpenAI API — complete.** Introduce the persistent node
    daemon, worker supervision, a versioned local control API, multi-model discovery
    and lazy client loading, a stable localhost OpenAI endpoint, local API-key
    lifecycle, route/coverage status, bounded concurrency, and clean shutdown. Measure
@@ -358,8 +358,23 @@ proof-of-work, staking, or blockchain consensus into inference routing.
    runtime residency, request-scoped leases, least-recently-used idle eviction,
    authenticated safe unload, and coverage observations from loaded route managers.
    An HTTP cancellation cannot release or evict a runtime while its executor thread
-   is still generating. Lightweight coverage discovery for unloaded models, worker
-   supervision, full key CRUD, edge measurements, and compatibility validation remain.
+   is still generating.
+
+   The final slice adds artifact-free, manifest-bound coverage discovery for every
+   configured model; isolated contribution-worker processes with observable restart
+   backoff and authenticated start, pause, and restart controls; persistent labeled
+   API-key creation, listing, relabeling, and revocation with hash-only storage; and a
+   reproducible cold-client benchmark for cache growth, local embedding/head
+   weights, process-tree RAM/accelerator use, load time, first-token latency, and
+   decode rate. A real Fly
+   swarm exposed two distinct manifests through one restarted node. The official
+   OpenAI Python client listed and generated from both, streamed a completion, reused
+   the persistent key after restart, and proved one-runtime LRU eviction plus exact
+   stock-model token parity. Unloaded discovery observed complete `8:8` external
+   routes without loading either client runtime. The measured TinyLlama CPU client
+   used 16,384,000 bytes for local embedding/head parameters and 11,773,110 bytes of
+   cold cache growth; this model fits the current local-logits edge design, while
+   larger selectable models still require their own published measurements.
 5. **Desktop application and contribution controls.** Ship signed installers for
    Windows, Linux, and macOS; complete first-run onboarding; manage keys in native
    credential stores; show endpoint, model, route and contribution health; enforce

--- a/docs/REVIVAL_TEST_RESULTS.md
+++ b/docs/REVIVAL_TEST_RESULTS.md
@@ -15,7 +15,7 @@ test harnesses are `scripts/smoke_tinyllama_local_swarm.py` and
 | 2. Real multi-machine swarm | Complete | A private Fly swarm reached explicit `0:8` coverage with two replicas per block; a selected `4:8` Machine was killed during generation, the client rerouted and replayed its prefix, and both the recovered request and a cache-cleanup request passed exact parity | None for this milestone; broader-model recovery remains follow-up work |
 | 3. Public protocol identity and content integrity | Complete | Content-derived manifests, signed expiring worker announcements, PeerID/TLS binding, replay/range/profile checks, signed intent leases, dual-signed rotation, revocation, deterministic interruption tests, real Hub HTTP 206 resume on Windows and macOS, signed Windows parity/failover, signed Fly cross-Machine parity, hosted macOS signed parity, and prior Fly poison rejection are proven | None |
 | 4. Unified local node and multi-model OpenAI API | Complete | Exact multi-manifest selection, artifact-free unloaded discovery, cancellation-safe lazy loading and LRU residency, isolated supervised workers, labeled hash-only key CRUD, authenticated controls, reproducible edge measurements, official OpenAI Python client compatibility, clean restart/key reuse, and real external two-model Fly parity are proven | None for this milestone; every additional selectable model still needs its own published edge envelope |
-| 5. Desktop application and contribution controls | In progress | ADR 0002 fixes the PySide/webview experiment; both Windows source and packaged UI smokes pass; OpenAI inference keys and the privileged control credential are now separate authorities | Clean cross-platform shell evidence, native credential storage, contribution policies and budgets, lifecycle integration, signing, updates, rollback, accessibility, and installer gates remain |
+| 5. Desktop application and contribution controls | In progress | ADR 0002 selects PySide 6 after all six clean Windows/Linux/macOS package and UI-smoke jobs passed; OpenAI inference keys and the privileged control credential are separate authorities | Native credential storage, contribution policies and budgets, lifecycle integration, startup/RSS and crash-isolation measurements, signing, updates, rollback, accessibility, and installer gates remain |
 
 ## Desktop milestone: control authority separation
 
@@ -31,7 +31,25 @@ key and creates `~/.drift/node/control-api.key` on first upgraded startup. An ex
 private path can be supplied with `--control_key_path`; putting the privileged secret
 itself on the command line is not supported. The desktop spike already reads this
 credential through a private-file bridge and will move it into the native OS store
-after the shell decision.
+during the selected PySide product implementation.
+
+## Desktop milestone: shell decision
+
+The clean cross-platform matrix built PySide 6.11.2 and pywebview 6.2.1 independently,
+verified the collected framework, and completed the same packaged authenticated UI smoke
+against an isolated fake node. All six package jobs passed.
+
+| Platform | PySide bundle | pywebview bundle |
+| --- | ---: | ---: |
+| Windows x64 | 128,862,316 bytes / 236 files | 29,234,555 bytes / 215 files |
+| Linux x64 | 324,323,392 bytes / 367 files | 948,268,266 bytes / 1,942 files |
+| macOS arm64 | 210,278,876 bytes / 268 files | 43,560,981 bytes / 106 files |
+
+ADR 0002 therefore selects PySide 6 for product implementation. Pywebview's Windows and
+macOS size advantage does not offset its 948 MB Linux Qt bundle, larger backend variance,
+and additional JavaScript bridge. The unsigned CI artifacts prove clean packaging and UI
+startup only; native credential stores, accessibility, lifecycle, crash isolation,
+startup/RSS, signed installers, upgrades, rollback, and uninstall remain open release gates.
 
 ## Unified local node: first vertical slice
 

--- a/docs/REVIVAL_TEST_RESULTS.md
+++ b/docs/REVIVAL_TEST_RESULTS.md
@@ -15,6 +15,23 @@ test harnesses are `scripts/smoke_tinyllama_local_swarm.py` and
 | 2. Real multi-machine swarm | Complete | A private Fly swarm reached explicit `0:8` coverage with two replicas per block; a selected `4:8` Machine was killed during generation, the client rerouted and replayed its prefix, and both the recovered request and a cache-cleanup request passed exact parity | None for this milestone; broader-model recovery remains follow-up work |
 | 3. Public protocol identity and content integrity | Complete | Content-derived manifests, signed expiring worker announcements, PeerID/TLS binding, replay/range/profile checks, signed intent leases, dual-signed rotation, revocation, deterministic interruption tests, real Hub HTTP 206 resume on Windows and macOS, signed Windows parity/failover, signed Fly cross-Machine parity, hosted macOS signed parity, and prior Fly poison rejection are proven | None |
 | 4. Unified local node and multi-model OpenAI API | Complete | Exact multi-manifest selection, artifact-free unloaded discovery, cancellation-safe lazy loading and LRU residency, isolated supervised workers, labeled hash-only key CRUD, authenticated controls, reproducible edge measurements, official OpenAI Python client compatibility, clean restart/key reuse, and real external two-model Fly parity are proven | None for this milestone; every additional selectable model still needs its own published edge envelope |
+| 5. Desktop application and contribution controls | In progress | ADR 0002 fixes the PySide/webview experiment; both Windows source and packaged UI smokes pass; OpenAI inference keys and the privileged control credential are now separate authorities | Clean cross-platform shell evidence, native credential storage, contribution policies and budgets, lifecycle integration, signing, updates, rollback, accessibility, and installer gates remain |
+
+## Desktop milestone: control authority separation
+
+The first milestone-5 production prerequisite separates the local authorization
+domains without changing endpoint versions. Managed, labeled OpenAI keys authorize
+only `/v1/*`; a distinct privileged key authorizes only `/control/v1/*`. The node
+rejects startup with a missing, duplicate, or overlapping control key. Key creation,
+relabeling, and revocation remain control operations, and newly created client keys
+cannot use those controls.
+
+The headless migration preserves `~/.drift/node/local-api.key` as an OpenAI client
+key and creates `~/.drift/node/control-api.key` on first upgraded startup. An explicit
+private path can be supplied with `--control_key_path`; putting the privileged secret
+itself on the command line is not supported. The desktop spike already reads this
+credential through a private-file bridge and will move it into the native OS store
+after the shell decision.
 
 ## Unified local node: first vertical slice
 
@@ -62,8 +79,9 @@ versioned JSON result and refuses a nonempty cache unless explicitly acknowledge
 The current bootstrap secret file remains the documented headless fallback; moving
 secrets into native OS credential stores belongs to milestone 5.
 
-The completed broad offline matrix passed with 201 tests and 7 platform/device
-skips. The repository's top-level external-swarm fixtures still require
+After the milestone-5 control-credential split, the broad offline matrix passed
+with 204 tests and 7 platform/device skips. The repository's top-level
+external-swarm fixtures still require
 `INITIAL_PEERS`, so the offline CI file list is run explicitly and the real swarm is
 validated separately.
 

--- a/docs/REVIVAL_TEST_RESULTS.md
+++ b/docs/REVIVAL_TEST_RESULTS.md
@@ -14,7 +14,7 @@ test harnesses are `scripts/smoke_tinyllama_local_swarm.py` and
 | 1. Reproducible execution baseline | Complete | Windows CPU, Docker Linux CPU, Windows CUDA, and native hosted Apple Silicon macOS all served blocks `0:8` and produced exact token parity; macOS also passed the MPS block-portability checks | None |
 | 2. Real multi-machine swarm | Complete | A private Fly swarm reached explicit `0:8` coverage with two replicas per block; a selected `4:8` Machine was killed during generation, the client rerouted and replayed its prefix, and both the recovered request and a cache-cleanup request passed exact parity | None for this milestone; broader-model recovery remains follow-up work |
 | 3. Public protocol identity and content integrity | Complete | Content-derived manifests, signed expiring worker announcements, PeerID/TLS binding, replay/range/profile checks, signed intent leases, dual-signed rotation, revocation, deterministic interruption tests, real Hub HTTP 206 resume on Windows and macOS, signed Windows parity/failover, signed Fly cross-Machine parity, hosted macOS signed parity, and prior Fly poison rejection are proven | None |
-| 4. Unified local node and multi-model OpenAI API | In progress | Exact multi-manifest/name/alias selection, strict secret-free config, concurrency-safe lazy loading, hard runtime residency, cancellation-safe leases, LRU idle eviction, authenticated status and safe unload, loaded-route coverage, persistent local key bootstrap, loopback guard, bounded generation concurrency, and clean shutdown; broad offline tests pass | Lightweight unloaded-model discovery, worker supervision, key CRUD, activity/cancellation controls, edge measurements, and representative client/restart/failover validation |
+| 4. Unified local node and multi-model OpenAI API | Complete | Exact multi-manifest selection, artifact-free unloaded discovery, cancellation-safe lazy loading and LRU residency, isolated supervised workers, labeled hash-only key CRUD, authenticated controls, reproducible edge measurements, official OpenAI Python client compatibility, clean restart/key reuse, and real external two-model Fly parity are proven | None for this milestone; every additional selectable model still needs its own published edge envelope |
 
 ## Unified local node: first vertical slice
 
@@ -42,12 +42,63 @@ active model, evicts only the least-recently-used idle model, closes its routing
 resources synchronously, and exposes authenticated explicit unload. Cancellation
 tests prove that an executor-backed load or generation cannot strand or prematurely
 release a lease. Loaded route managers expose their existing verified coverage view
-without status-triggered DHT activity; unloaded models remain explicitly unknown.
+without status-triggered DHT activity.
 
-The expanded broad offline suite passed with 175 tests and 7 skips. The
-full top-level suite still requires its existing `INITIAL_PEERS` external-swarm
-fixture, so no real swarm or representative external OpenAI clients have been
-claimed for the multi-model slice.
+The final slice completes the milestone. One client-mode TLS DHT is shared by
+models with the same seed set, while each query independently enforces its exact
+manifest digest, execution profile, signed-announcement replay order, and
+revocations. It reports unloaded coverage without constructing tokenizers or model
+weights and degrades to observable `unknown` state if discovery is unavailable.
+Configured contribution workers run in isolated child processes with explicit
+start, pause, restart, crash state, bounded log capture, and configured restart
+delay. The control API now creates, lists, relabels, and revokes 256-bit local keys;
+only domain-separated hashes are persisted, and the plaintext secret is returned
+once. Revoking the final active key is refused.
+
+`drift edge-benchmark` measures a dedicated cold cache, the unique parameter
+storage used by the client embeddings/head, process-tree RSS, available accelerator
+allocations, runtime load, first token, and post-first-token decode. It writes a
+versioned JSON result and refuses a nonempty cache unless explicitly acknowledged.
+The current bootstrap secret file remains the documented headless fallback; moving
+secrets into native OS credential stores belongs to milestone 5.
+
+The completed broad offline matrix passed with 201 tests and 7 platform/device
+skips. The repository's top-level external-swarm fixtures still require
+`INITIAL_PEERS`, so the offline CI file list is run explicitly and the real swarm is
+validated separately.
+
+## Unified local node: external multi-model validation
+
+On 2026-08-22, image
+`sha256:aafb9c9a168e4d7838ddea576e5777833f3a603239b1d5af27bcce1c721fe121`
+ran in Fly region `iad` with one bootstrap, one external full-range worker for each
+of two distinct manifested namespaces, and one client node. Both manifests pinned
+TinyLlama commit `298338802ab94432b917bcce11382aa151aee50f` but had different
+exact DHT identities. Artifact-free discovery observed complete `8:8` routes with
+two peer announcements per model before either client runtime was loaded.
+
+The official OpenAI Python SDK 2.54.0 connected over a real localhost TCP listener.
+It listed both models, generated from each, and streamed a completion. Alpha and
+Beta each produced `", a little"`, matching an independently loaded stock model.
+With `max_loaded_models=1`, status showed Alpha evicted when Beta loaded. The entire
+node then restarted, accepted the same persistent local key, lazily loaded Alpha,
+and repeated exact parity. During this run the API regression test also caught and
+fixed a Transformers 5 compatibility bug: the tokenizer generation argument is now
+sent only when stop strings require it.
+
+The dedicated cold benchmark against the external Alpha worker recorded:
+
+- 11,773,110 bytes of cache download/growth;
+- 16,384,000 unique bytes of local embedding/head parameters on CPU;
+- 445,968,384 bytes baseline, 1,073,139,712 bytes loaded, and 1,082,388,480
+  bytes peak process-tree RSS, for a 636,420,096-byte peak delta;
+- 9.872 seconds to load and 0.237 seconds to first token; and
+- 21.360 post-first-token token/s for a three-token generation, producing IDs
+  `[1,16644,31844,260,1496]` and decoded text `<s> Hello, a little`.
+
+The benchmark used Python 3.12.14, PyTorch 2.6.0 CPU, and Linux. Every temporary
+Fly Machine was destroyed after validation; the final application Machine list was
+empty.
 
 ## Manifest artifact integrity
 

--- a/docs/REVIVAL_TEST_RESULTS.md
+++ b/docs/REVIVAL_TEST_RESULTS.md
@@ -14,6 +14,40 @@ test harnesses are `scripts/smoke_tinyllama_local_swarm.py` and
 | 1. Reproducible execution baseline | Complete | Windows CPU, Docker Linux CPU, Windows CUDA, and native hosted Apple Silicon macOS all served blocks `0:8` and produced exact token parity; macOS also passed the MPS block-portability checks | None |
 | 2. Real multi-machine swarm | Complete | A private Fly swarm reached explicit `0:8` coverage with two replicas per block; a selected `4:8` Machine was killed during generation, the client rerouted and replayed its prefix, and both the recovered request and a cache-cleanup request passed exact parity | None for this milestone; broader-model recovery remains follow-up work |
 | 3. Public protocol identity and content integrity | Complete | Content-derived manifests, signed expiring worker announcements, PeerID/TLS binding, replay/range/profile checks, signed intent leases, dual-signed rotation, revocation, deterministic interruption tests, real Hub HTTP 206 resume on Windows and macOS, signed Windows parity/failover, signed Fly cross-Machine parity, hosted macOS signed parity, and prior Fly poison rejection are proven | None |
+| 4. Unified local node and multi-model OpenAI API | In progress | Exact multi-manifest/name/alias selection, strict secret-free config, concurrency-safe lazy loading, hard runtime residency, cancellation-safe leases, LRU idle eviction, authenticated status and safe unload, loaded-route coverage, persistent local key bootstrap, loopback guard, bounded generation concurrency, and clean shutdown; broad offline tests pass | Lightweight unloaded-model discovery, worker supervision, key CRUD, activity/cancellation controls, edge measurements, and representative client/restart/failover validation |
+
+## Unified local node: first vertical slice
+
+On 2026-08-22, the initial milestone 4 service boundary was implemented in
+[`ADR 0001`](adr/0001-unified-local-node.md). The existing OpenAI facade now routes
+requests through a model manager. It rejects unknown requested models, requires an
+explicit model when more than one is registered, and preserves the single-model
+compatibility behavior. The manager serializes concurrent first loads, publishes
+observable lifecycle and error state, retries failed lazy loads, and closes each
+loaded runtime once during shutdown.
+
+`drift node` registers pinned manifests without downloading their client artifacts
+at startup, binds to `127.0.0.1:8080` by default, authenticates the OpenAI and
+`/control/v1/status` surfaces, and requires `--allow_network` for a non-loopback
+listener. With no explicit key it atomically creates a dedicated local secret file
+and never logs the value. The first focused verification covers the manager, API,
+manifest-pinned loader, control endpoint, key persistence, argument guard, and
+shutdown lifecycle.
+
+The second slice added [`NodeConfig v1`](NODE_CONFIG_V1.md), with strict duplicate
+and unknown-field rejection, paths relative to the config, per-model peer/cache/
+revocation/retry inputs, and no provider or API secret fields. A configurable hard
+runtime limit now leases models for the full request, waits rather than evicting an
+active model, evicts only the least-recently-used idle model, closes its routing
+resources synchronously, and exposes authenticated explicit unload. Cancellation
+tests prove that an executor-backed load or generation cannot strand or prematurely
+release a lease. Loaded route managers expose their existing verified coverage view
+without status-triggered DHT activity; unloaded models remain explicitly unknown.
+
+The expanded broad offline suite passed with 175 tests and 7 skips. The
+full top-level suite still requires its existing `INITIAL_PEERS` external-swarm
+fixture, so no real swarm or representative external OpenAI clients have been
+claimed for the multi-model slice.
 
 ## Manifest artifact integrity
 

--- a/docs/adr/0001-unified-local-node.md
+++ b/docs/adr/0001-unified-local-node.md
@@ -82,22 +82,27 @@ coverage, runtime residency, explicit safe unload, worker controls, and key muta
 now extend `/control/v1` without making the GUI manipulate processes directly.
 Configuration mutation remains a later concern.
 
-`/health` is deliberately unauthenticated and contains only coarse liveness.
-OpenAI endpoints and `/control/v1/*` require the same local bearer-key set in this
-slice. Key classes can be separated later without changing endpoint versions.
+`/health` is deliberately unauthenticated and contains only coarse liveness. The
+initial milestone-4 slice used the same local bearer-key set for OpenAI and control
+requests. The first milestone-5 security follow-up separated those authorities
+without changing endpoint versions: managed OpenAI client keys authorize `/v1/*`,
+while a distinct privileged credential authorizes `/control/v1/*`. Startup rejects
+missing, duplicate, or overlapping control credentials.
 
 ### Binding and local keys
 
 The node binds to loopback by default. A non-loopback host requires the explicit
 `--allow_network` acknowledgement and authentication remains mandatory.
 
-When no key is supplied, the headless node atomically creates a dedicated secret at
-`~/.drift/node/local-api.key`, requests owner-only permissions, and logs only its
-path. It is not stored in ordinary model configuration. Labeled keys are random
-256-bit secrets whose metadata and domain-separated hashes are persisted; creation
-returns plaintext once and revocation applies immediately. The desktop milestone
-will replace bootstrap secret-file storage with native credential storage where
-available and expose the lifecycle in its UI.
+When no client key is supplied, the headless node atomically creates a dedicated
+OpenAI secret at `~/.drift/node/local-api.key`. It independently creates the
+privileged `~/.drift/node/control-api.key`; a headless operator can select another
+private file with `--control_key_path`. Both request owner-only permissions and only
+their paths are logged. Neither belongs in ordinary model configuration. Labeled
+OpenAI keys are random 256-bit secrets whose metadata and domain-separated hashes are
+persisted; creation returns plaintext once and revocation applies immediately. The
+desktop milestone will move the privileged credential into native credential storage
+where available and expose the OpenAI-key lifecycle in its UI.
 
 ## Consequences and implementation status
 

--- a/docs/adr/0001-unified-local-node.md
+++ b/docs/adr/0001-unified-local-node.md
@@ -23,11 +23,12 @@ routing remains client-side and therefore does not depend on an operator gateway
 - the loopback OpenAI and control listeners;
 - configuration and local API authentication;
 - a model registry and client-runtime lifecycle; and
-- future supervision of isolated contribution workers.
+- supervision of isolated contribution workers.
 
 Contribution workers remain child processes. A worker crash must not terminate the
-local API. The first implementation slice does not start a worker; it establishes
-the service and lifecycle boundary that the supervisor will join.
+local API. The supervisor starts, pauses, restarts, observes, and automatically
+restarts configured workers without placing their model execution inside the HTTP
+process.
 
 `drift api` remains a compatible single-model command. Internally, the HTTP facade
 adapts its already-loaded model into the same manager interface.
@@ -76,10 +77,10 @@ The versioned control surface begins with:
 GET /control/v1/status
 ```
 
-It reports node state, endpoint, and model snapshots. Loaded-route coverage,
-runtime residency, and explicit safe unload now extend `/control/v1`. Requests,
-key mutation, configuration mutation, and worker controls will continue extending
-it without making the GUI manipulate processes directly.
+It reports node state, endpoint, and model snapshots. Loaded and unloaded route
+coverage, runtime residency, explicit safe unload, worker controls, and key mutation
+now extend `/control/v1` without making the GUI manipulate processes directly.
+Configuration mutation remains a later concern.
 
 `/health` is deliberately unauthenticated and contains only coarse liveness.
 OpenAI endpoints and `/control/v1/*` require the same local bearer-key set in this
@@ -92,23 +93,23 @@ The node binds to loopback by default. A non-loopback host requires the explicit
 
 When no key is supplied, the headless node atomically creates a dedicated secret at
 `~/.drift/node/local-api.key`, requests owner-only permissions, and logs only its
-path. It is not stored in ordinary model configuration. The desktop milestone will
-replace this bootstrap store with native credential storage where available and add
-the complete create/label/revoke UI.
+path. It is not stored in ordinary model configuration. Labeled keys are random
+256-bit secrets whose metadata and domain-separated hashes are persisted; creation
+returns plaintext once and revocation applies immediately. The desktop milestone
+will replace bootstrap secret-file storage with native credential storage where
+available and expose the lifecycle in its UI.
 
-## Consequences and follow-up
+## Consequences and implementation status
 
-The second slice adds strict secret-free multi-manifest configuration, a hard
-resident-runtime budget, request-scoped runtime leases, least-recently-used idle
-eviction, explicit safe unload, and read-only coverage observations from each
-loaded route manager. It does not complete milestone 4. The next slices must add:
-
-1. lightweight route and complete-coverage discovery for unloaded models;
-2. isolated worker supervision and pause/restart controls;
-3. API-key create, label, list, and revoke operations;
-4. request cancellation and richer activity diagnostics;
-5. client-side embedding/head resource benchmarks and the thin-edge decision; and
-6. representative OpenAI-client compatibility and restart/failover tests.
+Milestone 4 is complete. Strict secret-free multi-manifest configuration, a hard
+resident-runtime budget, cancellation-safe request leases, least-recently-used idle
+eviction, explicit safe unload, loaded and unloaded coverage observations, isolated
+worker supervision, labeled key CRUD, and versioned edge benchmarking all live
+behind this boundary. A real external two-manifest swarm passed official OpenAI
+Python client listing, completion and streaming, exact parity, LRU eviction, full
+node restart, and persistent-key reuse. The measured TinyLlama client fits the
+current local embedding/head design; every larger selectable model must publish its
+own resource envelope before that conclusion is generalized.
 
 No desktop GUI, cross-model allocator, public catalog, or credit behavior belongs
 in this service until its corresponding roadmap gate begins.

--- a/docs/adr/0001-unified-local-node.md
+++ b/docs/adr/0001-unified-local-node.md
@@ -1,0 +1,114 @@
+# ADR 0001: Unified local node boundary
+
+- Status: Accepted
+- Date: 2026-08-22
+- Roadmap: Milestone 4
+
+## Context
+
+`drift api` is a useful OpenAI-compatible facade, but it eagerly constructs one
+client model per process. It has no persistent control surface, model lifecycle,
+or place to supervise an optional contributor worker. Building a desktop shell
+directly around that command would put lifecycle and security policy in the UI.
+
+The local product instead needs one stable loopback endpoint whose inference
+routing remains client-side and therefore does not depend on an operator gateway.
+
+## Decision
+
+### Process boundary
+
+`drift node` is the long-lived local service. Its HTTP process owns:
+
+- the loopback OpenAI and control listeners;
+- configuration and local API authentication;
+- a model registry and client-runtime lifecycle; and
+- future supervision of isolated contribution workers.
+
+Contribution workers remain child processes. A worker crash must not terminate the
+local API. The first implementation slice does not start a worker; it establishes
+the service and lifecycle boundary that the supervisor will join.
+
+`drift api` remains a compatible single-model command. Internally, the HTTP facade
+adapts its already-loaded model into the same manager interface.
+
+### Model identity and selection
+
+Every public-node model is registered from a validated `ModelManifest v1`. Its
+human-readable `name` is the canonical response ID. The declared OpenAI aliases and
+the exact `sha256:<manifest digest>` resolve to that record.
+
+Identifiers are unique case-insensitively within one node. A supplied OpenAI
+`model` value must resolve exactly; unknown identifiers return 404 and are never
+substituted. Omitting `model` is accepted only when exactly one model is configured,
+preserving compatibility with the old one-model facade. It returns 400 once the
+node has multiple choices.
+
+### Lifecycle and states
+
+The model manager exposes these version-one states:
+
+| State | Meaning |
+| --- | --- |
+| `known` | Manifest is configured; no client runtime is loaded. |
+| `downloading` | Reserved for observable artifact transfer. |
+| `loading` | One thread is constructing the tokenizer and client runtime. |
+| `ready` | The runtime can accept generation work. |
+| `degraded` | Reserved for a usable runtime without target route health. |
+| `unavailable` | The most recent load attempt failed. A later request may retry. |
+| `unloading` | An idle runtime is closing before its residency slot is reused. |
+| `stopping` | Shutdown has begun; no new loads are accepted. |
+
+Runtime creation is lazy and serialized independently per manifest. Concurrent
+requests for the same unloaded model share the one published runtime. A failed load
+is reported through authenticated status and is retryable. Shutdown stops the route
+manager and its client DHT before process exit.
+
+### HTTP surfaces
+
+The stable OpenAI base URL is `http://127.0.0.1:8080/v1` by default. Existing
+completion and streaming semantics remain unchanged. `/v1/models` reports each
+configured canonical model plus its aliases, manifest digest, and lifecycle state.
+
+The versioned control surface begins with:
+
+```text
+GET /control/v1/status
+```
+
+It reports node state, endpoint, and model snapshots. Loaded-route coverage,
+runtime residency, and explicit safe unload now extend `/control/v1`. Requests,
+key mutation, configuration mutation, and worker controls will continue extending
+it without making the GUI manipulate processes directly.
+
+`/health` is deliberately unauthenticated and contains only coarse liveness.
+OpenAI endpoints and `/control/v1/*` require the same local bearer-key set in this
+slice. Key classes can be separated later without changing endpoint versions.
+
+### Binding and local keys
+
+The node binds to loopback by default. A non-loopback host requires the explicit
+`--allow_network` acknowledgement and authentication remains mandatory.
+
+When no key is supplied, the headless node atomically creates a dedicated secret at
+`~/.drift/node/local-api.key`, requests owner-only permissions, and logs only its
+path. It is not stored in ordinary model configuration. The desktop milestone will
+replace this bootstrap store with native credential storage where available and add
+the complete create/label/revoke UI.
+
+## Consequences and follow-up
+
+The second slice adds strict secret-free multi-manifest configuration, a hard
+resident-runtime budget, request-scoped runtime leases, least-recently-used idle
+eviction, explicit safe unload, and read-only coverage observations from each
+loaded route manager. It does not complete milestone 4. The next slices must add:
+
+1. lightweight route and complete-coverage discovery for unloaded models;
+2. isolated worker supervision and pause/restart controls;
+3. API-key create, label, list, and revoke operations;
+4. request cancellation and richer activity diagnostics;
+5. client-side embedding/head resource benchmarks and the thin-edge decision; and
+6. representative OpenAI-client compatibility and restart/failover tests.
+
+No desktop GUI, cross-model allocator, public catalog, or credit behavior belongs
+in this service until its corresponding roadmap gate begins.

--- a/docs/adr/0002-desktop-shell-spike.md
+++ b/docs/adr/0002-desktop-shell-spike.md
@@ -1,0 +1,122 @@
+# ADR 0002: Desktop shell implementation spike
+
+- Status: Proposed; spike in progress
+- Date: 2026-08-22
+- Roadmap: Milestone 5
+
+## Context
+
+Milestone 4 established `drift node` as the persistent, authenticated service boundary.
+The desktop application must remain a client and lifecycle supervisor of that boundary;
+it must not import model runtimes into the GUI process or manipulate contribution-worker
+processes directly.
+
+The roadmap requires an evidence-based choice between a Python-native Qt/PySide shell
+and a webview shell with a Python sidecar. Choosing from source-code ergonomics alone
+would leave the most consequential questions unanswered: packaging, signing, background
+lifecycle, accessibility, native credential storage, update and rollback behavior, and
+crash isolation on Windows, Linux, and macOS.
+
+The current node also authorizes OpenAI inference and privileged `/control/v1/*`
+operations with the same bearer-key set. That was an intentional milestone-4 bridge,
+but it is not an acceptable final desktop boundary: an API key copied into an AI client
+must not authorize worker controls or key administration.
+
+## Spike decision
+
+Build two deliberately small shells over one standalone Python node client:
+
+1. a PySide 6 shell; and
+2. a pywebview shell whose UI calls a Python bridge.
+
+Both prototypes use only the versioned localhost control API. Neither imports `drift`,
+Torch, Transformers, Hivemind, or model code. Each prototype must exercise the same
+workflow and be packaged independently so its measurements include only its own shell
+runtime.
+
+The checked-in spike is not the product UI. It may be removed after the decision, while
+the protocol client and acceptance contract can be promoted into the selected desktop
+application.
+
+## Fixed experiment
+
+Each shell must demonstrate the following without changing the node service:
+
+- load a privileged control credential from a native credential store, with an explicit
+  private-file fallback for headless development;
+- reject non-loopback node URLs before transmitting the credential;
+- display the exact OpenAI base URL, node state, model state and route coverage, and
+  contribution-worker state;
+- copy the OpenAI endpoint, create a labeled client API key, and display its secret once;
+- start, pause, and restart a configured contribution worker through `/control/v1`;
+- keep network work outside the GUI event loop;
+- report connection and protocol errors without exposing the control credential;
+- reconnect after the GUI or node is restarted; and
+- produce independently measurable application bundles on Windows, Linux, and macOS.
+
+A shared headless acceptance harness validates authentication, status parsing, client-key
+lifecycle, and worker transitions. Packaged binaries expose a runtime check so CI verifies
+that the selected GUI framework was actually collected.
+
+## Measurements and decision gates
+
+For each operating system and shell, record:
+
+| Gate | Measurement |
+| --- | --- |
+| Packaging | Compressed and installed bundle bytes, file count, clean-machine prerequisites |
+| Startup | Cold start to usable window, idle RSS, background/tray RSS |
+| Isolation | GUI crash leaves the node and worker alive; worker crash leaves the GUI responsive |
+| Lifecycle | Login startup, single-instance behavior, clean shutdown, node reconnect |
+| Updates | Signed install, signed upgrade, rollback, uninstall, and retained user data |
+| Accessibility | Keyboard-only workflow, labels/roles, focus order, screen-reader smoke |
+| Native integration | Credential store, tray/menu bar, notifications, protocol links |
+| CI | Reproducible package build and runtime smoke on Windows, Linux, and macOS |
+
+The selected shell must pass every functional gate. Prefer the smaller and operationally
+simpler result if both pass. A modest source-code convenience does not outweigh a failed
+security, accessibility, signing, update, or crash-isolation gate.
+
+The repository CI produces unsigned spike bundles and size manifests. Signing and update
+tests require platform signing identities and remain a mandatory pre-release gate, not a
+reason to embed test credentials in the repository.
+
+### Preliminary Windows evidence
+
+On the initial Windows 10 development run, both source shells and both packaged binaries
+completed the authenticated UI self-test against an isolated fake node. PySide 6.11.2
+produced an approximately 125.1 MB onedir bundle; pywebview 6.2.1 produced an approximately
+40.0 MB bundle using the installed WebView2 runtime. These are directional results only:
+the local measurement environment contained both shell dependencies. The CI matrix builds
+each shell in a clean job and is the decision-grade source for bundle comparisons.
+
+## Security boundary required before productization
+
+The prototypes can connect to the milestone-4 API, but the production desktop must first
+separate two authorities:
+
+- a privileged desktop control credential, generated during local installation and kept
+  in the native credential store; and
+- revocable OpenAI inference keys that users copy into AI clients.
+
+Only the control credential may call `/control/v1/*`. OpenAI keys may call `/v1/*` and
+nothing else. The desktop must never accept either secret in a command-line argument,
+write it to logs, interpolate it into HTML, or send it to a non-loopback URL.
+
+## Non-goals
+
+This spike does not choose the final visual design, implement autonomous cross-model
+allocation, add public catalogs or credits, bundle model runtimes into the GUI, or relax
+the release gates in `docs/REVIVAL.md`.
+
+## Outcome template
+
+When the three-platform measurements are available, replace the status above with
+`Accepted` and record:
+
+- selected shell and rejected alternative;
+- artifact and runtime measurements by platform;
+- accessibility and crash-isolation results;
+- signing, upgrade, rollback, and uninstall results;
+- native credential-store behavior; and
+- any architectural consequence for the node/control API.

--- a/docs/adr/0002-desktop-shell-spike.md
+++ b/docs/adr/0002-desktop-shell-spike.md
@@ -1,6 +1,6 @@
 # ADR 0002: Desktop shell implementation spike
 
-- Status: Proposed; spike in progress
+- Status: Accepted; PySide 6 selected for product implementation
 - Date: 2026-08-22
 - Roadmap: Milestone 5
 
@@ -82,14 +82,41 @@ The repository CI produces unsigned spike bundles and size manifests. Signing an
 tests require platform signing identities and remain a mandatory pre-release gate, not a
 reason to embed test credentials in the repository.
 
-### Preliminary Windows evidence
+### Cross-platform packaging evidence
 
-On the initial Windows 10 development run, both source shells and both packaged binaries
-completed the authenticated UI self-test against an isolated fake node. PySide 6.11.2
-produced an approximately 125.1 MB onedir bundle; pywebview 6.2.1 produced an approximately
-40.0 MB bundle using the installed WebView2 runtime. These are directional results only:
-the local measurement environment contained both shell dependencies. The CI matrix builds
-each shell in a clean job and is the decision-grade source for bundle comparisons.
+The clean [three-platform CI run](https://github.com/flujo-app/CommunityAI/actions/runs/32595385317)
+built each shell independently and ran its packaged runtime check and authenticated UI
+self-test. All six jobs passed. Sizes below are uncompressed onedir bundle bytes; all
+artifacts are unsigned.
+
+| Platform | PySide 6.11.2 | pywebview 6.2.1 | Result |
+| --- | ---: | ---: | --- |
+| Windows x64 | 128,862,316 bytes / 236 files | 29,234,555 bytes / 215 files | Both passed |
+| Linux x64 | 324,323,392 bytes / 367 files | 948,268,266 bytes / 1,942 files | Both passed |
+| macOS arm64 | 210,278,876 bytes / 268 files | 43,560,981 bytes / 106 files | Both passed |
+
+The Linux jobs install `libegl`, `libgl`, DBus, and xkbcommon as explicit clean-runner
+prerequisites. The build harness preserves packaged-process stdout and stderr on failure,
+so missing runtime libraries do not collapse into an opaque exit code.
+
+## Outcome
+
+Select **PySide 6** for the production desktop shell and retire the pywebview alternative
+after promoting the shared node client and acceptance contract.
+
+Pywebview has a compelling size advantage on Windows and macOS, but its Linux Qt package
+is approximately 2.9 times the PySide package and contains more than five times as many
+files. It also introduces a JavaScript bridge and three renderer/backend families across
+the supported platforms. PySide provides one Python-native widget and accessibility model,
+one asynchronous task boundary, and the more consistent cross-platform packaging result.
+That consistency outweighs its larger Windows and macOS bundles for this product.
+
+This selection closes the shell-comparison gate, not the release gates. Productization
+must still measure cold startup and RSS, prove GUI/node/worker crash isolation, implement
+login startup and single-instance lifecycle behavior, use each operating system's native
+credential store, complete keyboard and screen-reader testing, and pass signed installer,
+upgrade, rollback, uninstall, and retained-data tests. No unsigned spike artifact is a
+release candidate.
 
 ## Security boundary implemented before productization
 
@@ -112,15 +139,3 @@ a non-loopback URL.
 This spike does not choose the final visual design, implement autonomous cross-model
 allocation, add public catalogs or credits, bundle model runtimes into the GUI, or relax
 the release gates in `docs/REVIVAL.md`.
-
-## Outcome template
-
-When the three-platform measurements are available, replace the status above with
-`Accepted` and record:
-
-- selected shell and rejected alternative;
-- artifact and runtime measurements by platform;
-- accessibility and crash-isolation results;
-- signing, upgrade, rollback, and uninstall results;
-- native credential-store behavior; and
-- any architectural consequence for the node/control API.

--- a/docs/adr/0002-desktop-shell-spike.md
+++ b/docs/adr/0002-desktop-shell-spike.md
@@ -17,10 +17,11 @@ would leave the most consequential questions unanswered: packaging, signing, bac
 lifecycle, accessibility, native credential storage, update and rollback behavior, and
 crash isolation on Windows, Linux, and macOS.
 
-The current node also authorizes OpenAI inference and privileged `/control/v1/*`
-operations with the same bearer-key set. That was an intentional milestone-4 bridge,
-but it is not an acceptable final desktop boundary: an API key copied into an AI client
-must not authorize worker controls or key administration.
+The milestone-4 node initially authorized OpenAI inference and privileged
+`/control/v1/*` operations with the same bearer-key set. That was an intentional
+bridge, but it is not an acceptable final desktop boundary: an API key copied into
+an AI client must not authorize worker controls or key administration. The first
+milestone-5 security slice below now closes that gap.
 
 ## Spike decision
 
@@ -90,18 +91,21 @@ produced an approximately 125.1 MB onedir bundle; pywebview 6.2.1 produced an ap
 the local measurement environment contained both shell dependencies. The CI matrix builds
 each shell in a clean job and is the decision-grade source for bundle comparisons.
 
-## Security boundary required before productization
+## Security boundary implemented before productization
 
-The prototypes can connect to the milestone-4 API, but the production desktop must first
-separate two authorities:
+The production desktop boundary now separates two authorities:
 
 - a privileged desktop control credential, generated during local installation and kept
   in the native credential store; and
 - revocable OpenAI inference keys that users copy into AI clients.
 
-Only the control credential may call `/control/v1/*`. OpenAI keys may call `/v1/*` and
-nothing else. The desktop must never accept either secret in a command-line argument,
-write it to logs, interpolate it into HTML, or send it to a non-loopback URL.
+The node now enforces this split: only the control credential may call
+`/control/v1/*`, while managed OpenAI keys may call `/v1/*` and nothing else. Startup
+rejects missing, duplicate, or overlapping control credentials. The headless bridge
+uses a private `control-api.key`; the selected desktop will replace that bridge with
+the operating-system credential store. The desktop must never accept either secret
+in a command-line argument, write it to logs, interpolate it into HTML, or send it to
+a non-loopback URL.
 
 ## Non-goals
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,10 @@ api = [
     "fastapi>=0.115",
     "uvicorn>=0.30",
 ]
+benchmark = [
+    # Process-tree peak RSS sampling for `drift edge-benchmark`.
+    "psutil>=5.9",
+]
 dev = [
     # These three + the `-p no:anyio` addopts below are one interlocked cluster pinned to the
     # pytest 6 era. Blockers to bumping: (a) pytest-forked mishandles teardown on pytest >=7
@@ -84,6 +88,8 @@ dev = [
     # tests/test_openai_api.py exercises the `drift api` shim offline (fastapi TestClient needs httpx)
     "fastapi>=0.115",
     "httpx>=0.27",
+    # Representative compatibility gate for the documented localhost OpenAI endpoint.
+    "openai>=2,<3",
 ]
 
 [project.scripts]

--- a/scripts/fly_smoke_node.py
+++ b/scripts/fly_smoke_node.py
@@ -6,6 +6,8 @@ Roles are selected with ``FLY_SMOKE_ROLE``:
 * ``worker`` serves the explicit range in ``FLY_SMOKE_BLOCKS``;
 * ``client`` waits for complete coverage, generates tokens, checks exact parity,
   and emits a machine-readable ``FLY_SMOKE_RESULT=...`` line;
+* ``multi-node-client`` validates two manifested routes through the official
+  OpenAI client, node restart, LRU residency, and the edge benchmark; and
 * ``local`` runs the one-process Linux CPU smoke test inside the image.
 
 All networking stays on Fly's organization-private IPv6 network. The bootstrap
@@ -17,10 +19,14 @@ from __future__ import annotations
 import json
 import os
 import resource
+import secrets
 import socket
 import subprocess
 import sys
+import tempfile
+import threading
 import time
+from contextlib import contextmanager
 from pathlib import Path
 
 import torch
@@ -38,6 +44,8 @@ MODEL = "Maykeye/TinyLLama-v0"
 NUM_BLOCKS = 8
 PORT = 31337
 DEFAULT_MANIFEST_PATH = "/workspace/model-manifest.json"
+MULTI_MANIFEST_A_PATH = "/workspace/model-a.json"
+MULTI_MANIFEST_B_PATH = "/workspace/model-b.json"
 
 
 def log(message: str) -> None:
@@ -341,6 +349,201 @@ def run_local() -> None:
     )
 
 
+@contextmanager
+def live_uvicorn(app):
+    import uvicorn
+
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    listener.bind(("127.0.0.1", 0))
+    port = listener.getsockname()[1]
+    server = uvicorn.Server(uvicorn.Config(app, log_level="warning", lifespan="on"))
+    thread = threading.Thread(target=server.run, kwargs={"sockets": [listener]}, daemon=True)
+    thread.start()
+    deadline = time.monotonic() + 10
+    while not server.started and thread.is_alive() and time.monotonic() < deadline:
+        time.sleep(0.05)
+    if not server.started:
+        server.should_exit = True
+        thread.join(timeout=5)
+        listener.close()
+        raise RuntimeError("the multi-model node HTTP server did not start")
+    try:
+        yield f"http://127.0.0.1:{port}"
+    finally:
+        server.should_exit = True
+        thread.join(timeout=10)
+        listener.close()
+        if thread.is_alive():
+            raise RuntimeError("the multi-model node HTTP server did not stop")
+
+
+def wait_for_node_routes(client, model_ids: list[str], timeout: float) -> dict:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        status = client.get("/control/v1/status").json()
+        routes = {item["id"]: item.get("route") for item in status["models"]}
+        log(f"node_routes={json.dumps(routes, sort_keys=True)}")
+        if all(routes.get(model_id, {}).get("status") == "complete" for model_id in model_ids):
+            return status
+        time.sleep(1)
+    raise TimeoutError("the multi-model node did not discover complete routes")
+
+
+def reference_completion(manifest: ModelManifest, prompt: str, max_new_tokens: int) -> str:
+    verifier = ManifestArtifactVerifier(
+        manifest,
+        manifest.source.repository,
+        manifest.source.revision,
+        cache_dir="/tmp/multi-model-node-cache",
+    )
+    source = verifier.ensure_startup_metadata(include_tokenizer=True)
+    tokenizer = AutoTokenizer.from_pretrained(source, local_files_only=True)
+    model = AutoModelForCausalLM.from_pretrained(
+        manifest.source.repository,
+        revision=manifest.source.revision,
+        cache_dir="/tmp/multi-model-node-cache",
+        dtype=getattr(torch, manifest.runtime.dtype),
+        attn_implementation=manifest.runtime.attention_implementation,
+    )
+    model.eval()
+    input_ids = tokenizer(prompt, return_tensors="pt")["input_ids"]
+    with torch.inference_mode():
+        output_ids = model.generate(input_ids, max_new_tokens=max_new_tokens, do_sample=False)
+    return tokenizer.decode(output_ids[0, input_ids.shape[1] :], skip_special_tokens=True)
+
+
+def run_multi_node_client() -> None:
+    import httpx
+    from openai import OpenAI
+
+    from drift.cli.run_node import _build_model_manager
+    from drift.node.config import NodeConfig, NodeModelConfig
+    from drift.node.edge_benchmark import benchmark_client_runtime
+    from drift.node.keys import ApiKeyStore
+    from drift.node.loading import make_manifest_loader
+    from drift.node.server import create_node_app
+
+    initial_peer = required_env("FLY_SMOKE_INITIAL_PEER")
+    timeout = float(os.environ.get("FLY_SMOKE_TIMEOUT", "300"))
+    manifest_paths = [
+        Path(os.environ.get("FLY_SMOKE_MANIFEST_A", MULTI_MANIFEST_A_PATH)),
+        Path(os.environ.get("FLY_SMOKE_MANIFEST_B", MULTI_MANIFEST_B_PATH)),
+    ]
+    manifests = [ModelManifest.load(path) for path in manifest_paths]
+    if manifests[0].digest == manifests[1].digest:
+        raise ValueError("multi-model validation requires two distinct manifest digests")
+    model_ids = [manifest.name for manifest in manifests]
+    prompt = "Hello"
+    max_new_tokens = 3
+    api_key = f"drift_{secrets.token_urlsafe(32)}"
+
+    config = NodeConfig(
+        schema_version=1,
+        max_loaded_models=1,
+        discovery_update_period=1,
+        discovery_startup_timeout=15,
+        models=tuple(
+            NodeModelConfig(
+                manifest_path=path,
+                initial_peers=(initial_peer,),
+                cache_dir=Path("/tmp/multi-model-node-cache"),
+                request_timeout=30,
+                max_retries=3,
+            )
+            for path in manifest_paths
+        ),
+    )
+    data_dir = Path(tempfile.mkdtemp(prefix="drift-fly-multi-node-"))
+    key_path = data_dir / "api-keys.json"
+    key_store = ApiKeyStore(key_path)
+    key_store.ensure_key(api_key, label="fly-validation")
+    edge_cache = Path("/tmp/edge-benchmark-cache")
+    edge_measurement = benchmark_client_runtime(
+        manifests[0],
+        make_manifest_loader(
+            manifests[0],
+            initial_peers=(initial_peer,),
+            cache_dir=str(edge_cache),
+            request_timeout=30,
+            max_retries=3,
+        ),
+        cache_dir=edge_cache,
+        prompt=prompt,
+        max_new_tokens=max_new_tokens,
+    )
+    expected = reference_completion(manifests[0], prompt, max_new_tokens)
+    result = {
+        "models": model_ids,
+        "manifest_digests": [manifest.digest_id for manifest in manifests],
+        "expected": expected,
+        "edge_benchmark": edge_measurement,
+    }
+
+    def run_node_once(*, exercise_both: bool) -> dict:
+        manager, _, discovery = _build_model_manager(config, token=None)
+        app = create_node_app(manager, api_key_store=ApiKeyStore(key_path), host="127.0.0.1", port=0)
+        discovery.start()
+        try:
+            with live_uvicorn(app) as origin:
+                headers = {"Authorization": f"Bearer {api_key}"}
+                control = httpx.Client(base_url=origin, headers=headers, timeout=30)
+                sdk = OpenAI(api_key=api_key, base_url=f"{origin}/v1", max_retries=0, timeout=60)
+                status_before = wait_for_node_routes(control, model_ids, timeout)
+                listed = sorted(model.id for model in sdk.models.list().data)
+                if listed != sorted(model_ids):
+                    raise AssertionError(f"official SDK listed {listed}, expected {sorted(model_ids)}")
+
+                first = sdk.completions.create(
+                    model=model_ids[0], prompt=prompt, max_tokens=max_new_tokens, temperature=0
+                )
+                if first.choices[0].text != expected:
+                    raise AssertionError(f"first model output {first.choices[0].text!r} != {expected!r}")
+                first_status = control.get("/control/v1/status").json()
+                states_after_first = {item["id"]: item["state"] for item in first_status["models"]}
+
+                second_text = None
+                states_after_second = None
+                if exercise_both:
+                    stream = sdk.completions.create(
+                        model=model_ids[1],
+                        prompt=prompt,
+                        max_tokens=max_new_tokens,
+                        temperature=0,
+                        stream=True,
+                    )
+                    second_text = "".join(chunk.choices[0].text or "" for chunk in stream if chunk.choices)
+                    if second_text != expected:
+                        raise AssertionError(f"second model output {second_text!r} != {expected!r}")
+                    second_status = control.get("/control/v1/status").json()
+                    states_after_second = {item["id"]: item["state"] for item in second_status["models"]}
+                    if states_after_second[model_ids[0]] != "known" or states_after_second[model_ids[1]] not in {
+                        "ready",
+                        "degraded",
+                    }:
+                        raise AssertionError(f"LRU residency did not move to the second model: {states_after_second}")
+                sdk.close()
+                control.close()
+                return {
+                    "routes_before_load": {item["id"]: item["route"] for item in status_before["models"]},
+                    "listed": listed,
+                    "first_completion": first.choices[0].text,
+                    "states_after_first": states_after_first,
+                    "second_stream": second_text,
+                    "states_after_second": states_after_second,
+                }
+        finally:
+            manager.shutdown()
+
+    result["first_node"] = run_node_once(exercise_both=True)
+    result["restarted_node"] = run_node_once(exercise_both=False)
+    result["persistent_key_reused"] = ApiKeyStore(key_path).verify(api_key)
+    result["exact_completion_parity"] = result["first_node"]["first_completion"] == expected
+    result["restart_completion_parity"] = result["restarted_node"]["first_completion"] == expected
+    result["client_max_rss_kib"] = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    print(f"FLY_MULTI_NODE_RESULT={json.dumps(result, sort_keys=True)}", flush=True)
+
+
 def main() -> None:
     role = os.environ.get("FLY_SMOKE_ROLE", "local")
     roles = {
@@ -348,6 +551,7 @@ def main() -> None:
         "worker": run_worker,
         "poisoned-worker": run_poisoned_worker,
         "client": run_client,
+        "multi-node-client": run_multi_node_client,
         "local": run_local,
     }
     try:

--- a/scripts/fly_smoke_node.py
+++ b/scripts/fly_smoke_node.py
@@ -437,6 +437,7 @@ def run_multi_node_client() -> None:
     prompt = "Hello"
     max_new_tokens = 3
     api_key = f"drift_{secrets.token_urlsafe(32)}"
+    control_key = f"drift_control_{secrets.token_urlsafe(32)}"
 
     config = NodeConfig(
         schema_version=1,
@@ -482,13 +483,30 @@ def run_multi_node_client() -> None:
 
     def run_node_once(*, exercise_both: bool) -> dict:
         manager, _, discovery = _build_model_manager(config, token=None)
-        app = create_node_app(manager, api_key_store=ApiKeyStore(key_path), host="127.0.0.1", port=0)
+        app = create_node_app(
+            manager,
+            api_key_store=ApiKeyStore(key_path),
+            control_keys=[control_key],
+            host="127.0.0.1",
+            port=0,
+        )
         discovery.start()
         try:
             with live_uvicorn(app) as origin:
-                headers = {"Authorization": f"Bearer {api_key}"}
-                control = httpx.Client(base_url=origin, headers=headers, timeout=30)
+                control_headers = {"Authorization": f"Bearer {control_key}"}
+                control = httpx.Client(base_url=origin, headers=control_headers, timeout=30)
                 sdk = OpenAI(api_key=api_key, base_url=f"{origin}/v1", max_retries=0, timeout=60)
+                if (
+                    httpx.get(
+                        f"{origin}/control/v1/status",
+                        headers={"Authorization": f"Bearer {api_key}"},
+                        timeout=30,
+                    ).status_code
+                    != 401
+                ):
+                    raise AssertionError("OpenAI client key unexpectedly authorized the control API")
+                if control.get("/v1/models").status_code != 401:
+                    raise AssertionError("control key unexpectedly authorized the OpenAI API")
                 status_before = wait_for_node_routes(control, model_ids, timeout)
                 listed = sorted(model.id for model in sdk.models.list().data)
                 if listed != sorted(model_ids):
@@ -531,6 +549,7 @@ def run_multi_node_client() -> None:
                     "states_after_first": states_after_first,
                     "second_stream": second_text,
                     "states_after_second": states_after_second,
+                    "authorization_domains_separate": True,
                 }
         finally:
             manager.shutdown()

--- a/spikes/desktop/README.md
+++ b/spikes/desktop/README.md
@@ -5,6 +5,9 @@ This standalone package compares the two desktop-shell candidates from
 depend on the `drift` package: both shells communicate with an already-running local
 node through `/control/v1`.
 
+The cross-platform experiment selected PySide 6 for product implementation. The
+pywebview prototype remains here only to preserve the measured comparison.
+
 ## Install
 
 Create a disposable virtual environment inside this directory, then install one shell:
@@ -29,8 +32,8 @@ communityai-desktop-spike --store-control-key
 For a headless development node, its existing private key file can be selected instead:
 
 ```shell
-communityai-desktop-spike --shell pyside --control-key-file /path/to/local-api.key
-communityai-desktop-spike --shell webview --control-key-file /path/to/local-api.key
+communityai-desktop-spike --shell pyside --control-key-file /path/to/control-api.key
+communityai-desktop-spike --shell webview --control-key-file /path/to/control-api.key
 ```
 
 The default endpoint is `http://127.0.0.1:8080`. A URL ending in `/v1` is accepted and

--- a/spikes/desktop/README.md
+++ b/spikes/desktop/README.md
@@ -1,0 +1,63 @@
+# CommunityAI desktop shell spike
+
+This standalone package compares the two desktop-shell candidates from
+[`ADR 0002`](../../docs/adr/0002-desktop-shell-spike.md). It intentionally does not
+depend on the `drift` package: both shells communicate with an already-running local
+node through `/control/v1`.
+
+## Install
+
+Create a disposable virtual environment inside this directory, then install one shell:
+
+```shell
+python -m pip install -e ".[pyside,dev]"
+```
+
+or:
+
+```shell
+python -m pip install -e ".[webview,dev]"
+```
+
+The native credential-store adapter uses the operating-system backend exposed by
+`keyring`. Store the node control credential without putting it in the process list:
+
+```shell
+communityai-desktop-spike --store-control-key
+```
+
+For a headless development node, its existing private key file can be selected instead:
+
+```shell
+communityai-desktop-spike --shell pyside --control-key-file /path/to/local-api.key
+communityai-desktop-spike --shell webview --control-key-file /path/to/local-api.key
+```
+
+The default endpoint is `http://127.0.0.1:8080`. A URL ending in `/v1` is accepted and
+normalized. Non-loopback URLs are rejected before the control credential is read.
+
+## Verification
+
+The contract test has no GUI dependency:
+
+```shell
+python -m unittest discover -s tests -v
+communityai-desktop-spike --self-test
+```
+
+Verify that an installed shell runtime can be imported:
+
+```shell
+communityai-desktop-spike --shell pyside --check-runtime
+communityai-desktop-spike --shell webview --check-runtime
+```
+
+Build and smoke-test independent PyInstaller bundles:
+
+```shell
+python build_spike.py --shell pyside
+python build_spike.py --shell webview
+```
+
+The build writes a JSON size manifest beside each bundle. GitHub Actions repeats this
+on Windows, Linux, and macOS. These are unsigned experimental bundles, not releases.

--- a/spikes/desktop/build_spike.py
+++ b/spikes/desktop/build_spike.py
@@ -1,0 +1,121 @@
+"""Build and runtime-smoke one independently packaged desktop shell."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _directory_metrics(path: Path) -> tuple[int, int]:
+    files = [item for item in path.rglob("*") if item.is_file()]
+    return sum(item.stat().st_size for item in files), len(files)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--shell", required=True, choices=("pyside", "webview"))
+    parser.add_argument("--output-root", type=Path)
+    args = parser.parse_args()
+
+    try:
+        import PyInstaller.__main__
+    except ImportError as exc:
+        parser.error(f"PyInstaller is not installed: {exc}")
+
+    project = Path(__file__).resolve().parent
+    output_root = (args.output_root or project / "dist" / "desktop-spike").resolve()
+    source_root = project / "src"
+    build_root = project / "build" / "desktop-spike" / args.shell
+    launcher = project / f"launch_{args.shell}.py"
+    display_name = "CommunityAI-PySide-Spike" if args.shell == "pyside" else "CommunityAI-Webview-Spike"
+    bundle_root = output_root / args.shell / display_name
+
+    pyinstaller_args = [
+        str(launcher),
+        "--name",
+        display_name,
+        "--onedir",
+        "--noconfirm",
+        "--clean",
+        "--paths",
+        str(source_root),
+        "--distpath",
+        str(output_root / args.shell),
+        "--workpath",
+        str(build_root / "work"),
+        "--specpath",
+        str(build_root / "spec"),
+        "--collect-data",
+        "communityai_desktop_spike",
+        "--hidden-import",
+        f"communityai_desktop_spike.{args.shell}_shell",
+    ]
+    credential_backend = {
+        "Windows": "keyring.backends.Windows",
+        "Darwin": "keyring.backends.macOS",
+        "Linux": "keyring.backends.SecretService",
+    }.get(platform.system())
+    if credential_backend:
+        pyinstaller_args.extend(("--hidden-import", credential_backend))
+    if args.shell == "webview":
+        webview_backend = {
+            "Windows": "webview.platforms.winforms",
+            "Darwin": "webview.platforms.cocoa",
+            "Linux": "webview.platforms.qt",
+        }.get(platform.system())
+        if webview_backend:
+            pyinstaller_args.extend(("--hidden-import", webview_backend))
+
+    PyInstaller.__main__.run(pyinstaller_args)
+
+    executable = bundle_root / f"{display_name}{'.exe' if os.name == 'nt' else ''}"
+    if not executable.is_file():
+        raise RuntimeError(f"packaged executable was not created: {executable}")
+    environment = os.environ.copy()
+    environment.setdefault("QT_QPA_PLATFORM", "offscreen")
+    environment.setdefault("QTWEBENGINE_CHROMIUM_FLAGS", "--no-sandbox")
+    if platform.system() == "Linux" and args.shell == "webview":
+        environment.setdefault("PYWEBVIEW_GUI", "qt")
+    check = subprocess.run(
+        [str(executable), "--check-runtime"],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        env=environment,
+    )
+    runtime = json.loads(check.stdout.strip())
+    subprocess.run(
+        [str(executable), "--ui-self-test"],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        env=environment,
+    )
+    bundle_bytes, file_count = _directory_metrics(bundle_root)
+    metrics = {
+        "schema_version": 1,
+        "shell": args.shell,
+        "platform": platform.platform(),
+        "python": platform.python_version(),
+        "bundle_bytes": bundle_bytes,
+        "file_count": file_count,
+        "runtime": runtime,
+        "ui_smoke_passed": True,
+        "signed": False,
+    }
+    metrics_path = output_root / f"{args.shell}-metrics.json"
+    metrics_path.parent.mkdir(parents=True, exist_ok=True)
+    metrics_path.write_text(json.dumps(metrics, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps(metrics, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/spikes/desktop/build_spike.py
+++ b/spikes/desktop/build_spike.py
@@ -16,6 +16,24 @@ def _directory_metrics(path: Path) -> tuple[int, int]:
     return sum(item.stat().st_size for item in files), len(files)
 
 
+def _run_bundle(executable: Path, action: str, environment: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        [str(executable), action],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        env=environment,
+    )
+    if result.returncode:
+        raise RuntimeError(
+            f"packaged executable failed {action} with exit code {result.returncode}\n"
+            f"stdout:\n{result.stdout.strip()}\n"
+            f"stderr:\n{result.stderr.strip()}"
+        )
+    return result
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--shell", required=True, choices=("pyside", "webview"))
@@ -81,23 +99,9 @@ def main() -> int:
     environment.setdefault("QTWEBENGINE_CHROMIUM_FLAGS", "--no-sandbox")
     if platform.system() == "Linux" and args.shell == "webview":
         environment.setdefault("PYWEBVIEW_GUI", "qt")
-    check = subprocess.run(
-        [str(executable), "--check-runtime"],
-        check=True,
-        capture_output=True,
-        text=True,
-        timeout=60,
-        env=environment,
-    )
+    check = _run_bundle(executable, "--check-runtime", environment)
     runtime = json.loads(check.stdout.strip())
-    subprocess.run(
-        [str(executable), "--ui-self-test"],
-        check=True,
-        capture_output=True,
-        text=True,
-        timeout=60,
-        env=environment,
-    )
+    _run_bundle(executable, "--ui-self-test", environment)
     bundle_bytes, file_count = _directory_metrics(bundle_root)
     metrics = {
         "schema_version": 1,

--- a/spikes/desktop/launch_pyside.py
+++ b/spikes/desktop/launch_pyside.py
@@ -1,0 +1,3 @@
+from communityai_desktop_spike.cli import main
+
+raise SystemExit(main(default_shell="pyside", locked_shell=True))

--- a/spikes/desktop/launch_webview.py
+++ b/spikes/desktop/launch_webview.py
@@ -1,0 +1,3 @@
+from communityai_desktop_spike.cli import main
+
+raise SystemExit(main(default_shell="webview", locked_shell=True))

--- a/spikes/desktop/pyproject.toml
+++ b/spikes/desktop/pyproject.toml
@@ -1,0 +1,44 @@
+[build-system]
+requires = ["setuptools>=69"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "communityai-desktop-spike"
+version = "0.1.0"
+description = "Isolated desktop shell comparison for CommunityAI"
+requires-python = ">=3.10"
+dependencies = [
+    "keyring>=25,<27",
+]
+
+[project.optional-dependencies]
+pyside = [
+    "PySide6>=6.8,<7",
+]
+webview = [
+    "pywebview>=5.4,<7; sys_platform != 'linux'",
+    "pywebview[qt]>=5.4,<7; sys_platform == 'linux'",
+]
+dev = [
+    "pyinstaller>=6.11,<7",
+]
+
+[project.scripts]
+communityai-desktop-spike = "communityai_desktop_spike.cli:main"
+
+[tool.setuptools]
+package-dir = { "" = "src" }
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.package-data]
+communityai_desktop_spike = ["webview.html"]
+
+[tool.black]
+line-length = 120
+required-version = "22.3.0"
+
+[tool.isort]
+profile = "black"
+line_length = 120

--- a/spikes/desktop/src/communityai_desktop_spike/__init__.py
+++ b/spikes/desktop/src/communityai_desktop_spike/__init__.py
@@ -1,0 +1,3 @@
+"""Standalone CommunityAI desktop-shell experiment."""
+
+__version__ = "0.1.0"

--- a/spikes/desktop/src/communityai_desktop_spike/__main__.py
+++ b/spikes/desktop/src/communityai_desktop_spike/__main__.py
@@ -1,0 +1,3 @@
+from communityai_desktop_spike.cli import main
+
+raise SystemExit(main())

--- a/spikes/desktop/src/communityai_desktop_spike/acceptance.py
+++ b/spikes/desktop/src/communityai_desktop_spike/acceptance.py
@@ -1,0 +1,218 @@
+"""Shared headless acceptance contract for both desktop shells."""
+
+from __future__ import annotations
+
+import json
+import threading
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any, Dict, Iterator, Tuple
+from urllib.parse import unquote
+
+from communityai_desktop_spike.client import NodeClient
+
+
+class _FakeNodeState:
+    token = "spike-control-secret"
+
+    def __init__(self):
+        self.worker_state = "paused"
+        self.keys: Dict[str, Dict[str, Any]] = {
+            "bootstrap": {
+                "id": "bootstrap",
+                "label": "bootstrap",
+                "fingerprint": "sha256:bootstrap",
+                "created_at": 1,
+                "revoked_at": None,
+            }
+        }
+        self.next_key = 1
+
+    def worker(self) -> Dict[str, Any]:
+        return {
+            "id": "worker-a",
+            "model": "Tiny Test",
+            "state": self.worker_state,
+            "desired_running": self.worker_state == "running",
+            "restart_count": 0,
+            "last_error": None,
+        }
+
+
+def _handler(state: _FakeNodeState):
+    class FakeNodeHandler(BaseHTTPRequestHandler):
+        server_version = "CommunityAIFakeNode/1"
+
+        def log_message(self, format, *args):  # noqa: A002, ANN001
+            return
+
+        def _authorized(self) -> bool:
+            if self.headers.get("Authorization") == f"Bearer {state.token}":
+                return True
+            # Intentionally echo the bad candidate so the client contract proves it redacts
+            # a hostile or buggy local server response before presenting an error.
+            self._send(401, {"detail": f"Invalid API key {self.headers.get('Authorization', '')}"})
+            return False
+
+        def _body(self) -> Dict[str, Any]:
+            size = int(self.headers.get("Content-Length", "0"))
+            value = json.loads(self.rfile.read(size).decode("utf-8")) if size else {}
+            if not isinstance(value, dict):
+                raise ValueError("body must be an object")
+            return value
+
+        def _send(self, code: int, body: Dict[str, Any]) -> None:
+            encoded = json.dumps(body).encode("utf-8")
+            self.send_response(code)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(encoded)))
+            self.end_headers()
+            self.wfile.write(encoded)
+
+        def do_GET(self):  # noqa: N802
+            if not self._authorized():
+                return
+            if self.path == "/control/v1/status":
+                self._send(
+                    200,
+                    {
+                        "api_version": 1,
+                        "status": "running",
+                        "started_at": 1,
+                        "openai_base_url": f"http://127.0.0.1:{self.server.server_port}/v1",
+                        "runtime_budget": {
+                            "max_loaded_models": 1,
+                            "resident_models": 0,
+                        },
+                        "models": [
+                            {
+                                "id": "Tiny Test",
+                                "state": "known",
+                                "active_requests": 0,
+                                "route": {"covered_blocks": 8, "total_blocks": 8},
+                            }
+                        ],
+                        "workers": [state.worker()],
+                    },
+                )
+            elif self.path == "/control/v1/workers":
+                self._send(200, {"workers": [state.worker()]})
+            elif self.path == "/control/v1/keys":
+                self._send(200, {"keys": list(state.keys.values())})
+            else:
+                self._send(404, {"detail": "not found"})
+
+        def do_POST(self):  # noqa: N802
+            if not self._authorized():
+                return
+            if self.path == "/control/v1/keys":
+                body = self._body()
+                key_id = f"client-{state.next_key}"
+                state.next_key += 1
+                metadata = {
+                    "id": key_id,
+                    "label": body["label"],
+                    "fingerprint": f"sha256:{key_id}",
+                    "created_at": state.next_key,
+                    "revoked_at": None,
+                }
+                state.keys[key_id] = metadata
+                self._send(201, {"key": metadata, "secret": f"drift_{key_id}-secret"})
+                return
+            parts = self.path.split("/")
+            if len(parts) == 7 and parts[1:4] == ["control", "v1", "workers"]:
+                worker_id, action = unquote(parts[4]), parts[5]
+                # The route has six slash-separated components plus the leading empty string.
+                if parts[6]:
+                    self._send(404, {"detail": "not found"})
+                    return
+                if worker_id == "worker-a" and action in ("start", "pause", "restart"):
+                    state.worker_state = "paused" if action == "pause" else "running"
+                    self._send(200, {"changed": True, "worker": state.worker()})
+                    return
+            # Accept the actual route without a trailing slash.
+            if len(parts) == 6 and parts[1:4] == ["control", "v1", "workers"]:
+                worker_id, action = unquote(parts[4]), parts[5]
+                if worker_id == "worker-a" and action in ("start", "pause", "restart"):
+                    state.worker_state = "paused" if action == "pause" else "running"
+                    self._send(200, {"changed": True, "worker": state.worker()})
+                    return
+            self._send(404, {"detail": "not found"})
+
+        def do_PATCH(self):  # noqa: N802
+            if not self._authorized():
+                return
+            prefix = "/control/v1/keys/"
+            key_id = unquote(self.path[len(prefix) :]) if self.path.startswith(prefix) else ""
+            if key_id not in state.keys:
+                self._send(404, {"detail": "unknown key"})
+                return
+            state.keys[key_id]["label"] = self._body()["label"]
+            self._send(200, {"key": state.keys[key_id]})
+
+        def do_DELETE(self):  # noqa: N802
+            if not self._authorized():
+                return
+            prefix = "/control/v1/keys/"
+            key_id = unquote(self.path[len(prefix) :]) if self.path.startswith(prefix) else ""
+            if key_id not in state.keys:
+                self._send(404, {"detail": "unknown key"})
+                return
+            state.keys[key_id]["revoked_at"] = 2
+            self._send(200, {"key": state.keys[key_id]})
+
+    return FakeNodeHandler
+
+
+@contextmanager
+def fake_node() -> Iterator[Tuple[str, str]]:
+    state = _FakeNodeState()
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _handler(state))
+    thread = threading.Thread(target=server.serve_forever, name="desktop-spike-fake-node", daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}", state.token
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def run_contract(client: NodeClient) -> Dict[str, Any]:
+    """Exercise the common protocol surface used by both shells."""
+    status = client.status()
+    workers = client.list_workers()
+    if len(workers) != 1 or workers[0].get("state") != "paused":
+        raise AssertionError("acceptance node did not begin with one paused worker")
+
+    for action, expected in (
+        ("start", "running"),
+        ("pause", "paused"),
+        ("restart", "running"),
+    ):
+        response = client.worker_action("worker-a", action)
+        if response.get("worker", {}).get("state") != expected:
+            raise AssertionError(f"worker {action} did not produce state {expected}")
+
+    created = client.create_key("acceptance client")
+    key_id = created["key"]["id"]
+    if created["secret"] in json.dumps(client.list_keys()):
+        raise AssertionError("API-key listing exposed plaintext secret")
+    relabeled = client.relabel_key(key_id, "renamed acceptance client")
+    if relabeled.get("key", {}).get("label") != "renamed acceptance client":
+        raise AssertionError("API-key relabel did not persist")
+    revoked = client.revoke_key(key_id)
+    if revoked.get("key", {}).get("revoked_at") is None:
+        raise AssertionError("API-key revocation did not persist")
+
+    return {
+        "api_version": status["api_version"],
+        "model_count": len(status["models"]),
+        "worker_actions": 3,
+        "key_lifecycle": "passed",
+    }
+
+
+def run_self_test() -> Dict[str, Any]:
+    with fake_node() as (url, token):
+        return run_contract(NodeClient(url, token))

--- a/spikes/desktop/src/communityai_desktop_spike/cli.py
+++ b/spikes/desktop/src/communityai_desktop_spike/cli.py
@@ -1,0 +1,104 @@
+"""Command-line launcher shared by the desktop shell prototypes."""
+
+from __future__ import annotations
+
+import argparse
+import getpass
+import importlib
+import json
+import sys
+from pathlib import Path
+from typing import Optional, Sequence
+
+from communityai_desktop_spike.acceptance import fake_node, run_self_test
+from communityai_desktop_spike.client import NodeClient, NodeClientError, normalize_loopback_url
+from communityai_desktop_spike.controller import DesktopController
+from communityai_desktop_spike.credentials import (
+    DEFAULT_CREDENTIAL_ACCOUNT,
+    DEFAULT_CREDENTIAL_SERVICE,
+    CredentialError,
+    NativeCredentialStore,
+    load_private_key_file,
+)
+
+
+def build_parser(*, default_shell: Optional[str] = None, locked_shell: bool = False) -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="CommunityAI desktop shell experiment")
+    if locked_shell:
+        if default_shell not in ("pyside", "webview"):
+            raise ValueError("a packaged launcher must select one desktop shell")
+        parser.set_defaults(shell=default_shell)
+    else:
+        parser.add_argument("--shell", choices=("pyside", "webview"), default=default_shell or "pyside")
+    parser.add_argument("--node-url", default="http://127.0.0.1:8080")
+    parser.add_argument("--timeout", type=float, default=5.0)
+    parser.add_argument("--control-key-file", type=Path)
+    parser.add_argument("--credential-service", default=DEFAULT_CREDENTIAL_SERVICE)
+    parser.add_argument("--credential-account", default=DEFAULT_CREDENTIAL_ACCOUNT)
+    action = parser.add_mutually_exclusive_group()
+    action.add_argument("--store-control-key", action="store_true")
+    action.add_argument("--delete-control-key", action="store_true")
+    action.add_argument("--check-runtime", action="store_true")
+    action.add_argument("--self-test", action="store_true")
+    action.add_argument("--ui-self-test", action="store_true", help=argparse.SUPPRESS)
+    action.add_argument("--probe-only", action="store_true")
+    return parser
+
+
+def _shell_module(shell: str):
+    return importlib.import_module(f"communityai_desktop_spike.{shell}_shell")
+
+
+def _credential_store(args: argparse.Namespace) -> NativeCredentialStore:
+    return NativeCredentialStore(args.credential_service, args.credential_account)
+
+
+def _load_control_token(args: argparse.Namespace) -> str:
+    if args.control_key_file is not None:
+        return load_private_key_file(args.control_key_file)
+    return _credential_store(args).get()
+
+
+def main(
+    argv: Optional[Sequence[str]] = None,
+    *,
+    default_shell: Optional[str] = None,
+    locked_shell: bool = False,
+) -> int:
+    parser = build_parser(default_shell=default_shell, locked_shell=locked_shell)
+    args = parser.parse_args(argv)
+    try:
+        if args.self_test:
+            print(json.dumps(run_self_test(), sort_keys=True))
+            return 0
+        if args.check_runtime:
+            print(json.dumps(_shell_module(args.shell).check_runtime(), sort_keys=True))
+            return 0
+        if args.ui_self_test:
+            with fake_node() as (url, token):
+                controller = DesktopController(NodeClient(url, token))
+                return int(_shell_module(args.shell).run(controller, auto_close_seconds=1.0) or 0)
+        if args.store_control_key:
+            secret = getpass.getpass("Local node control credential: ")
+            _credential_store(args).set(secret)
+            print(f"Stored control credential for account {args.credential_account!r}")
+            return 0
+        if args.delete_control_key:
+            deleted = _credential_store(args).delete()
+            print("Deleted control credential" if deleted else "No stored control credential")
+            return 0
+
+        # Validate the destination before opening either credential source.
+        node_url = normalize_loopback_url(args.node_url)
+        client = NodeClient(node_url, _load_control_token(args), timeout=args.timeout)
+        controller = DesktopController(client)
+        if args.probe_only:
+            print(json.dumps(controller.snapshot(), sort_keys=True))
+            return 0
+        return int(_shell_module(args.shell).run(controller) or 0)
+    except (CredentialError, NodeClientError, ValueError) as exc:
+        parser.exit(2, f"communityai-desktop-spike: {exc}\n")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/spikes/desktop/src/communityai_desktop_spike/client.py
+++ b/spikes/desktop/src/communityai_desktop_spike/client.py
@@ -1,0 +1,189 @@
+"""Strict localhost client for the versioned CommunityAI node control API."""
+
+from __future__ import annotations
+
+import ipaddress
+import json
+import socket
+from typing import Any, Dict, List, Mapping, Optional
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote, urlsplit, urlunsplit
+from urllib.request import HTTPRedirectHandler, Request, build_opener
+
+MAX_RESPONSE_BYTES = 4 * 1024 * 1024
+SUPPORTED_CONTROL_API_VERSION = 1
+
+
+class NodeClientError(RuntimeError):
+    """The local node could not be reached or returned an invalid response."""
+
+
+class NodeApiError(NodeClientError):
+    """The local node returned an HTTP error."""
+
+    def __init__(self, status_code: int, detail: str):
+        super().__init__(f"Local node returned HTTP {status_code}: {detail}")
+        self.status_code = status_code
+        self.detail = detail
+
+
+class _RejectRedirects(HTTPRedirectHandler):
+    """Never forward the privileged Authorization header through a redirect."""
+
+    def redirect_request(self, request, file_pointer, code, message, headers, new_url):  # noqa: ANN001
+        return None
+
+
+def normalize_loopback_url(value: str) -> str:
+    """Normalize a node URL and reject anything that could exfiltrate its credential."""
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError("node URL must be a non-empty string")
+    parsed = urlsplit(value.strip())
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError("node URL scheme must be http or https")
+    if not parsed.hostname:
+        raise ValueError("node URL must include a host")
+    if parsed.username is not None or parsed.password is not None:
+        raise ValueError("node URL must not include user information")
+    if parsed.query or parsed.fragment:
+        raise ValueError("node URL must not include a query or fragment")
+
+    hostname = parsed.hostname.rstrip(".").casefold()
+    if hostname != "localhost":
+        try:
+            if not ipaddress.ip_address(hostname).is_loopback:
+                raise ValueError("node URL must use a loopback address")
+        except ValueError as exc:
+            if str(exc) == "node URL must use a loopback address":
+                raise
+            raise ValueError("node URL must use localhost or a literal loopback address") from exc
+
+    path = parsed.path.rstrip("/")
+    if path == "/v1":
+        path = ""
+    if path:
+        raise ValueError("node URL path must be empty or /v1")
+    try:
+        parsed.port
+    except ValueError as exc:
+        raise ValueError("node URL has an invalid port") from exc
+    return urlunsplit((parsed.scheme, parsed.netloc, "", "", ""))
+
+
+class NodeClient:
+    """Synchronous control client; GUI adapters must call it off their event loop."""
+
+    def __init__(self, node_url: str, control_token: str, *, timeout: float = 5.0):
+        self.node_url = normalize_loopback_url(node_url)
+        if not isinstance(control_token, str) or not control_token.strip():
+            raise ValueError("control credential must be a non-empty string")
+        if timeout <= 0:
+            raise ValueError("timeout must be positive")
+        self._control_token = control_token.strip()
+        self.timeout = float(timeout)
+        self._opener = build_opener(_RejectRedirects())
+
+    def _decode_response(self, response) -> Dict[str, Any]:  # noqa: ANN001
+        body = response.read(MAX_RESPONSE_BYTES + 1)
+        if len(body) > MAX_RESPONSE_BYTES:
+            raise NodeClientError("Local node response exceeded the size limit")
+        try:
+            decoded = json.loads(body.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise NodeClientError("Local node returned invalid JSON") from exc
+        if not isinstance(decoded, dict):
+            raise NodeClientError("Local node response must be a JSON object")
+        return decoded
+
+    def _request(self, method: str, path: str, *, payload: Optional[Mapping[str, Any]] = None) -> Dict[str, Any]:
+        data = None if payload is None else json.dumps(payload, separators=(",", ":")).encode("utf-8")
+        request = Request(
+            f"{self.node_url}{path}",
+            data=data,
+            method=method,
+            headers={
+                "Accept": "application/json",
+                "Authorization": f"Bearer {self._control_token}",
+                **({"Content-Type": "application/json"} if data is not None else {}),
+            },
+        )
+        try:
+            with self._opener.open(request, timeout=self.timeout) as response:
+                return self._decode_response(response)
+        except HTTPError as exc:
+            detail = exc.reason or "request failed"
+            try:
+                body = exc.read(MAX_RESPONSE_BYTES + 1)
+                decoded = json.loads(body.decode("utf-8"))
+                if isinstance(decoded, dict) and isinstance(decoded.get("detail"), str):
+                    detail = decoded["detail"]
+            except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+                pass
+            raise NodeApiError(exc.code, str(detail).replace(self._control_token, "<redacted>")) from exc
+        except (URLError, TimeoutError, socket.timeout, OSError) as exc:
+            reason = getattr(exc, "reason", exc)
+            raise NodeClientError(f"Could not connect to the local node: {reason}") from exc
+
+    def status(self) -> Dict[str, Any]:
+        result = self._request("GET", "/control/v1/status")
+        if result.get("api_version") != SUPPORTED_CONTROL_API_VERSION:
+            raise NodeClientError(
+                f"Unsupported control API version {result.get('api_version')!r}; "
+                f"expected {SUPPORTED_CONTROL_API_VERSION}"
+            )
+        if not isinstance(result.get("openai_base_url"), str):
+            raise NodeClientError("Local node status omitted openai_base_url")
+        normalize_loopback_url(result["openai_base_url"])
+        if (
+            not isinstance(result.get("models"), list)
+            or any(not isinstance(item, dict) for item in result["models"])
+            or not isinstance(result.get("workers"), list)
+            or any(not isinstance(item, dict) for item in result["workers"])
+        ):
+            raise NodeClientError("Local node status has invalid model or worker data")
+        return result
+
+    def list_workers(self) -> List[Dict[str, Any]]:
+        result = self._request("GET", "/control/v1/workers")
+        workers = result.get("workers")
+        if not isinstance(workers, list) or any(not isinstance(item, dict) for item in workers):
+            raise NodeClientError("Local node returned invalid worker data")
+        return workers
+
+    def worker_action(self, worker_id: str, action: str) -> Dict[str, Any]:
+        if action not in ("start", "pause", "restart"):
+            raise ValueError("worker action must be start, pause, or restart")
+        if not isinstance(worker_id, str) or not worker_id.strip():
+            raise ValueError("worker id must be a non-empty string")
+        return self._request("POST", f"/control/v1/workers/{quote(worker_id.strip(), safe='')}/{action}")
+
+    def list_keys(self) -> List[Dict[str, Any]]:
+        result = self._request("GET", "/control/v1/keys")
+        keys = result.get("keys")
+        if not isinstance(keys, list) or any(not isinstance(item, dict) for item in keys):
+            raise NodeClientError("Local node returned invalid API-key data")
+        return keys
+
+    def create_key(self, label: str) -> Dict[str, Any]:
+        if not isinstance(label, str) or not label.strip():
+            raise ValueError("API-key label must be a non-empty string")
+        result = self._request("POST", "/control/v1/keys", payload={"label": label.strip()})
+        if not isinstance(result.get("key"), dict) or not isinstance(result.get("secret"), str):
+            raise NodeClientError("Local node returned an invalid API-key creation response")
+        return result
+
+    def relabel_key(self, key_id: str, label: str) -> Dict[str, Any]:
+        if not isinstance(key_id, str) or not key_id.strip():
+            raise ValueError("API-key id must be a non-empty string")
+        if not isinstance(label, str) or not label.strip():
+            raise ValueError("API-key label must be a non-empty string")
+        return self._request(
+            "PATCH",
+            f"/control/v1/keys/{quote(key_id.strip(), safe='')}",
+            payload={"label": label.strip()},
+        )
+
+    def revoke_key(self, key_id: str) -> Dict[str, Any]:
+        if not isinstance(key_id, str) or not key_id.strip():
+            raise ValueError("API-key id must be a non-empty string")
+        return self._request("DELETE", f"/control/v1/keys/{quote(key_id.strip(), safe='')}")

--- a/spikes/desktop/src/communityai_desktop_spike/controller.py
+++ b/spikes/desktop/src/communityai_desktop_spike/controller.py
@@ -1,0 +1,54 @@
+"""Shell-neutral desktop actions and presentation snapshots."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from communityai_desktop_spike.client import NodeClient
+
+
+class DesktopController:
+    def __init__(self, client: NodeClient):
+        self.client = client
+
+    def snapshot(self) -> Dict[str, Any]:
+        status = self.client.status()
+        return {
+            "node_status": status.get("status", "unknown"),
+            "openai_base_url": status["openai_base_url"],
+            "started_at": status.get("started_at"),
+            "runtime_budget": status.get("runtime_budget", {}),
+            "models": [self._model_view(model) for model in status["models"]],
+            "workers": [self._worker_view(worker) for worker in status["workers"]],
+        }
+
+    @staticmethod
+    def _model_view(model: Dict[str, Any]) -> Dict[str, Any]:
+        route = model.get("route") if isinstance(model.get("route"), dict) else {}
+        covered = route.get("covered_blocks")
+        total = route.get("total_blocks")
+        coverage = f"{covered}/{total}" if isinstance(covered, int) and isinstance(total, int) else "unknown"
+        return {
+            "id": str(model.get("id", "unknown")),
+            "state": str(model.get("state", "unknown")),
+            "coverage": coverage,
+            "active_requests": model.get("active_requests", 0),
+            "last_error": model.get("last_error"),
+        }
+
+    @staticmethod
+    def _worker_view(worker: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            "id": str(worker.get("id", "unknown")),
+            "model": str(worker.get("model", "unknown")),
+            "state": str(worker.get("state", "unknown")),
+            "desired_running": bool(worker.get("desired_running", False)),
+            "restart_count": worker.get("restart_count", 0),
+            "last_error": worker.get("last_error"),
+        }
+
+    def worker_action(self, worker_id: str, action: str) -> Dict[str, Any]:
+        return self.client.worker_action(worker_id, action)
+
+    def create_client_key(self, label: str) -> Dict[str, Any]:
+        return self.client.create_key(label)

--- a/spikes/desktop/src/communityai_desktop_spike/credentials.py
+++ b/spikes/desktop/src/communityai_desktop_spike/credentials.py
@@ -1,0 +1,83 @@
+"""Native credential-store and private-file adapters for the desktop spike."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Optional
+
+DEFAULT_CREDENTIAL_SERVICE = "org.communityai.desktop.spike"
+DEFAULT_CREDENTIAL_ACCOUNT = "local-node-control"
+
+
+class CredentialError(RuntimeError):
+    """A control credential could not be loaded or stored safely."""
+
+
+def _validate_secret(value: Optional[str]) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise CredentialError("control credential is empty")
+    return value.strip()
+
+
+class NativeCredentialStore:
+    def __init__(
+        self,
+        service: str = DEFAULT_CREDENTIAL_SERVICE,
+        account: str = DEFAULT_CREDENTIAL_ACCOUNT,
+    ):
+        if not service.strip() or not account.strip():
+            raise ValueError("credential service and account must not be empty")
+        self.service = service.strip()
+        self.account = account.strip()
+
+    @staticmethod
+    def _keyring():
+        try:
+            import keyring
+            from keyring.errors import KeyringError
+        except ImportError as exc:
+            raise CredentialError("native credential support is not installed") from exc
+        return keyring, KeyringError
+
+    def get(self) -> str:
+        keyring, keyring_error = self._keyring()
+        try:
+            secret = keyring.get_password(self.service, self.account)
+        except keyring_error as exc:
+            raise CredentialError(f"native credential store failed: {exc}") from exc
+        if secret is None:
+            raise CredentialError(
+                f"no control credential is stored for account {self.account!r}; " "run with --store-control-key first"
+            )
+        return _validate_secret(secret)
+
+    def set(self, secret: str) -> None:
+        keyring, keyring_error = self._keyring()
+        try:
+            keyring.set_password(self.service, self.account, _validate_secret(secret))
+        except keyring_error as exc:
+            raise CredentialError(f"native credential store failed: {exc}") from exc
+
+    def delete(self) -> bool:
+        keyring, keyring_error = self._keyring()
+        try:
+            if keyring.get_password(self.service, self.account) is None:
+                return False
+            keyring.delete_password(self.service, self.account)
+        except keyring_error as exc:
+            raise CredentialError(f"native credential store failed: {exc}") from exc
+        return True
+
+
+def load_private_key_file(path: Path | str) -> str:
+    """Load the milestone-4 headless fallback without following links."""
+    path = Path(path)
+    if path.is_symlink() or not path.is_file():
+        raise CredentialError(f"control-key path is not a regular file: {path}")
+    try:
+        if os.name != "nt" and path.stat().st_mode & 0o077:
+            raise CredentialError(f"control-key file must not be accessible to group or other users: {path}")
+        return _validate_secret(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise CredentialError(f"could not read control-key file {path}: {exc}") from exc

--- a/spikes/desktop/src/communityai_desktop_spike/pyside_shell.py
+++ b/spikes/desktop/src/communityai_desktop_spike/pyside_shell.py
@@ -1,0 +1,235 @@
+"""PySide 6 implementation of the fixed desktop-spike workflow."""
+
+from __future__ import annotations
+
+from importlib.metadata import version
+from typing import Any, Callable, Dict
+
+
+def check_runtime() -> Dict[str, str]:
+    import PySide6  # noqa: F401
+
+    return {"shell": "pyside", "framework": "PySide6", "version": version("PySide6")}
+
+
+def run(controller, *, auto_close_seconds=None) -> int:  # noqa: ANN001
+    from PySide6.QtCore import QObject, QRunnable, Qt, QThreadPool, QTimer, Signal, Slot
+    from PySide6.QtGui import QGuiApplication
+    from PySide6.QtWidgets import (
+        QApplication,
+        QComboBox,
+        QGridLayout,
+        QGroupBox,
+        QHBoxLayout,
+        QHeaderView,
+        QInputDialog,
+        QLabel,
+        QMainWindow,
+        QMessageBox,
+        QPushButton,
+        QTableWidget,
+        QTableWidgetItem,
+        QVBoxLayout,
+        QWidget,
+    )
+
+    class TaskSignals(QObject):
+        result = Signal(object)
+        error = Signal(str)
+
+    class Task(QRunnable):
+        def __init__(self, operation: Callable[[], Any]):
+            super().__init__()
+            self.operation = operation
+            self.signals = TaskSignals()
+
+        @Slot()
+        def run(self):
+            try:
+                self.signals.result.emit(self.operation())
+            except Exception as exc:  # GUI boundary: render the node error and remain responsive.
+                self.signals.error.emit(str(exc))
+
+    class MainWindow(QMainWindow):
+        def __init__(self):
+            super().__init__()
+            self.setWindowTitle("CommunityAI desktop shell spike — PySide")
+            self.resize(900, 640)
+            self._pool = QThreadPool.globalInstance()
+            self._tasks = set()
+            self._busy = 0
+
+            root = QWidget()
+            layout = QVBoxLayout(root)
+            self.setCentralWidget(root)
+
+            endpoint_group = QGroupBox("Local OpenAI endpoint")
+            endpoint_layout = QHBoxLayout(endpoint_group)
+            self.endpoint = QLabel("Connecting…")
+            self.endpoint.setTextInteractionFlags(Qt.TextSelectableByMouse | Qt.TextSelectableByKeyboard)
+            self.copy_endpoint = QPushButton("Copy endpoint")
+            self.copy_endpoint.clicked.connect(self._copy_endpoint)
+            endpoint_layout.addWidget(self.endpoint, 1)
+            endpoint_layout.addWidget(self.copy_endpoint)
+            layout.addWidget(endpoint_group)
+
+            self.node_state = QLabel("Connecting to the local node…")
+            self.node_state.setAccessibleName("Local node connection status")
+            layout.addWidget(self.node_state)
+
+            models_group = QGroupBox("Community models")
+            models_layout = QVBoxLayout(models_group)
+            self.models = QTableWidget(0, 4)
+            self.models.setHorizontalHeaderLabels(("Model", "State", "Route coverage", "Active requests"))
+            self.models.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
+            self.models.setEditTriggers(QTableWidget.NoEditTriggers)
+            self.models.setSelectionBehavior(QTableWidget.SelectRows)
+            models_layout.addWidget(self.models)
+            layout.addWidget(models_group, 1)
+
+            workers_group = QGroupBox("Contribution")
+            workers_layout = QGridLayout(workers_group)
+            self.workers = QTableWidget(0, 4)
+            self.workers.setHorizontalHeaderLabels(("Worker", "Model", "State", "Restarts"))
+            self.workers.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
+            self.workers.setEditTriggers(QTableWidget.NoEditTriggers)
+            workers_layout.addWidget(self.workers, 0, 0, 1, 4)
+            self.worker_choice = QComboBox()
+            self.worker_choice.setAccessibleName("Contribution worker")
+            workers_layout.addWidget(self.worker_choice, 1, 0)
+            self.worker_buttons = []
+            for column, (label, action) in enumerate(
+                (("Start", "start"), ("Pause", "pause"), ("Restart", "restart")),
+                start=1,
+            ):
+                button = QPushButton(label)
+                button.clicked.connect(lambda checked=False, selected=action: self._worker_action(selected))
+                self.worker_buttons.append(button)
+                workers_layout.addWidget(button, 1, column)
+            layout.addWidget(workers_group, 1)
+
+            buttons = QHBoxLayout()
+            self.refresh_button = QPushButton("Refresh")
+            self.refresh_button.clicked.connect(self.refresh)
+            self.create_key_button = QPushButton("Create client API key")
+            self.create_key_button.clicked.connect(self._create_key)
+            buttons.addWidget(self.refresh_button)
+            buttons.addWidget(self.create_key_button)
+            buttons.addStretch(1)
+            layout.addLayout(buttons)
+
+            disclosure = QLabel(
+                "Privacy: volunteer workers process request-derived data and may be able to observe or retain it."
+            )
+            disclosure.setWordWrap(True)
+            disclosure.setAccessibleName("Volunteer worker privacy disclosure")
+            layout.addWidget(disclosure)
+
+            self._timer = QTimer(self)
+            self._timer.setInterval(10_000)
+            self._timer.timeout.connect(self.refresh)
+            self._timer.start()
+            self.refresh()
+
+        def _set_busy(self, change: int) -> None:
+            self._busy += change
+            busy = self._busy > 0
+            self.refresh_button.setDisabled(busy)
+            self.create_key_button.setDisabled(busy)
+            for button in self.worker_buttons:
+                button.setDisabled(busy or self.worker_choice.count() == 0)
+
+        def _submit(self, operation: Callable[[], Any], on_result: Callable[[Any], None]) -> None:
+            self._set_busy(1)
+            task = Task(operation)
+            self._tasks.add(task)
+
+            def finish(result: Any) -> None:
+                self._tasks.discard(task)
+                self._set_busy(-1)
+                on_result(result)
+
+            def fail(message: str) -> None:
+                self._tasks.discard(task)
+                self._set_busy(-1)
+                self.node_state.setText(f"Disconnected: {message}")
+
+            task.signals.result.connect(finish)
+            task.signals.error.connect(fail)
+            self._pool.start(task)
+
+        def refresh(self) -> None:
+            if self._busy:
+                return
+            self.node_state.setText("Refreshing local node status…")
+            self._submit(controller.snapshot, self._render)
+
+        def _render(self, snapshot: Dict[str, Any]) -> None:
+            self.node_state.setText(f"Node: {snapshot['node_status']}")
+            self.endpoint.setText(snapshot["openai_base_url"])
+            self.models.setRowCount(len(snapshot["models"]))
+            for row, model in enumerate(snapshot["models"]):
+                values = (
+                    model["id"],
+                    model["state"],
+                    model["coverage"],
+                    str(model["active_requests"]),
+                )
+                for column, value in enumerate(values):
+                    self.models.setItem(row, column, QTableWidgetItem(value))
+
+            selected = self.worker_choice.currentData()
+            self.worker_choice.clear()
+            self.workers.setRowCount(len(snapshot["workers"]))
+            for row, worker in enumerate(snapshot["workers"]):
+                values = (
+                    worker["id"],
+                    worker["model"],
+                    worker["state"],
+                    str(worker["restart_count"]),
+                )
+                for column, value in enumerate(values):
+                    self.workers.setItem(row, column, QTableWidgetItem(value))
+                self.worker_choice.addItem(worker["id"], worker["id"])
+            index = self.worker_choice.findData(selected)
+            if index >= 0:
+                self.worker_choice.setCurrentIndex(index)
+            for button in self.worker_buttons:
+                button.setDisabled(self.worker_choice.count() == 0)
+
+        def _copy_endpoint(self) -> None:
+            QGuiApplication.clipboard().setText(self.endpoint.text())
+            self.node_state.setText("Copied the OpenAI endpoint")
+
+        def _worker_action(self, action: str) -> None:
+            worker_id = self.worker_choice.currentData()
+            if worker_id:
+                self.node_state.setText(f"Requesting {action} for {worker_id}…")
+                self._submit(
+                    lambda: controller.worker_action(worker_id, action),
+                    lambda result: self.refresh(),
+                )
+
+        def _create_key(self) -> None:
+            label, accepted = QInputDialog.getText(self, "Create client API key", "Label")
+            if accepted and label.strip():
+                self._submit(lambda: controller.create_client_key(label), self._show_key)
+
+        def _show_key(self, result: Dict[str, Any]) -> None:
+            secret = result["secret"]
+            QGuiApplication.clipboard().setText(secret)
+            message = QMessageBox(self)
+            message.setWindowTitle("Client API key created")
+            message.setTextFormat(Qt.PlainText)
+            message.setText("The new API key was copied to the clipboard. It is shown only once:")
+            message.setDetailedText(secret)
+            message.exec()
+            self.node_state.setText("Created and copied a client API key")
+
+    application = QApplication.instance() or QApplication([])
+    application.setApplicationName("CommunityAI desktop spike")
+    window = MainWindow()
+    window.show()
+    if auto_close_seconds is not None:
+        QTimer.singleShot(max(1, int(float(auto_close_seconds) * 1000)), application.quit)
+    return application.exec()

--- a/spikes/desktop/src/communityai_desktop_spike/webview.html
+++ b/spikes/desktop/src/communityai_desktop_spike/webview.html
@@ -1,0 +1,136 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'">
+  <title>CommunityAI desktop shell spike</title>
+  <style>
+    :root { color-scheme: light dark; font: 15px/1.45 system-ui, sans-serif; }
+    body { margin: 0; background: Canvas; color: CanvasText; }
+    main { max-width: 980px; margin: auto; padding: 24px; }
+    h1 { margin: 0 0 4px; font-size: 1.55rem; }
+    h2 { font-size: 1rem; margin-top: 0; }
+    .muted { opacity: .75; }
+    .card { border: 1px solid color-mix(in srgb, CanvasText 25%, transparent); border-radius: 10px; padding: 16px; margin: 16px 0; }
+    .endpoint, .actions { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+    code { user-select: all; overflow-wrap: anywhere; }
+    button, input, select { font: inherit; min-height: 36px; }
+    button { padding: 6px 12px; cursor: pointer; }
+    button:disabled { cursor: wait; opacity: .55; }
+    table { border-collapse: collapse; width: 100%; }
+    th, td { border-bottom: 1px solid color-mix(in srgb, CanvasText 18%, transparent); padding: 8px; text-align: left; }
+    th { font-weight: 600; }
+    #error { color: #c33; white-space: pre-wrap; }
+    .disclosure { border-left: 4px solid #d88b19; padding-left: 12px; }
+    dialog { max-width: min(620px, 90vw); }
+    textarea { box-sizing: border-box; width: 100%; min-height: 90px; }
+  </style>
+</head>
+<body>
+<main>
+  <h1>CommunityAI</h1>
+  <div class="muted">Webview implementation spike</div>
+
+  <section class="card" aria-labelledby="endpoint-heading">
+    <h2 id="endpoint-heading">Local OpenAI endpoint</h2>
+    <div class="endpoint"><code id="endpoint">Connecting…</code><button id="copy-endpoint">Copy endpoint</button></div>
+    <p id="node-state" role="status">Connecting to the local node…</p>
+    <div id="error" role="alert"></div>
+  </section>
+
+  <section class="card" aria-labelledby="models-heading">
+    <h2 id="models-heading">Community models</h2>
+    <table><thead><tr><th>Model</th><th>State</th><th>Route coverage</th><th>Active requests</th></tr></thead><tbody id="models"></tbody></table>
+  </section>
+
+  <section class="card" aria-labelledby="workers-heading">
+    <h2 id="workers-heading">Contribution</h2>
+    <table><thead><tr><th>Worker</th><th>Model</th><th>State</th><th>Restarts</th></tr></thead><tbody id="workers"></tbody></table>
+    <div class="actions">
+      <label for="worker-choice">Worker</label><select id="worker-choice"></select>
+      <button data-action="start">Start</button><button data-action="pause">Pause</button><button data-action="restart">Restart</button>
+    </div>
+  </section>
+
+  <div class="actions"><button id="refresh">Refresh</button><button id="create-key">Create client API key</button></div>
+  <p class="disclosure"><strong>Privacy:</strong> volunteer workers process request-derived data and may be able to observe or retain it.</p>
+</main>
+
+<dialog id="key-dialog">
+  <h2>Client API key created</h2>
+  <p>This secret is shown only once. Copy it into the AI client now.</p>
+  <textarea id="new-key" readonly aria-label="New client API key"></textarea>
+  <div class="actions"><button id="copy-key">Copy key</button><button id="close-key">Close</button></div>
+</dialog>
+
+<script>
+  const byId = id => document.getElementById(id);
+  const buttons = () => [...document.querySelectorAll('button')];
+
+  function cell(row, value) {
+    const item = document.createElement('td');
+    item.textContent = String(value ?? '');
+    row.appendChild(item);
+  }
+
+  function renderRows(target, rows, fields) {
+    target.replaceChildren();
+    for (const source of rows) {
+      const row = document.createElement('tr');
+      fields.forEach(field => cell(row, source[field]));
+      target.appendChild(row);
+    }
+  }
+
+  function setBusy(busy) { buttons().forEach(button => { button.disabled = busy; }); }
+  function fail(message) { byId('error').textContent = message; byId('node-state').textContent = 'Disconnected'; }
+
+  async function call(operation) {
+    setBusy(true); byId('error').textContent = '';
+    try {
+      const result = await operation();
+      if (!result.ok) throw new Error(result.error || 'Unknown local node error');
+      return result.value;
+    } catch (error) {
+      fail(String(error));
+      return null;
+    } finally { setBusy(false); }
+  }
+
+  async function refresh() {
+    const snapshot = await call(() => window.pywebview.api.snapshot());
+    if (!snapshot) return;
+    byId('node-state').textContent = `Node: ${snapshot.node_status}`;
+    byId('endpoint').textContent = snapshot.openai_base_url;
+    renderRows(byId('models'), snapshot.models, ['id', 'state', 'coverage', 'active_requests']);
+    renderRows(byId('workers'), snapshot.workers, ['id', 'model', 'state', 'restart_count']);
+    const choice = byId('worker-choice');
+    const selected = choice.value;
+    choice.replaceChildren();
+    snapshot.workers.forEach(worker => {
+      const option = document.createElement('option'); option.value = worker.id; option.textContent = worker.id; choice.appendChild(option);
+    });
+    if ([...choice.options].some(option => option.value === selected)) choice.value = selected;
+  }
+
+  window.addEventListener('pywebviewready', () => {
+    byId('refresh').addEventListener('click', refresh);
+    byId('copy-endpoint').addEventListener('click', () => navigator.clipboard.writeText(byId('endpoint').textContent));
+    document.querySelectorAll('[data-action]').forEach(button => button.addEventListener('click', async () => {
+      const worker = byId('worker-choice').value;
+      if (worker && await call(() => window.pywebview.api.worker_action(worker, button.dataset.action))) await refresh();
+    }));
+    byId('create-key').addEventListener('click', async () => {
+      const label = window.prompt('Label for this AI client');
+      if (!label || !label.trim()) return;
+      const created = await call(() => window.pywebview.api.create_client_key(label.trim()));
+      if (created) { byId('new-key').value = created.secret; byId('key-dialog').showModal(); }
+    });
+    byId('copy-key').addEventListener('click', () => navigator.clipboard.writeText(byId('new-key').value));
+    byId('close-key').addEventListener('click', () => { byId('new-key').value = ''; byId('key-dialog').close(); });
+    refresh(); setInterval(refresh, 10000);
+  });
+</script>
+</body>
+</html>

--- a/spikes/desktop/src/communityai_desktop_spike/webview_shell.py
+++ b/spikes/desktop/src/communityai_desktop_spike/webview_shell.py
@@ -1,0 +1,65 @@
+"""pywebview implementation of the fixed desktop-spike workflow."""
+
+from __future__ import annotations
+
+import threading
+import time
+from importlib.metadata import version
+from importlib.resources import files
+from typing import Any, Callable, Dict
+
+
+def check_runtime() -> Dict[str, str]:
+    import webview  # noqa: F401
+
+    return {
+        "shell": "webview",
+        "framework": "pywebview",
+        "version": version("pywebview"),
+    }
+
+
+class _Bridge:
+    def __init__(self, controller):  # noqa: ANN001
+        self._controller = controller
+        self._lock = threading.Lock()
+
+    def _call(self, operation: Callable[[], Any]) -> Dict[str, Any]:
+        try:
+            with self._lock:
+                return {"ok": True, "value": operation()}
+        except Exception as exc:  # pywebview RPC boundary: return an inert error string.
+            return {"ok": False, "error": str(exc)}
+
+    def snapshot(self) -> Dict[str, Any]:
+        return self._call(self._controller.snapshot)
+
+    def worker_action(self, worker_id: str, action: str) -> Dict[str, Any]:
+        return self._call(lambda: self._controller.worker_action(worker_id, action))
+
+    def create_client_key(self, label: str) -> Dict[str, Any]:
+        return self._call(lambda: self._controller.create_client_key(label))
+
+
+def run(controller, *, auto_close_seconds=None) -> int:  # noqa: ANN001
+    import webview
+
+    html = files("communityai_desktop_spike").joinpath("webview.html").read_text(encoding="utf-8")
+    window = webview.create_window(
+        "CommunityAI desktop shell spike — webview",
+        html=html,
+        js_api=_Bridge(controller),
+        width=1000,
+        height=720,
+        min_size=(720, 520),
+    )
+    if auto_close_seconds is None:
+        webview.start(debug=False)
+    else:
+
+        def close_after_load():
+            time.sleep(max(0.1, float(auto_close_seconds)))
+            window.destroy()
+
+        webview.start(close_after_load, debug=False)
+    return 0

--- a/spikes/desktop/tests/test_client.py
+++ b/spikes/desktop/tests/test_client.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import threading
+import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+from communityai_desktop_spike.acceptance import fake_node, run_contract
+from communityai_desktop_spike.client import NodeApiError, NodeClient, normalize_loopback_url
+from communityai_desktop_spike.controller import DesktopController
+from communityai_desktop_spike.credentials import CredentialError, load_private_key_file
+
+
+class NodeClientTests(unittest.TestCase):
+    def test_normalizes_loopback_openai_url(self):
+        self.assertEqual(normalize_loopback_url("http://127.0.0.1:8080/v1/"), "http://127.0.0.1:8080")
+        self.assertEqual(normalize_loopback_url("https://[::1]:9443/v1"), "https://[::1]:9443")
+        self.assertEqual(normalize_loopback_url("http://localhost.:8080"), "http://localhost.:8080")
+
+    def test_rejects_destinations_that_could_receive_the_control_credential(self):
+        rejected = (
+            "https://example.com",
+            "http://localhost.example.com",
+            "http://user:secret@localhost:8080",
+            "file:///tmp/node.sock",
+            "http://localhost:8080/control",
+            "http://localhost:8080/?redirect=1",
+        )
+        for value in rejected:
+            with self.subTest(value=value), self.assertRaises(ValueError):
+                normalize_loopback_url(value)
+
+    def test_shared_acceptance_contract(self):
+        with fake_node() as (url, token):
+            result = run_contract(NodeClient(url, token))
+        self.assertEqual(result["api_version"], 1)
+        self.assertEqual(result["worker_actions"], 3)
+        self.assertEqual(result["key_lifecycle"], "passed")
+
+    def test_invalid_auth_does_not_expose_the_candidate_secret(self):
+        secret = "must-never-appear-in-errors"
+        with fake_node() as (url, _):
+            with self.assertRaises(NodeApiError) as caught:
+                NodeClient(url, secret).status()
+        self.assertEqual(caught.exception.status_code, 401)
+        self.assertNotIn(secret, str(caught.exception))
+
+    def test_redirect_is_not_followed_with_the_control_credential(self):
+        class RedirectHandler(BaseHTTPRequestHandler):
+            def log_message(self, format, *args):  # noqa: A002, ANN001
+                return
+
+            def do_GET(self):  # noqa: N802
+                self.send_response(302)
+                self.send_header("Location", "https://example.com/credential-capture")
+                self.end_headers()
+
+        server = ThreadingHTTPServer(("127.0.0.1", 0), RedirectHandler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            with self.assertRaises(NodeApiError) as caught:
+                NodeClient(f"http://127.0.0.1:{server.server_port}", "control-secret").status()
+            self.assertEqual(caught.exception.status_code, 302)
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=5)
+
+    def test_controller_builds_shell_neutral_view(self):
+        with fake_node() as (url, token):
+            snapshot = DesktopController(NodeClient(url, token)).snapshot()
+        self.assertEqual(snapshot["openai_base_url"].rsplit("/", 1)[-1], "v1")
+        self.assertEqual(snapshot["models"][0]["coverage"], "8/8")
+        self.assertEqual(snapshot["workers"][0]["state"], "paused")
+
+
+class CredentialFileTests(unittest.TestCase):
+    def test_reads_private_regular_file(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "control.key"
+            path.write_text("drift_secret\n", encoding="utf-8")
+            if os.name != "nt":
+                path.chmod(0o600)
+            self.assertEqual(load_private_key_file(path), "drift_secret")
+
+    def test_rejects_empty_or_public_file(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "control.key"
+            path.write_text("", encoding="utf-8")
+            if os.name != "nt":
+                path.chmod(0o600)
+            with self.assertRaises(CredentialError):
+                load_private_key_file(path)
+
+            if os.name != "nt":
+                path.write_text("drift_secret", encoding="utf-8")
+                path.chmod(0o644)
+                with self.assertRaises(CredentialError):
+                    load_private_key_file(path)
+
+    def test_rejects_directory(self):
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaises(CredentialError):
+                load_private_key_file(Path(directory))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/drift/api/server.py
+++ b/src/drift/api/server.py
@@ -16,6 +16,7 @@ honored but may still appear in *streamed* output (the non-streaming path trims 
 
 import asyncio
 import json
+import secrets
 import time
 import uuid
 from queue import Empty
@@ -27,6 +28,14 @@ from fastapi.responses import StreamingResponse
 from hivemind.utils.logging import get_logger
 from pydantic import BaseModel
 from transformers import TextIteratorStreamer
+
+from drift.node.model_manager import (
+    AmbiguousModelError,
+    LoadedModel,
+    ModelManager,
+    ModelManagerClosedError,
+    ModelNotFoundError,
+)
 
 logger = get_logger(__name__)
 
@@ -126,14 +135,33 @@ def trim_stop_strings(text: str, stop: Optional[Union[str, List[str]]]) -> str:
 
 
 def create_app(
-    model,
-    tokenizer,
-    model_name: str,
+    model=None,
+    tokenizer=None,
+    model_name: Optional[str] = None,
     *,
+    model_manager: Optional[ModelManager] = None,
     api_keys: Optional[List[str]] = None,
     max_concurrent: int = 1,
     default_max_tokens: int = DEFAULT_MAX_TOKENS,
 ) -> FastAPI:
+    """Create the OpenAI-compatible application.
+
+    ``model``/``tokenizer``/``model_name`` retain the original single-model API.
+    The node daemon supplies ``model_manager`` instead, enabling exact alias
+    resolution and lazy loading without changing the HTTP request surface.
+    """
+    if max_concurrent < 1:
+        raise ValueError("max_concurrent must be at least 1")
+    if default_max_tokens < 1:
+        raise ValueError("default_max_tokens must be at least 1")
+    if model_manager is None:
+        if model is None or tokenizer is None or model_name is None:
+            raise ValueError("model, tokenizer, and model_name are required without model_manager")
+        model_manager = ModelManager()
+        model_manager.register_loaded(model_name, model, tokenizer)
+    elif model is not None or tokenizer is not None or model_name is not None:
+        raise ValueError("pass either model_manager or the single-model arguments, not both")
+
     app = FastAPI(title="DRIFT-LLM OpenAI-compatible API")
     semaphore = asyncio.Semaphore(max_concurrent)
     served_since = int(time.time())
@@ -142,13 +170,45 @@ def create_app(
         if not api_keys:
             return
         auth = request.headers.get("authorization", "")
-        if not (auth.startswith("Bearer ") and auth[len("Bearer ") :] in api_keys):
+        candidate = auth[len("Bearer ") :] if auth.startswith("Bearer ") else ""
+        if not any(secrets.compare_digest(candidate, key) for key in api_keys):
             raise HTTPException(status_code=401, detail="Invalid API key")
 
-    def generate_sync(input_ids: torch.Tensor, gen_kwargs: Dict[str, Any], streamer=None) -> torch.Tensor:
+    async def load_model(identifier: Optional[str]) -> LoadedModel:
+        loop = asyncio.get_running_loop()
+        future = loop.run_in_executor(None, model_manager.load, identifier)
+        try:
+            return await asyncio.shield(future)
+        except asyncio.CancelledError:
+            # A thread waiting for a residency slot or downloading a model cannot be
+            # cancelled through asyncio. If the HTTP request goes away, release the
+            # eventual lease instead of permanently pinning the runtime.
+            def release_abandoned_load(completed_future) -> None:
+                try:
+                    completed_future.result().release()
+                except BaseException:
+                    pass
+
+            future.add_done_callback(release_abandoned_load)
+            raise
+        except AmbiguousModelError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        except ModelNotFoundError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        except ModelManagerClosedError as exc:
+            raise HTTPException(status_code=503, detail="Node is shutting down") from exc
+        except Exception as exc:
+            logger.exception("Model %r failed to load", identifier)
+            raise HTTPException(status_code=503, detail="Model is unavailable") from exc
+
+    def generate_sync(
+        loaded: LoadedModel, input_ids: torch.Tensor, gen_kwargs: Dict[str, Any], streamer=None
+    ) -> torch.Tensor:
         # tokenizer is required by transformers when stop_strings is set; harmless otherwise
         with torch.inference_mode():
-            return model.generate(input_ids, tokenizer=tokenizer, streamer=streamer, **gen_kwargs)
+            return loaded.runtime.model.generate(
+                input_ids, tokenizer=loaded.runtime.tokenizer, streamer=streamer, **gen_kwargs
+            )
 
     def usage(input_ids: torch.Tensor, output_ids: torch.Tensor) -> Dict[str, int]:
         prompt_tokens = input_ids.shape[1]
@@ -162,58 +222,87 @@ def create_app(
     def finish_reason(completion_tokens: int, gen_kwargs: Dict[str, Any]) -> str:
         return "length" if completion_tokens >= gen_kwargs["max_new_tokens"] else "stop"
 
-    async def sse_stream(input_ids: torch.Tensor, gen_kwargs: Dict[str, Any], *, chat: bool):
+    async def sse_stream(loaded: LoadedModel, input_ids: torch.Tensor, gen_kwargs: Dict[str, Any], *, chat: bool):
         """Yield OpenAI-format SSE chunks while generate() runs in a worker thread."""
         request_id = f"{'chatcmpl' if chat else 'cmpl'}-{uuid.uuid4().hex[:24]}"
         created = int(time.time())
         object_name = "chat.completion.chunk" if chat else "text_completion"
+        selected_model = loaded.descriptor.model_id
+        selected_tokenizer = loaded.runtime.tokenizer
 
         def chunk(payload: Dict[str, Any], reason: Optional[str] = None) -> str:
             choice: Dict[str, Any] = {"index": 0, "finish_reason": reason}
             choice.update(payload)
-            body = {"id": request_id, "object": object_name, "created": created, "model": model_name}
+            body = {"id": request_id, "object": object_name, "created": created, "model": selected_model}
             body["choices"] = [choice]
             return f"data: {json.dumps(body)}\n\n"
 
-        async with semaphore:
-            loop = asyncio.get_running_loop()
-            streamer = TextIteratorStreamer(
-                tokenizer, skip_prompt=True, skip_special_tokens=True, timeout=_STREAM_POLL_SECONDS
-            )
-            future = loop.run_in_executor(None, lambda: generate_sync(input_ids, gen_kwargs, streamer))
-            if chat:
-                yield chunk({"delta": {"role": "assistant", "content": ""}})
-            while True:
+        future = None
+        release_deferred = False
+        try:
+            async with semaphore:
+                loop = asyncio.get_running_loop()
+                streamer = TextIteratorStreamer(
+                    selected_tokenizer, skip_prompt=True, skip_special_tokens=True, timeout=_STREAM_POLL_SECONDS
+                )
+                future = loop.run_in_executor(None, lambda: generate_sync(loaded, input_ids, gen_kwargs, streamer))
+                if chat:
+                    yield chunk({"delta": {"role": "assistant", "content": ""}})
+                while True:
+                    try:
+                        piece = await loop.run_in_executor(None, _next_piece, streamer)
+                    except Empty:
+                        if future.done():
+                            break  # generate() died before calling streamer.end(); surfaced below
+                        continue
+                    if piece is _STREAM_DONE:
+                        break
+                    if piece:
+                        yield chunk({"delta": {"content": piece}} if chat else {"text": piece})
                 try:
-                    piece = await loop.run_in_executor(None, _next_piece, streamer)
-                except Empty:
-                    if future.done():
-                        break  # generate() died before calling streamer.end(); surfaced below
-                    continue
-                if piece is _STREAM_DONE:
-                    break
-                if piece:
-                    yield chunk({"delta": {"content": piece}} if chat else {"text": piece})
-            try:
-                output_ids = await future
-                reason = finish_reason(output_ids.shape[1] - input_ids.shape[1], gen_kwargs)
-            except Exception as exc:
-                logger.exception("Generation failed mid-stream")
-                yield f"data: {json.dumps({'error': {'message': str(exc), 'type': 'server_error'}})}\n\n"
-                reason = "stop"
-            yield chunk({"delta": {}} if chat else {"text": ""}, reason)
-            yield "data: [DONE]\n\n"
+                    output_ids = await asyncio.shield(future)
+                    reason = finish_reason(output_ids.shape[1] - input_ids.shape[1], gen_kwargs)
+                except Exception as exc:
+                    logger.exception("Generation failed mid-stream")
+                    yield f"data: {json.dumps({'error': {'message': str(exc), 'type': 'server_error'}})}\n\n"
+                    reason = "stop"
+                yield chunk({"delta": {}} if chat else {"text": ""}, reason)
+                yield "data: [DONE]\n\n"
+        finally:
+            # Cancelling an HTTP stream does not stop model.generate() in its executor
+            # thread. Keep the residency lease until that thread really exits so an
+            # unload or LRU eviction cannot close the runtime underneath generation.
+            if future is not None and not future.done():
+                future.add_done_callback(lambda _: loaded.release())
+                release_deferred = True
+            if not release_deferred:
+                loaded.release()
 
     @app.get("/health")
     async def health():
-        return {"status": "ok", "model": model_name}
+        snapshots = model_manager.snapshots()
+        response = {"status": "ok", "models": len(snapshots)}
+        if len(snapshots) == 1:
+            response["model"] = snapshots[0].model_id
+        return response
 
     @app.get("/v1/models")
     async def list_models(request: Request):
         check_auth(request)
         return {
             "object": "list",
-            "data": [{"id": model_name, "object": "model", "created": served_since, "owned_by": "drift"}],
+            "data": [
+                {
+                    "id": snapshot.model_id,
+                    "object": "model",
+                    "created": served_since,
+                    "owned_by": "drift",
+                    "status": snapshot.state.value,
+                    "aliases": list(snapshot.aliases),
+                    "manifest_digest": snapshot.manifest_digest,
+                }
+                for snapshot in model_manager.snapshots()
+            ],
         }
 
     @app.post("/v1/chat/completions")
@@ -221,31 +310,50 @@ def create_app(
         check_auth(request)
         if body.n != 1:
             raise HTTPException(status_code=400, detail="n > 1 is not supported")
-        messages = [{"role": m.role, "content": message_text(m.content)} for m in body.messages]
-        input_ids = tokenizer.apply_chat_template(
-            messages, add_generation_prompt=True, return_dict=True, return_tensors="pt"
-        )["input_ids"]
-        gen_kwargs = build_generate_kwargs(
-            max_tokens=body.max_tokens if body.max_tokens is not None else body.max_completion_tokens,
-            temperature=body.temperature,
-            top_p=body.top_p,
-            stop=body.stop,
-            default_max_tokens=default_max_tokens,
-        )
+        loaded = await load_model(body.model)
+        selected_model = loaded.descriptor.model_id
+        selected_tokenizer = loaded.runtime.tokenizer
+        try:
+            messages = [{"role": m.role, "content": message_text(m.content)} for m in body.messages]
+            input_ids = selected_tokenizer.apply_chat_template(
+                messages, add_generation_prompt=True, return_dict=True, return_tensors="pt"
+            )["input_ids"]
+            gen_kwargs = build_generate_kwargs(
+                max_tokens=body.max_tokens if body.max_tokens is not None else body.max_completion_tokens,
+                temperature=body.temperature,
+                top_p=body.top_p,
+                stop=body.stop,
+                default_max_tokens=default_max_tokens,
+            )
+        except BaseException:
+            loaded.release()
+            raise
 
         if body.stream:
-            return StreamingResponse(sse_stream(input_ids, gen_kwargs, chat=True), media_type="text/event-stream")
+            return StreamingResponse(
+                sse_stream(loaded, input_ids, gen_kwargs, chat=True), media_type="text/event-stream"
+            )
 
-        async with semaphore:
-            loop = asyncio.get_running_loop()
-            output_ids = await loop.run_in_executor(None, lambda: generate_sync(input_ids, gen_kwargs))
-        text = tokenizer.decode(output_ids[0, input_ids.shape[1] :], skip_special_tokens=True)
+        future = None
+        release_deferred = False
+        try:
+            async with semaphore:
+                loop = asyncio.get_running_loop()
+                future = loop.run_in_executor(None, lambda: generate_sync(loaded, input_ids, gen_kwargs))
+                output_ids = await asyncio.shield(future)
+        finally:
+            if future is not None and not future.done():
+                future.add_done_callback(lambda _: loaded.release())
+                release_deferred = True
+            if not release_deferred:
+                loaded.release()
+        text = selected_tokenizer.decode(output_ids[0, input_ids.shape[1] :], skip_special_tokens=True)
         text = trim_stop_strings(text, body.stop)
         return {
             "id": f"chatcmpl-{uuid.uuid4().hex[:24]}",
             "object": "chat.completion",
             "created": int(time.time()),
-            "model": model_name,
+            "model": selected_model,
             "choices": [
                 {
                     "index": 0,
@@ -261,32 +369,51 @@ def create_app(
         check_auth(request)
         if body.n != 1:
             raise HTTPException(status_code=400, detail="n > 1 is not supported")
-        if not isinstance(body.prompt, str):
-            if len(body.prompt) != 1:
-                raise HTTPException(status_code=400, detail="Batched prompts are not supported")
-            body.prompt = body.prompt[0]
-        input_ids = tokenizer(body.prompt, return_tensors="pt").input_ids
-        gen_kwargs = build_generate_kwargs(
-            max_tokens=body.max_tokens,
-            temperature=body.temperature,
-            top_p=body.top_p,
-            stop=body.stop,
-            default_max_tokens=default_max_tokens,
-        )
+        loaded = await load_model(body.model)
+        selected_model = loaded.descriptor.model_id
+        selected_tokenizer = loaded.runtime.tokenizer
+        try:
+            if not isinstance(body.prompt, str):
+                if len(body.prompt) != 1:
+                    raise HTTPException(status_code=400, detail="Batched prompts are not supported")
+                body.prompt = body.prompt[0]
+            input_ids = selected_tokenizer(body.prompt, return_tensors="pt").input_ids
+            gen_kwargs = build_generate_kwargs(
+                max_tokens=body.max_tokens,
+                temperature=body.temperature,
+                top_p=body.top_p,
+                stop=body.stop,
+                default_max_tokens=default_max_tokens,
+            )
+        except BaseException:
+            loaded.release()
+            raise
 
         if body.stream:
-            return StreamingResponse(sse_stream(input_ids, gen_kwargs, chat=False), media_type="text/event-stream")
+            return StreamingResponse(
+                sse_stream(loaded, input_ids, gen_kwargs, chat=False), media_type="text/event-stream"
+            )
 
-        async with semaphore:
-            loop = asyncio.get_running_loop()
-            output_ids = await loop.run_in_executor(None, lambda: generate_sync(input_ids, gen_kwargs))
-        text = tokenizer.decode(output_ids[0, input_ids.shape[1] :], skip_special_tokens=True)
+        future = None
+        release_deferred = False
+        try:
+            async with semaphore:
+                loop = asyncio.get_running_loop()
+                future = loop.run_in_executor(None, lambda: generate_sync(loaded, input_ids, gen_kwargs))
+                output_ids = await asyncio.shield(future)
+        finally:
+            if future is not None and not future.done():
+                future.add_done_callback(lambda _: loaded.release())
+                release_deferred = True
+            if not release_deferred:
+                loaded.release()
+        text = selected_tokenizer.decode(output_ids[0, input_ids.shape[1] :], skip_special_tokens=True)
         text = trim_stop_strings(text, body.stop)
         return {
             "id": f"cmpl-{uuid.uuid4().hex[:24]}",
             "object": "text_completion",
             "created": int(time.time()),
-            "model": model_name,
+            "model": selected_model,
             "choices": [
                 {
                     "index": 0,

--- a/src/drift/api/server.py
+++ b/src/drift/api/server.py
@@ -20,7 +20,7 @@ import secrets
 import time
 import uuid
 from queue import Empty
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 
 import torch
 from fastapi import FastAPI, HTTPException, Request
@@ -141,6 +141,7 @@ def create_app(
     *,
     model_manager: Optional[ModelManager] = None,
     api_keys: Optional[List[str]] = None,
+    api_key_verifier: Optional[Callable[[str], bool]] = None,
     max_concurrent: int = 1,
     default_max_tokens: int = DEFAULT_MAX_TOKENS,
 ) -> FastAPI:
@@ -161,17 +162,24 @@ def create_app(
         model_manager.register_loaded(model_name, model, tokenizer)
     elif model is not None or tokenizer is not None or model_name is not None:
         raise ValueError("pass either model_manager or the single-model arguments, not both")
+    if api_keys and api_key_verifier is not None:
+        raise ValueError("pass either api_keys or api_key_verifier, not both")
 
     app = FastAPI(title="DRIFT-LLM OpenAI-compatible API")
     semaphore = asyncio.Semaphore(max_concurrent)
     served_since = int(time.time())
 
     def check_auth(request: Request) -> None:
-        if not api_keys:
+        if not api_keys and api_key_verifier is None:
             return
         auth = request.headers.get("authorization", "")
         candidate = auth[len("Bearer ") :] if auth.startswith("Bearer ") else ""
-        if not any(secrets.compare_digest(candidate, key) for key in api_keys):
+        valid = (
+            api_key_verifier(candidate)
+            if api_key_verifier is not None
+            else any(secrets.compare_digest(candidate, key) for key in api_keys)
+        )
+        if not valid:
             raise HTTPException(status_code=401, detail="Invalid API key")
 
     async def load_model(identifier: Optional[str]) -> LoadedModel:
@@ -204,11 +212,14 @@ def create_app(
     def generate_sync(
         loaded: LoadedModel, input_ids: torch.Tensor, gen_kwargs: Dict[str, Any], streamer=None
     ) -> torch.Tensor:
-        # tokenizer is required by transformers when stop_strings is set; harmless otherwise
+        # Transformers requires the tokenizer for stop-string matching, but otherwise
+        # forwards unknown generate kwargs into model.forward(). Distributed model
+        # forwards intentionally reject a stray ``tokenizer`` argument.
+        call_kwargs = dict(gen_kwargs)
+        if call_kwargs.get("stop_strings"):
+            call_kwargs["tokenizer"] = loaded.runtime.tokenizer
         with torch.inference_mode():
-            return loaded.runtime.model.generate(
-                input_ids, tokenizer=loaded.runtime.tokenizer, streamer=streamer, **gen_kwargs
-            )
+            return loaded.runtime.model.generate(input_ids, streamer=streamer, **call_kwargs)
 
     def usage(input_ids: torch.Tensor, output_ids: torch.Tensor) -> Dict[str, int]:
         prompt_tokens = input_ids.shape[1]
@@ -298,6 +309,7 @@ def create_app(
                     "created": served_since,
                     "owned_by": "drift",
                     "status": snapshot.state.value,
+                    "availability": snapshot.route.get("status") if snapshot.route is not None else "unknown",
                     "aliases": list(snapshot.aliases),
                     "manifest_digest": snapshot.manifest_digest,
                 }

--- a/src/drift/cli/__main__.py
+++ b/src/drift/cli/__main__.py
@@ -6,6 +6,7 @@
     drift dht ...                   A standalone lightweight DHT bootstrap peer
     drift api <model> ...           An OpenAI-compatible HTTP API backed by the swarm
     drift node <manifest> ...       A persistent authenticated localhost gateway
+    drift edge-benchmark <manifest> Measure client-only edge resource use
     drift manifest <file>           Validate and inspect a ModelManifest v1
     drift identity ...              Manage public-swarm identities and trust records
 
@@ -15,7 +16,7 @@ name and delegates. Also runnable as ``python -m drift.cli``.
 
 import sys
 
-_COMMANDS = ("up", "down", "server", "dht", "api", "node", "manifest", "identity")
+_COMMANDS = ("up", "down", "server", "dht", "api", "node", "edge-benchmark", "manifest", "identity")
 
 _USAGE = """usage: drift <command> [options]
 
@@ -28,6 +29,8 @@ commands:
   dht       Run a standalone DHT bootstrap peer
   api       Serve an OpenAI-compatible HTTP API backed by the swarm (requires drift[api])
   node      Run a persistent authenticated localhost gateway (requires drift[api])
+  edge-benchmark
+            Measure manifested client storage, memory, and generation latency (requires drift[benchmark])
   manifest  Validate and inspect a content-addressed ModelManifest v1
   identity  Create, inspect, rotate, revoke, and verify public-swarm identities
 
@@ -58,6 +61,8 @@ def main() -> int:
         from drift.cli.run_api import main as run
     elif command == "node":
         from drift.cli.run_node import main as run
+    elif command == "edge-benchmark":
+        from drift.cli.run_edge_benchmark import main as run
     elif command == "manifest":
         from drift.cli.run_manifest import main as run
     elif command == "identity":

--- a/src/drift/cli/__main__.py
+++ b/src/drift/cli/__main__.py
@@ -5,6 +5,7 @@
     drift server <model> ...        The full server with every knob (drift.cli.run_server)
     drift dht ...                   A standalone lightweight DHT bootstrap peer
     drift api <model> ...           An OpenAI-compatible HTTP API backed by the swarm
+    drift node <manifest> ...       A persistent authenticated localhost gateway
     drift manifest <file>           Validate and inspect a ModelManifest v1
     drift identity ...              Manage public-swarm identities and trust records
 
@@ -14,7 +15,7 @@ name and delegates. Also runnable as ``python -m drift.cli``.
 
 import sys
 
-_COMMANDS = ("up", "down", "server", "dht", "api", "manifest", "identity")
+_COMMANDS = ("up", "down", "server", "dht", "api", "node", "manifest", "identity")
 
 _USAGE = """usage: drift <command> [options]
 
@@ -26,6 +27,7 @@ commands:
   server    Run a server with the full set of options (advanced)
   dht       Run a standalone DHT bootstrap peer
   api       Serve an OpenAI-compatible HTTP API backed by the swarm (requires drift[api])
+  node      Run a persistent authenticated localhost gateway (requires drift[api])
   manifest  Validate and inspect a content-addressed ModelManifest v1
   identity  Create, inspect, rotate, revoke, and verify public-swarm identities
 
@@ -54,6 +56,8 @@ def main() -> int:
         from drift.cli.run_server import main as run
     elif command == "api":
         from drift.cli.run_api import main as run
+    elif command == "node":
+        from drift.cli.run_node import main as run
     elif command == "manifest":
         from drift.cli.run_manifest import main as run
     elif command == "identity":

--- a/src/drift/cli/run_edge_benchmark.py
+++ b/src/drift/cli/run_edge_benchmark.py
@@ -1,0 +1,102 @@
+"""``drift edge-benchmark``: measure the current manifested client-only path."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import secrets
+import sys
+from pathlib import Path
+
+import drift
+from drift.model_manifest import ManifestError, ModelManifest
+from drift.node.edge_benchmark import benchmark_client_runtime, cache_is_empty
+from drift.node.loading import make_manifest_loader
+from drift.utils.process_lifetime import tie_child_processes_to_this_process
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="drift edge-benchmark",
+        description="Measure cold-start storage, memory, first-token latency, and throughput for one client route",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("model_manifest", type=Path, help="Path to one exact ModelManifest v1")
+    parser.add_argument("--initial_peers", nargs="+", required=True, help="Manifested swarm bootstrap multiaddrs")
+    parser.add_argument("--cache_dir", type=Path, required=True, help="Dedicated Hugging Face cache to measure")
+    parser.add_argument("--allow_warm_cache", action="store_true", help="Allow a non-empty cache (reported as warm)")
+    parser.add_argument("--token", default=None, help="Hugging Face token for a gated repository")
+    parser.add_argument("--revocation_file", action="append", default=[])
+    parser.add_argument("--request_timeout", type=float, default=30)
+    parser.add_argument("--max_retries", type=int, default=3)
+    parser.add_argument("--prompt", default="Hello")
+    parser.add_argument("--max_new_tokens", type=int, default=8)
+    parser.add_argument("--output", type=Path, help="Write JSON atomically to this file; otherwise print it")
+    return parser
+
+
+def _write_json(path: Path, result: dict) -> None:
+    path = path.expanduser().resolve()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{secrets.token_hex(8)}.tmp")
+    try:
+        with temporary.open("w", encoding="utf-8", newline="\n") as stream:
+            json.dump(result, stream, ensure_ascii=False, allow_nan=False, indent=2, sort_keys=True)
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+    finally:
+        try:
+            temporary.unlink()
+        except OSError:
+            pass
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+    if args.request_timeout <= 0:
+        parser.error("--request_timeout must be positive")
+    if args.max_retries < 1:
+        parser.error("--max_retries must be at least 1")
+    if args.max_new_tokens < 2:
+        parser.error("--max_new_tokens must be at least 2")
+    cache_dir = args.cache_dir.expanduser().resolve()
+    if not args.allow_warm_cache and not cache_is_empty(cache_dir):
+        parser.error("--cache_dir must be empty for a cold-start measurement (or pass --allow_warm_cache)")
+
+    try:
+        manifest = ModelManifest.load(args.model_manifest)
+        manifest.validate_runtime(drift.__version__)
+        if manifest.runtime.adapter_profile != "none":
+            raise ManifestError("Content-addressed adapter profiles are not executable in this release")
+        tie_child_processes_to_this_process()
+        result = benchmark_client_runtime(
+            manifest,
+            make_manifest_loader(
+                manifest,
+                initial_peers=args.initial_peers,
+                token=args.token,
+                cache_dir=str(cache_dir),
+                revocation_files=args.revocation_file,
+                request_timeout=args.request_timeout,
+                max_retries=args.max_retries,
+            ),
+            cache_dir=cache_dir,
+            prompt=args.prompt,
+            max_new_tokens=args.max_new_tokens,
+        )
+    except (ManifestError, OSError, RuntimeError, ValueError) as exc:
+        parser.error(str(exc))
+
+    if args.output is not None:
+        _write_json(args.output, result)
+    else:
+        json.dump(result, sys.stdout, ensure_ascii=False, allow_nan=False, indent=2, sort_keys=True)
+        sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/drift/cli/run_node.py
+++ b/src/drift/cli/run_node.py
@@ -1,0 +1,211 @@
+"""``drift node``: persistent, authenticated localhost gateway for manifested swarms."""
+
+from __future__ import annotations
+
+import argparse
+import math
+from pathlib import Path
+
+from hivemind.utils.logging import get_logger, use_hivemind_log_handler
+
+import drift
+from drift.model_manifest import ManifestError, ModelManifest
+from drift.node.config import NODE_CONFIG_SCHEMA_VERSION, NodeConfig, NodeConfigError, NodeModelConfig
+from drift.node.keys import load_or_create_api_key
+from drift.node.loading import make_manifest_loader
+from drift.node.model_manager import ModelDescriptor, ModelManager
+from drift.utils.process_lifetime import tie_child_processes_to_this_process
+
+use_hivemind_log_handler("in_root_logger")
+logger = get_logger(__name__)
+
+DEFAULT_NODE_DATA_DIR = Path.home() / ".drift" / "node"
+_LOOPBACK_HOSTS = {"127.0.0.1", "::1", "localhost"}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="drift node",
+        description="Run a persistent local OpenAI gateway for manifested DRIFT swarms",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("model_manifest", nargs="?", help="Path to one exact ModelManifest v1 (legacy shorthand)")
+    parser.add_argument("--config", type=Path, help="Path to a versioned multi-model node configuration")
+    parser.add_argument("--initial_peers", nargs="+", help="Multiaddrs for the shorthand model to join via")
+    parser.add_argument("--token", default=None, help="Hugging Face token for gated model artifacts")
+    parser.add_argument("--cache_dir", default=None, help="Hugging Face cache directory")
+    parser.add_argument(
+        "--revocation_file",
+        action="append",
+        default=[],
+        help="Signed identity rotation/revocation JSON to enforce (repeatable)",
+    )
+    parser.add_argument("--host", default="127.0.0.1", help="Interface for the local HTTP API")
+    parser.add_argument("--port", type=int, default=8080)
+    parser.add_argument(
+        "--allow_network",
+        action="store_true",
+        help="Required acknowledgement before binding the authenticated API beyond loopback",
+    )
+    parser.add_argument(
+        "--api_key",
+        action="append",
+        default=[],
+        help="Bearer key accepted by both APIs (repeatable; otherwise a persistent key is generated)",
+    )
+    parser.add_argument("--data_dir", type=Path, default=DEFAULT_NODE_DATA_DIR)
+    parser.add_argument(
+        "--max_loaded_models",
+        type=int,
+        default=None,
+        help="Override the maximum number of resident client runtimes",
+    )
+    parser.add_argument("--max_concurrent", type=int, default=1)
+    parser.add_argument("--request_timeout", type=float, default=None)
+    parser.add_argument("--max_retries", type=int, default=None)
+    parser.add_argument("--default_max_tokens", type=int, default=512)
+    return parser
+
+
+def _validate_args(parser: argparse.ArgumentParser, args: argparse.Namespace) -> None:
+    if bool(args.model_manifest) == bool(args.config):
+        parser.error("provide exactly one of model_manifest or --config")
+    if args.model_manifest and not args.initial_peers:
+        parser.error("model_manifest requires --initial_peers")
+    if args.config and any(
+        (
+            args.initial_peers,
+            args.cache_dir,
+            args.revocation_file,
+            args.request_timeout is not None,
+            args.max_retries is not None,
+        )
+    ):
+        parser.error(
+            "--config supplies per-model peers, cache, revocations, timeout, and retries; "
+            "do not combine their shorthand options"
+        )
+    if args.host.casefold() not in _LOOPBACK_HOSTS and not args.allow_network:
+        parser.error("non-loopback --host requires explicit --allow_network")
+    if not 1 <= args.port <= 65535:
+        parser.error("--port must be between 1 and 65535")
+    if args.max_concurrent < 1:
+        parser.error("--max_concurrent must be at least 1")
+    if args.max_loaded_models is not None and args.max_loaded_models < 1:
+        parser.error("--max_loaded_models must be at least 1")
+    if args.request_timeout is not None and (not math.isfinite(args.request_timeout) or args.request_timeout <= 0):
+        parser.error("--request_timeout must be positive")
+    if args.max_retries is not None and args.max_retries < 1:
+        parser.error("--max_retries must be at least 1")
+    if args.default_max_tokens < 1:
+        parser.error("--default_max_tokens must be at least 1")
+    if any(not key for key in args.api_key):
+        parser.error("--api_key values must not be empty")
+
+
+def _load_node_config(args: argparse.Namespace) -> NodeConfig:
+    if args.config:
+        configured = NodeConfig.load(args.config)
+        if args.max_loaded_models is None:
+            return configured
+        return NodeConfig(
+            schema_version=configured.schema_version,
+            max_loaded_models=args.max_loaded_models,
+            models=configured.models,
+        )
+
+    manifest_path = Path(args.model_manifest).expanduser().resolve()
+    cache_dir = Path(args.cache_dir).expanduser().resolve() if args.cache_dir else None
+    return NodeConfig(
+        schema_version=NODE_CONFIG_SCHEMA_VERSION,
+        max_loaded_models=args.max_loaded_models or 1,
+        models=(
+            NodeModelConfig(
+                manifest_path=manifest_path,
+                initial_peers=tuple(args.initial_peers),
+                cache_dir=cache_dir,
+                revocation_files=tuple(Path(path).expanduser().resolve() for path in args.revocation_file),
+                request_timeout=args.request_timeout if args.request_timeout is not None else 30.0,
+                max_retries=args.max_retries if args.max_retries is not None else 3,
+            ),
+        ),
+    )
+
+
+def _build_model_manager(config: NodeConfig, *, token: str | None) -> tuple[ModelManager, tuple[ModelDescriptor, ...]]:
+    manager = ModelManager(max_loaded_models=config.max_loaded_models)
+    descriptors = []
+    try:
+        for model_config in config.models:
+            manifest = ModelManifest.load(model_config.manifest_path)
+            manifest.validate_runtime(drift.__version__)
+            if manifest.runtime.adapter_profile != "none":
+                raise ManifestError("Content-addressed adapter profiles are not executable in this release")
+            descriptors.append(
+                manager.register_manifest(
+                    manifest,
+                    make_manifest_loader(
+                        manifest,
+                        initial_peers=model_config.initial_peers,
+                        token=token,
+                        cache_dir=str(model_config.cache_dir) if model_config.cache_dir is not None else None,
+                        revocation_files=tuple(str(path) for path in model_config.revocation_files),
+                        request_timeout=model_config.request_timeout,
+                        max_retries=model_config.max_retries,
+                    ),
+                )
+            )
+    except BaseException:
+        manager.shutdown()
+        raise
+    return manager, tuple(descriptors)
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+    _validate_args(parser, args)
+
+    try:
+        config = _load_node_config(args)
+        manager, descriptors = _build_model_manager(config, token=args.token)
+    except (NodeConfigError, ManifestError, ValueError) as exc:
+        parser.error(str(exc))
+
+    try:
+        import uvicorn
+
+        from drift.node.server import create_node_app
+    except ImportError as exc:
+        raise SystemExit(f"drift node requires the 'api' extra: pip install drift[api] ({exc})") from exc
+
+    if args.api_key:
+        api_keys = args.api_key
+    else:
+        key_path = args.data_dir / "local-api.key"
+        key, created = load_or_create_api_key(key_path)
+        api_keys = [key]
+        if created:
+            logger.info(f"Created the local API key in {key_path}; its value is not written to logs")
+        else:
+            logger.info(f"Using the local API key from {key_path}")
+
+    # Arm this before a lazy request can create the model client's p2pd child.
+    tie_child_processes_to_this_process()
+    app = create_node_app(
+        manager,
+        api_keys=api_keys,
+        host=args.host,
+        port=args.port,
+        max_concurrent=args.max_concurrent,
+        default_max_tokens=args.default_max_tokens,
+    )
+    model_names = ", ".join(repr(descriptor.model_id) for descriptor in descriptors)
+    logger.info(
+        f"Local node knows {len(descriptors)} exact model(s) ({model_names}) at http://{args.host}:{args.port}/v1"
+    )
+    uvicorn.run(app, host=args.host, port=args.port, log_level="info")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/drift/cli/run_node.py
+++ b/src/drift/cli/run_node.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import math
+import sys
 from pathlib import Path
 
 from hivemind.utils.logging import get_logger, use_hivemind_log_handler
@@ -11,9 +12,11 @@ from hivemind.utils.logging import get_logger, use_hivemind_log_handler
 import drift
 from drift.model_manifest import ManifestError, ModelManifest
 from drift.node.config import NODE_CONFIG_SCHEMA_VERSION, NodeConfig, NodeConfigError, NodeModelConfig
-from drift.node.keys import load_or_create_api_key
+from drift.node.discovery import CoverageTarget, ModelCoverageDiscovery
+from drift.node.keys import ApiKeyStore, ApiKeyStoreError, load_or_create_api_key
 from drift.node.loading import make_manifest_loader
-from drift.node.model_manager import ModelDescriptor, ModelManager
+from drift.node.model_manager import ModelDescriptor, ModelManager, ModelNotFoundError
+from drift.node.worker_supervisor import WorkerLaunch, WorkerSupervisor
 from drift.utils.process_lifetime import tie_child_processes_to_this_process
 
 use_hivemind_log_handler("in_root_logger")
@@ -112,6 +115,9 @@ def _load_node_config(args: argparse.Namespace) -> NodeConfig:
             schema_version=configured.schema_version,
             max_loaded_models=args.max_loaded_models,
             models=configured.models,
+            workers=configured.workers,
+            discovery_update_period=configured.discovery_update_period,
+            discovery_startup_timeout=configured.discovery_startup_timeout,
         )
 
     manifest_path = Path(args.model_manifest).expanduser().resolve()
@@ -132,15 +138,34 @@ def _load_node_config(args: argparse.Namespace) -> NodeConfig:
     )
 
 
-def _build_model_manager(config: NodeConfig, *, token: str | None) -> tuple[ModelManager, tuple[ModelDescriptor, ...]]:
+def _build_model_manager(
+    config: NodeConfig, *, token: str | None
+) -> tuple[ModelManager, tuple[ModelDescriptor, ...], ModelCoverageDiscovery]:
     manager = ModelManager(max_loaded_models=config.max_loaded_models)
     descriptors = []
     try:
+        configured_manifests = []
         for model_config in config.models:
             manifest = ModelManifest.load(model_config.manifest_path)
             manifest.validate_runtime(drift.__version__)
             if manifest.runtime.adapter_profile != "none":
                 raise ManifestError("Content-addressed adapter profiles are not executable in this release")
+            configured_manifests.append((model_config, manifest))
+
+        discovery = ModelCoverageDiscovery(
+            [
+                CoverageTarget(
+                    manifest=manifest,
+                    initial_peers=model_config.initial_peers,
+                    revocation_files=model_config.revocation_files,
+                )
+                for model_config, manifest in configured_manifests
+            ],
+            update_period=config.discovery_update_period,
+            startup_timeout=config.discovery_startup_timeout,
+        )
+        manager.add_shutdown_callback(discovery.close)
+        for model_config, manifest in configured_manifests:
             descriptors.append(
                 manager.register_manifest(
                     manifest,
@@ -153,12 +178,107 @@ def _build_model_manager(config: NodeConfig, *, token: str | None) -> tuple[Mode
                         request_timeout=model_config.request_timeout,
                         max_retries=model_config.max_retries,
                     ),
+                    route_health=discovery.observer(manifest.digest_id),
                 )
             )
     except BaseException:
         manager.shutdown()
         raise
-    return manager, tuple(descriptors)
+    return manager, tuple(descriptors), discovery
+
+
+def _build_worker_supervisor(
+    config: NodeConfig, manager: ModelManager, *, token: str | None = None
+) -> WorkerSupervisor:
+    manifested_models = {}
+    for model_config in config.models:
+        manifest = ModelManifest.load(model_config.manifest_path)
+        manifested_models[manifest.digest_id] = (model_config, manifest)
+
+    launches = []
+    for worker in config.workers:
+        try:
+            descriptor = manager.resolve(worker.model)
+        except ModelNotFoundError as exc:
+            raise NodeConfigError(f"worker {worker.worker_id!r} selects {exc}") from exc
+        model_config, manifest = manifested_models[descriptor.manifest_digest]
+        if worker.num_blocks is not None and worker.num_blocks > manifest.model.num_blocks:
+            raise NodeConfigError(
+                f"worker {worker.worker_id!r} requests {worker.num_blocks} blocks from a "
+                f"{manifest.model.num_blocks}-block model"
+            )
+        if worker.block_indices is not None and int(worker.block_indices.split(":")[1]) > manifest.model.num_blocks:
+            raise NodeConfigError(
+                f"worker {worker.worker_id!r} block range exceeds model size {manifest.model.num_blocks}"
+            )
+        if worker.public_ip is not None and worker.port is None:
+            raise NodeConfigError(f"worker {worker.worker_id!r} public_ip requires port")
+
+        command = [
+            sys.executable,
+            "-m",
+            "drift.cli",
+            "server",
+            manifest.source.repository,
+            "--model_manifest",
+            str(model_config.manifest_path),
+            "--identity_path",
+            str(worker.identity_path),
+            "--initial_peers",
+            *model_config.initial_peers,
+            "--throughput",
+            str(worker.throughput),
+        ]
+        if worker.num_blocks is not None:
+            command.extend(("--num_blocks", str(worker.num_blocks)))
+        else:
+            command.extend(("--block_indices", worker.block_indices))
+        if worker.device is not None:
+            command.extend(("--device", worker.device))
+        cache_dir = worker.cache_dir if worker.cache_dir is not None else model_config.cache_dir
+        if cache_dir is not None:
+            command.extend(("--cache_dir", str(cache_dir)))
+        if worker.max_disk_space is not None:
+            command.extend(("--max_disk_space", worker.max_disk_space))
+        if worker.port is not None:
+            command.extend(("--port", str(worker.port)))
+        if worker.public_ip is not None:
+            command.extend(("--public_ip", worker.public_ip))
+        for revocation_file in model_config.revocation_files:
+            command.extend(("--revocation_file", str(revocation_file)))
+
+        launches.append(
+            WorkerLaunch(
+                worker_id=worker.worker_id,
+                model_id=descriptor.model_id,
+                command=tuple(command),
+                auto_start=worker.enabled,
+                auto_restart=worker.auto_restart,
+                restart_backoff=worker.restart_backoff,
+                environment=(("HF_TOKEN", token),) if token is not None else (),
+            )
+        )
+    return WorkerSupervisor(launches)
+
+
+def _prepare_api_key_store(data_dir: Path, supplied_keys: list[str]) -> tuple[ApiKeyStore, Path | None, bool]:
+    """Import explicit keys or bootstrap only an otherwise keyless store.
+
+    Once control clients have created a replacement and revoked the bootstrap key,
+    the persistent managed-key set is authoritative across node restarts.
+    """
+    key_store = ApiKeyStore(data_dir / "api-keys.json")
+    if supplied_keys:
+        for index, key in enumerate(supplied_keys, start=1):
+            key_store.ensure_key(key, label=f"command-line-{index}")
+        return key_store, None, False
+    if any(item["revoked_at"] is None for item in key_store.list()):
+        return key_store, None, False
+
+    key_path = data_dir / "local-api.key"
+    key, created = load_or_create_api_key(key_path)
+    key_store.ensure_key(key, label="bootstrap")
+    return key_store, key_path, created
 
 
 def main() -> None:
@@ -168,7 +288,8 @@ def main() -> None:
 
     try:
         config = _load_node_config(args)
-        manager, descriptors = _build_model_manager(config, token=args.token)
+        manager, descriptors, discovery = _build_model_manager(config, token=args.token)
+        worker_supervisor = _build_worker_supervisor(config, manager, token=args.token)
     except (NodeConfigError, ManifestError, ValueError) as exc:
         parser.error(str(exc))
 
@@ -179,32 +300,40 @@ def main() -> None:
     except ImportError as exc:
         raise SystemExit(f"drift node requires the 'api' extra: pip install drift[api] ({exc})") from exc
 
-    if args.api_key:
-        api_keys = args.api_key
-    else:
-        key_path = args.data_dir / "local-api.key"
-        key, created = load_or_create_api_key(key_path)
-        api_keys = [key]
-        if created:
-            logger.info(f"Created the local API key in {key_path}; its value is not written to logs")
-        else:
-            logger.info(f"Using the local API key from {key_path}")
+    try:
+        key_store, key_path, created = _prepare_api_key_store(args.data_dir, args.api_key)
+        if key_path is not None:
+            if created:
+                logger.info(f"Created the local API key in {key_path}; its value is not written to logs")
+            else:
+                logger.info(f"Using the local API key from {key_path}")
+        elif not args.api_key:
+            logger.info(f"Using the active managed API keys in {key_store.path}")
+    except (ApiKeyStoreError, OSError, ValueError) as exc:
+        parser.error(str(exc))
 
     # Arm this before a lazy request can create the model client's p2pd child.
     tie_child_processes_to_this_process()
     app = create_node_app(
         manager,
-        api_keys=api_keys,
+        api_key_store=key_store,
         host=args.host,
         port=args.port,
         max_concurrent=args.max_concurrent,
         default_max_tokens=args.default_max_tokens,
+        worker_supervisor=worker_supervisor,
     )
     model_names = ", ".join(repr(descriptor.model_id) for descriptor in descriptors)
     logger.info(
         f"Local node knows {len(descriptors)} exact model(s) ({model_names}) at http://{args.host}:{args.port}/v1"
     )
-    uvicorn.run(app, host=args.host, port=args.port, log_level="info")
+    discovery.start()
+    worker_supervisor.start_service()
+    try:
+        uvicorn.run(app, host=args.host, port=args.port, log_level="info")
+    finally:
+        worker_supervisor.shutdown()
+        manager.shutdown()
 
 
 if __name__ == "__main__":

--- a/src/drift/cli/run_node.py
+++ b/src/drift/cli/run_node.py
@@ -13,7 +13,7 @@ import drift
 from drift.model_manifest import ManifestError, ModelManifest
 from drift.node.config import NODE_CONFIG_SCHEMA_VERSION, NodeConfig, NodeConfigError, NodeModelConfig
 from drift.node.discovery import CoverageTarget, ModelCoverageDiscovery
-from drift.node.keys import ApiKeyStore, ApiKeyStoreError, load_or_create_api_key
+from drift.node.keys import ApiKeyStore, ApiKeyStoreError, load_or_create_api_key, load_or_create_control_key
 from drift.node.loading import make_manifest_loader
 from drift.node.model_manager import ModelDescriptor, ModelManager, ModelNotFoundError
 from drift.node.worker_supervisor import WorkerLaunch, WorkerSupervisor
@@ -54,9 +54,15 @@ def build_parser() -> argparse.ArgumentParser:
         "--api_key",
         action="append",
         default=[],
-        help="Bearer key accepted by both APIs (repeatable; otherwise a persistent key is generated)",
+        help="Bearer key accepted by the OpenAI API (repeatable; otherwise a persistent client key is generated)",
     )
     parser.add_argument("--data_dir", type=Path, default=DEFAULT_NODE_DATA_DIR)
+    parser.add_argument(
+        "--control_key_path",
+        type=Path,
+        default=None,
+        help="Private drift_control_ key file for the privileged control API (generated if missing)",
+    )
     parser.add_argument(
         "--max_loaded_models",
         type=int,
@@ -264,8 +270,8 @@ def _build_worker_supervisor(
 def _prepare_api_key_store(data_dir: Path, supplied_keys: list[str]) -> tuple[ApiKeyStore, Path | None, bool]:
     """Import explicit keys or bootstrap only an otherwise keyless store.
 
-    Once control clients have created a replacement and revoked the bootstrap key,
-    the persistent managed-key set is authoritative across node restarts.
+    Once a control client has created a replacement and revoked the bootstrap client
+    key, the persistent managed-key set is authoritative across node restarts.
     """
     key_store = ApiKeyStore(data_dir / "api-keys.json")
     if supplied_keys:
@@ -279,6 +285,13 @@ def _prepare_api_key_store(data_dir: Path, supplied_keys: list[str]) -> tuple[Ap
     key, created = load_or_create_api_key(key_path)
     key_store.ensure_key(key, label="bootstrap")
     return key_store, key_path, created
+
+
+def _prepare_control_key(data_dir: Path, supplied_path: Path | None) -> tuple[str, Path, bool]:
+    """Load or atomically create the credential used only by `/control/v1/*`."""
+    key_path = supplied_path if supplied_path is not None else data_dir / "control-api.key"
+    key, created = load_or_create_control_key(key_path)
+    return key, key_path, created
 
 
 def main() -> None:
@@ -302,6 +315,7 @@ def main() -> None:
 
     try:
         key_store, key_path, created = _prepare_api_key_store(args.data_dir, args.api_key)
+        control_key, control_key_path, control_key_created = _prepare_control_key(args.data_dir, args.control_key_path)
         if key_path is not None:
             if created:
                 logger.info(f"Created the local API key in {key_path}; its value is not written to logs")
@@ -309,6 +323,12 @@ def main() -> None:
                 logger.info(f"Using the local API key from {key_path}")
         elif not args.api_key:
             logger.info(f"Using the active managed API keys in {key_store.path}")
+        if control_key_created:
+            logger.info(
+                f"Created the privileged local control key in {control_key_path}; its value is not written to logs"
+            )
+        else:
+            logger.info(f"Using the privileged local control key from {control_key_path}")
     except (ApiKeyStoreError, OSError, ValueError) as exc:
         parser.error(str(exc))
 
@@ -317,6 +337,7 @@ def main() -> None:
     app = create_node_app(
         manager,
         api_key_store=key_store,
+        control_keys=[control_key],
         host=args.host,
         port=args.port,
         max_concurrent=args.max_concurrent,

--- a/src/drift/node/__init__.py
+++ b/src/drift/node/__init__.py
@@ -1,0 +1,33 @@
+"""Persistent local-node building blocks.
+
+The node package deliberately stays independent from FastAPI so model lifecycle and
+selection can be tested without installing the optional HTTP dependencies.
+"""
+
+from drift.node.model_manager import (
+    AmbiguousModelError,
+    LoadedModel,
+    ModelDescriptor,
+    ModelInUseError,
+    ModelManager,
+    ModelManagerClosedError,
+    ModelNotFoundError,
+    ModelRuntime,
+    ModelSnapshot,
+    ModelState,
+    ModelUnloadError,
+)
+
+__all__ = [
+    "AmbiguousModelError",
+    "LoadedModel",
+    "ModelDescriptor",
+    "ModelInUseError",
+    "ModelManager",
+    "ModelManagerClosedError",
+    "ModelNotFoundError",
+    "ModelRuntime",
+    "ModelSnapshot",
+    "ModelState",
+    "ModelUnloadError",
+]

--- a/src/drift/node/config.py
+++ b/src/drift/node/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import math
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Mapping, Optional, Tuple
@@ -42,6 +43,12 @@ def _require_string(value: Any, field: str) -> str:
 def _require_positive_int(value: Any, field: str) -> int:
     if isinstance(value, bool) or not isinstance(value, int) or value < 1:
         raise NodeConfigError(f"{field} must be an integer >= 1")
+    return value
+
+
+def _require_bool(value: Any, field: str) -> bool:
+    if not isinstance(value, bool):
+        raise NodeConfigError(f"{field} must be a boolean")
     return value
 
 
@@ -109,12 +116,110 @@ class NodeModelConfig:
 
 
 @dataclass(frozen=True)
+class WorkerConfig:
+    """One isolated contribution worker controlled by the local node."""
+
+    worker_id: str
+    model: str
+    identity_path: Path
+    num_blocks: Optional[int] = None
+    block_indices: Optional[str] = None
+    enabled: bool = False
+    auto_restart: bool = True
+    restart_backoff: float = 5.0
+    device: Optional[str] = None
+    cache_dir: Optional[Path] = None
+    max_disk_space: Optional[str] = None
+    throughput: float | str = "auto"
+    port: Optional[int] = None
+    public_ip: Optional[str] = None
+
+    @classmethod
+    def from_dict(cls, source: Mapping[str, Any], *, base_dir: Path, index: int) -> "WorkerConfig":
+        field = f"workers[{index}]"
+        source = _require_object(source, field)
+        _require_fields(
+            source,
+            field,
+            required=("id", "model", "identity_path"),
+            optional=(
+                "num_blocks",
+                "block_indices",
+                "enabled",
+                "auto_restart",
+                "restart_backoff",
+                "device",
+                "cache_dir",
+                "max_disk_space",
+                "throughput",
+                "port",
+                "public_ip",
+            ),
+        )
+        worker_id = _require_string(source["id"], f"{field}.id")
+        if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,63}", worker_id):
+            raise NodeConfigError(f"{field}.id must match [A-Za-z0-9][A-Za-z0-9._-]{{0,63}}")
+
+        num_blocks_value = source.get("num_blocks")
+        block_indices_value = source.get("block_indices")
+        if (num_blocks_value is None) == (block_indices_value is None):
+            raise NodeConfigError(f"{field} must provide exactly one of num_blocks or block_indices")
+        num_blocks = (
+            None if num_blocks_value is None else _require_positive_int(num_blocks_value, f"{field}.num_blocks")
+        )
+        block_indices = None
+        if block_indices_value is not None:
+            block_indices = _require_string(block_indices_value, f"{field}.block_indices")
+            match = re.fullmatch(r"(0|[1-9][0-9]*):(0|[1-9][0-9]*)", block_indices)
+            if match is None or int(match.group(1)) >= int(match.group(2)):
+                raise NodeConfigError(f"{field}.block_indices must be a non-empty start:end range")
+
+        throughput_value = source.get("throughput", "auto")
+        if isinstance(throughput_value, str):
+            if throughput_value != "auto":
+                raise NodeConfigError(f"{field}.throughput must be 'auto' or a finite number > 0")
+            throughput: float | str = throughput_value
+        else:
+            throughput = _require_positive_number(throughput_value, f"{field}.throughput")
+
+        port_value = source.get("port")
+        port = None if port_value is None else _require_positive_int(port_value, f"{field}.port")
+        if port is not None and port > 65535:
+            raise NodeConfigError(f"{field}.port must be <= 65535")
+
+        def optional_string(name: str) -> Optional[str]:
+            value = source.get(name)
+            return None if value is None else _require_string(value, f"{field}.{name}")
+
+        cache_value = source.get("cache_dir")
+        return cls(
+            worker_id=worker_id,
+            model=_require_string(source["model"], f"{field}.model"),
+            identity_path=_resolve_path(source["identity_path"], f"{field}.identity_path", base_dir),
+            num_blocks=num_blocks,
+            block_indices=block_indices,
+            enabled=_require_bool(source.get("enabled", False), f"{field}.enabled"),
+            auto_restart=_require_bool(source.get("auto_restart", True), f"{field}.auto_restart"),
+            restart_backoff=_require_positive_number(source.get("restart_backoff", 5), f"{field}.restart_backoff"),
+            device=optional_string("device"),
+            cache_dir=None if cache_value is None else _resolve_path(cache_value, f"{field}.cache_dir", base_dir),
+            max_disk_space=optional_string("max_disk_space"),
+            throughput=throughput,
+            port=port,
+            public_ip=optional_string("public_ip"),
+        )
+
+
+@dataclass(frozen=True)
 class NodeConfig:
     """Versioned multi-model configuration loaded atomically at node startup."""
 
     schema_version: int
     max_loaded_models: int
     models: Tuple[NodeModelConfig, ...]
+    workers: Tuple[WorkerConfig, ...] = ()
+    discovery_update_period: float = 30.0
+    discovery_startup_timeout: float = 15.0
 
     @classmethod
     def from_dict(cls, source: Mapping[str, Any], *, base_dir: Path) -> "NodeConfig":
@@ -123,7 +228,7 @@ class NodeConfig:
             source,
             "node config",
             required=("schema_version", "models"),
-            optional=("max_loaded_models",),
+            optional=("max_loaded_models", "discovery_update_period", "discovery_startup_timeout", "workers"),
         )
         schema_version = _require_positive_int(source["schema_version"], "schema_version")
         if schema_version != NODE_CONFIG_SCHEMA_VERSION:
@@ -137,10 +242,26 @@ class NodeConfig:
         manifest_paths = [model.manifest_path for model in models]
         if len(set(manifest_paths)) != len(manifest_paths):
             raise NodeConfigError("models must not configure the same manifest path more than once")
+        workers_value = source.get("workers", [])
+        if not isinstance(workers_value, list):
+            raise NodeConfigError("workers must be a JSON array")
+        workers = tuple(
+            WorkerConfig.from_dict(item, base_dir=base_dir, index=index) for index, item in enumerate(workers_value)
+        )
+        worker_ids = [worker.worker_id.casefold() for worker in workers]
+        if len(set(worker_ids)) != len(worker_ids):
+            raise NodeConfigError("worker ids must be unique case-insensitively")
         return cls(
             schema_version=schema_version,
             max_loaded_models=_require_positive_int(source.get("max_loaded_models", 1), "max_loaded_models"),
             models=models,
+            workers=workers,
+            discovery_update_period=_require_positive_number(
+                source.get("discovery_update_period", 30), "discovery_update_period"
+            ),
+            discovery_startup_timeout=_require_positive_number(
+                source.get("discovery_startup_timeout", 15), "discovery_startup_timeout"
+            ),
         )
 
     @classmethod

--- a/src/drift/node/config.py
+++ b/src/drift/node/config.py
@@ -1,0 +1,172 @@
+"""Strict, secret-free configuration for a multi-model local node."""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Optional, Tuple
+
+NODE_CONFIG_SCHEMA_VERSION = 1
+
+
+class NodeConfigError(ValueError):
+    """The node configuration is malformed or cannot be read."""
+
+
+def _require_object(value: Any, field: str) -> Mapping[str, Any]:
+    if not isinstance(value, dict):
+        raise NodeConfigError(f"{field} must be a JSON object")
+    return value
+
+
+def _require_fields(
+    value: Mapping[str, Any], field: str, *, required: Tuple[str, ...], optional: Tuple[str, ...] = ()
+) -> None:
+    actual = set(value)
+    missing = set(required) - actual
+    extra = actual - set(required) - set(optional)
+    if missing:
+        raise NodeConfigError(f"{field} is missing required field(s): {', '.join(sorted(missing))}")
+    if extra:
+        raise NodeConfigError(f"{field} has unknown field(s): {', '.join(sorted(extra))}")
+
+
+def _require_string(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise NodeConfigError(f"{field} must be a non-empty string")
+    return value
+
+
+def _require_positive_int(value: Any, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise NodeConfigError(f"{field} must be an integer >= 1")
+    return value
+
+
+def _require_positive_number(value: Any, field: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise NodeConfigError(f"{field} must be a finite number > 0")
+    result = float(value)
+    if not math.isfinite(result) or result <= 0:
+        raise NodeConfigError(f"{field} must be a finite number > 0")
+    return result
+
+
+def _require_string_list(value: Any, field: str, *, nonempty: bool = False) -> Tuple[str, ...]:
+    if not isinstance(value, list):
+        raise NodeConfigError(f"{field} must be a JSON array")
+    result = tuple(_require_string(item, f"{field}[]") for item in value)
+    if nonempty and not result:
+        raise NodeConfigError(f"{field} must contain at least one value")
+    if len(set(result)) != len(result):
+        raise NodeConfigError(f"{field} must not contain duplicates")
+    return result
+
+
+def _resolve_path(value: Any, field: str, base_dir: Path) -> Path:
+    raw_path = Path(_require_string(value, field)).expanduser()
+    if not raw_path.is_absolute():
+        raw_path = base_dir / raw_path
+    return raw_path.resolve()
+
+
+@dataclass(frozen=True)
+class NodeModelConfig:
+    """Startup inputs for one exact manifested swarm."""
+
+    manifest_path: Path
+    initial_peers: Tuple[str, ...]
+    cache_dir: Optional[Path] = None
+    revocation_files: Tuple[Path, ...] = ()
+    request_timeout: float = 30.0
+    max_retries: int = 3
+
+    @classmethod
+    def from_dict(cls, source: Mapping[str, Any], *, base_dir: Path, index: int) -> "NodeModelConfig":
+        field = f"models[{index}]"
+        source = _require_object(source, field)
+        _require_fields(
+            source,
+            field,
+            required=("manifest", "initial_peers"),
+            optional=("cache_dir", "revocation_files", "request_timeout", "max_retries"),
+        )
+        cache_value = source.get("cache_dir")
+        cache_dir = None if cache_value is None else _resolve_path(cache_value, f"{field}.cache_dir", base_dir)
+        revocation_values = _require_string_list(source.get("revocation_files", []), f"{field}.revocation_files")
+        return cls(
+            manifest_path=_resolve_path(source["manifest"], f"{field}.manifest", base_dir),
+            initial_peers=_require_string_list(source["initial_peers"], f"{field}.initial_peers", nonempty=True),
+            cache_dir=cache_dir,
+            revocation_files=tuple(
+                _resolve_path(value, f"{field}.revocation_files[]", base_dir) for value in revocation_values
+            ),
+            request_timeout=_require_positive_number(source.get("request_timeout", 30), f"{field}.request_timeout"),
+            max_retries=_require_positive_int(source.get("max_retries", 3), f"{field}.max_retries"),
+        )
+
+
+@dataclass(frozen=True)
+class NodeConfig:
+    """Versioned multi-model configuration loaded atomically at node startup."""
+
+    schema_version: int
+    max_loaded_models: int
+    models: Tuple[NodeModelConfig, ...]
+
+    @classmethod
+    def from_dict(cls, source: Mapping[str, Any], *, base_dir: Path) -> "NodeConfig":
+        source = _require_object(source, "node config")
+        _require_fields(
+            source,
+            "node config",
+            required=("schema_version", "models"),
+            optional=("max_loaded_models",),
+        )
+        schema_version = _require_positive_int(source["schema_version"], "schema_version")
+        if schema_version != NODE_CONFIG_SCHEMA_VERSION:
+            raise NodeConfigError(f"Unsupported schema_version {schema_version}; expected {NODE_CONFIG_SCHEMA_VERSION}")
+        models_value = source["models"]
+        if not isinstance(models_value, list) or not models_value:
+            raise NodeConfigError("models must be a non-empty JSON array")
+        models = tuple(
+            NodeModelConfig.from_dict(item, base_dir=base_dir, index=index) for index, item in enumerate(models_value)
+        )
+        manifest_paths = [model.manifest_path for model in models]
+        if len(set(manifest_paths)) != len(manifest_paths):
+            raise NodeConfigError("models must not configure the same manifest path more than once")
+        return cls(
+            schema_version=schema_version,
+            max_loaded_models=_require_positive_int(source.get("max_loaded_models", 1), "max_loaded_models"),
+            models=models,
+        )
+
+    @classmethod
+    def from_json(cls, source: str, *, base_dir: Path) -> "NodeConfig":
+        def reject_duplicate_keys(pairs):
+            result = {}
+            for key, value in pairs:
+                if key in result:
+                    raise NodeConfigError(f"Node config JSON contains duplicate object key {key!r}")
+                result[key] = value
+            return result
+
+        def reject_non_finite(value):
+            raise NodeConfigError(f"Node config JSON contains non-finite number {value}")
+
+        try:
+            value = json.loads(source, object_pairs_hook=reject_duplicate_keys, parse_constant=reject_non_finite)
+        except json.JSONDecodeError as exc:
+            raise NodeConfigError(f"Invalid node config JSON: {exc}") from exc
+        return cls.from_dict(value, base_dir=base_dir)
+
+    @classmethod
+    def load(cls, path: Path | str) -> "NodeConfig":
+        config_path = Path(path).expanduser().resolve()
+        try:
+            source = config_path.read_text(encoding="utf-8")
+        except (OSError, UnicodeError) as exc:
+            raise NodeConfigError(f"Could not read node config {config_path}: {exc}") from exc
+        return cls.from_json(source, base_dir=config_path.parent)

--- a/src/drift/node/discovery.py
+++ b/src/drift/node/discovery.py
@@ -1,0 +1,228 @@
+"""Lightweight, artifact-free route coverage discovery for configured models."""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional, Sequence, Tuple
+
+from drift.data_structures import UID_DELIMITER
+from drift.model_manifest import ModelManifest
+from drift.node.route_health import module_infos_route_health
+from drift.protocol_identity import ReplayGuard, RevocationStore
+from drift.utils.dht import get_remote_module_infos
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class CoverageTarget:
+    manifest: ModelManifest
+    initial_peers: Tuple[str, ...]
+    revocation_files: Tuple[Path, ...] = ()
+
+
+@dataclass
+class _TargetState:
+    target: CoverageTarget
+    revocations: RevocationStore
+    replay_guard: ReplayGuard
+    last_health: Optional[Dict[str, Any]] = None
+    last_updated: Optional[float] = None
+    last_error: Optional[str] = None
+
+
+def _default_dht_factory(**kwargs):
+    from hivemind import DHT
+
+    return DHT(**kwargs)
+
+
+class ModelCoverageDiscovery:
+    """Query signed DHT announcements without loading any model artifacts.
+
+    Models that use the same ordered bootstrap set share one client-mode DHT. A
+    failed seed or query degrades only discovery status; it never prevents the
+    localhost API from starting or serving an already loaded route.
+    """
+
+    def __init__(
+        self,
+        targets: Sequence[CoverageTarget],
+        *,
+        update_period: float = 30.0,
+        startup_timeout: float = 15.0,
+        dht_factory: Callable[..., Any] = _default_dht_factory,
+        lookup: Callable[..., Any] = get_remote_module_infos,
+    ) -> None:
+        if update_period <= 0 or startup_timeout <= 0:
+            raise ValueError("discovery periods must be positive")
+        self._update_period = update_period
+        self._startup_timeout = startup_timeout
+        self._dht_factory = dht_factory
+        self._lookup = lookup
+        self._states: Dict[str, _TargetState] = {}
+        self._groups: Dict[Tuple[str, ...], list[_TargetState]] = {}
+        for target in targets:
+            digest = target.manifest.digest_id
+            if digest in self._states:
+                raise ValueError(f"duplicate discovery manifest {digest}")
+            state = _TargetState(
+                target=target,
+                revocations=RevocationStore.from_files(target.revocation_files),
+                replay_guard=ReplayGuard(),
+            )
+            self._states[digest] = state
+            self._groups.setdefault(target.initial_peers, []).append(state)
+
+        self._lock = threading.RLock()
+        self._stop = threading.Event()
+        self._threads: list[threading.Thread] = []
+        self._dhts: Dict[Tuple[str, ...], Any] = {}
+        self._shutdown_dht_ids: set[int] = set()
+        self._started = False
+        self._closed = False
+
+    def start(self) -> None:
+        with self._lock:
+            if self._closed:
+                raise RuntimeError("coverage discovery is closed")
+            if self._started:
+                return
+            self._started = True
+            for group_index, (initial_peers, states) in enumerate(self._groups.items()):
+                thread = threading.Thread(
+                    target=self._run_group,
+                    args=(initial_peers, tuple(states)),
+                    name=f"drift-coverage-{group_index}",
+                    daemon=True,
+                )
+                self._threads.append(thread)
+                thread.start()
+
+    def observer(self, digest_id: str) -> Callable[[], Dict[str, Any]]:
+        if digest_id not in self._states:
+            raise KeyError(digest_id)
+        return lambda: self.snapshot(digest_id)
+
+    def snapshot(self, digest_id: str) -> Dict[str, Any]:
+        with self._lock:
+            state = self._states[digest_id]
+            if state.last_health is None:
+                result = {
+                    "status": "unknown",
+                    "total_blocks": state.target.manifest.model.num_blocks,
+                    "covered_blocks": None,
+                    "missing_blocks": None,
+                    "minimum_replicas": None,
+                    "replica_counts": None,
+                    "peer_count": None,
+                    "last_updated_age": None,
+                }
+            else:
+                result = dict(state.last_health)
+                result["last_updated_age"] = max(0.0, time.monotonic() - state.last_updated)
+                if state.last_error is not None:
+                    result["last_known_status"] = result["status"]
+                    result["status"] = "unknown"
+            result["source"] = "discovery"
+            result["last_error"] = state.last_error
+            return result
+
+    def _set_success(self, state: _TargetState, health: Dict[str, Any]) -> None:
+        with self._lock:
+            state.last_health = dict(health)
+            state.last_updated = time.monotonic()
+            state.last_error = None
+
+    def _set_error(self, states: Sequence[_TargetState], exc: Exception) -> None:
+        error = f"{type(exc).__name__}: {exc}"
+        with self._lock:
+            for state in states:
+                state.last_error = error
+
+    def _shutdown_dht_once(self, dht: Any) -> None:
+        with self._lock:
+            identity = id(dht)
+            if identity in self._shutdown_dht_ids:
+                return
+            self._shutdown_dht_ids.add(identity)
+        if dht.is_alive():
+            dht.shutdown()
+
+    def _run_group(self, initial_peers: Tuple[str, ...], states: Tuple[_TargetState, ...]) -> None:
+        dht = None
+        try:
+            while not self._stop.is_set():
+                if dht is None or not dht.is_alive():
+                    try:
+                        dht = self._dht_factory(
+                            initial_peers=list(initial_peers),
+                            client_mode=True,
+                            num_workers=min(max(state.target.manifest.model.num_blocks for state in states), 32),
+                            startup_timeout=self._startup_timeout,
+                            start=True,
+                            tls=True,
+                        )
+                        with self._lock:
+                            self._dhts[initial_peers] = dht
+                    except Exception as exc:
+                        self._set_error(states, exc)
+                        logger.warning("Coverage discovery could not join peers %r: %s", initial_peers, exc)
+                        dht = None
+                        if self._stop.wait(min(self._update_period, 5.0)):
+                            break
+                        continue
+
+                for state in states:
+                    if self._stop.is_set():
+                        break
+                    manifest = state.target.manifest
+                    uids = [
+                        f"{manifest.dht_prefix}{UID_DELIMITER}{block_index}"
+                        for block_index in range(manifest.model.num_blocks)
+                    ]
+                    try:
+                        module_infos = self._lookup(
+                            dht,
+                            uids,
+                            manifest_digest=manifest.digest,
+                            manifest_execution_profile=manifest.runtime.to_dict(),
+                            revocations=state.revocations,
+                            replay_guard=state.replay_guard,
+                            latest=True,
+                        )
+                        self._set_success(state, module_infos_route_health(module_infos))
+                    except Exception as exc:
+                        self._set_error((state,), exc)
+                        logger.warning("Coverage discovery failed for %s: %s", manifest.digest_id, exc)
+
+                if self._stop.wait(self._update_period):
+                    break
+        finally:
+            with self._lock:
+                self._dhts.pop(initial_peers, None)
+            if dht is not None:
+                try:
+                    self._shutdown_dht_once(dht)
+                except Exception:
+                    logger.exception("Failed to close a coverage-discovery DHT")
+
+    def close(self) -> None:
+        with self._lock:
+            if self._closed:
+                return
+            self._closed = True
+            self._stop.set()
+            dhts = tuple(self._dhts.values())
+            threads = tuple(self._threads)
+        for dht in dhts:
+            try:
+                self._shutdown_dht_once(dht)
+            except Exception:
+                logger.exception("Failed to interrupt a coverage-discovery DHT")
+        for thread in threads:
+            thread.join(timeout=5)

--- a/src/drift/node/edge_benchmark.py
+++ b/src/drift/node/edge_benchmark.py
@@ -1,0 +1,301 @@
+"""Reproducible resource measurements for a manifested client-only runtime."""
+
+from __future__ import annotations
+
+import platform
+import threading
+import time
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterable, Optional
+
+import drift
+from drift.model_manifest import ModelManifest
+from drift.node.model_manager import ModelRuntime
+
+EDGE_BENCHMARK_SCHEMA_VERSION = 1
+
+
+def directory_size(path: Path | str) -> int:
+    """Return bytes in regular, non-symlink files below *path*."""
+    root = Path(path)
+    if not root.exists():
+        return 0
+    total = 0
+    for candidate in root.rglob("*"):
+        try:
+            if candidate.is_file() and not candidate.is_symlink():
+                total += candidate.stat().st_size
+        except OSError:
+            # Concurrent cache maintenance may remove a temporary between the walk and stat.
+            continue
+    return total
+
+
+def cache_is_empty(path: Path | str) -> bool:
+    root = Path(path)
+    return not root.exists() or next(root.iterdir(), None) is None
+
+
+def _storage_key(parameter) -> tuple:
+    try:
+        storage = parameter.untyped_storage()
+        return str(parameter.device), storage.data_ptr(), storage.nbytes()
+    except (AttributeError, RuntimeError):
+        return str(parameter.device), parameter.data_ptr(), parameter.numel() * parameter.element_size()
+
+
+def _component_memory(modules: Iterable[tuple[str, Any]]) -> Dict[str, Any]:
+    components: Dict[str, Any] = {}
+    all_storages: Dict[tuple, int] = {}
+    for name, module in modules:
+        storages: Dict[tuple, int] = {}
+        parameters = tuple(module.parameters())
+        for parameter in parameters:
+            key = _storage_key(parameter)
+            storages[key] = key[2]
+            all_storages[key] = key[2]
+        components[name] = {
+            "parameter_count": sum(parameter.numel() for parameter in parameters),
+            "parameter_bytes": sum(storages.values()),
+            "devices": sorted({str(parameter.device) for parameter in parameters}),
+            "dtypes": sorted({str(parameter.dtype).removeprefix("torch.") for parameter in parameters}),
+        }
+    return {"components": components, "unique_parameter_bytes": sum(all_storages.values())}
+
+
+def client_component_memory(model) -> Dict[str, Any]:
+    """Measure the local embedding/head weights, de-duplicating tied storage."""
+    return _component_memory(
+        (
+            ("input_embeddings", model.get_input_embeddings()),
+            ("output_head", model.get_output_embeddings()),
+        )
+    )
+
+
+class _TokenTimingStreamer:
+    def __init__(self) -> None:
+        self._saw_prompt = False
+        self.first_token_at: Optional[float] = None
+        self.ended_at: Optional[float] = None
+        self.generated_tokens = 0
+
+    def put(self, value) -> None:
+        # Transformers sends the prompt as the first value when generation starts.
+        if not self._saw_prompt:
+            self._saw_prompt = True
+            return
+        count = int(value.numel())
+        if count and self.first_token_at is None:
+            self.first_token_at = time.perf_counter()
+        self.generated_tokens += count
+
+    def end(self) -> None:
+        self.ended_at = time.perf_counter()
+
+
+def _accelerator_allocated_bytes(torch_module) -> Dict[str, int]:
+    result: Dict[str, int] = {}
+    for name in ("cuda", "xpu"):
+        backend = getattr(torch_module, name, None)
+        if backend is None:
+            continue
+        try:
+            available = backend.is_available()
+        except (AttributeError, RuntimeError):
+            available = False
+        if available and callable(getattr(backend, "memory_allocated", None)):
+            try:
+                result[name] = int(backend.memory_allocated())
+            except RuntimeError:
+                pass
+    mps = getattr(torch_module, "mps", None)
+    if mps is not None:
+        try:
+            if mps.is_available() and callable(getattr(mps, "current_allocated_memory", None)):
+                result["mps"] = int(mps.current_allocated_memory())
+        except (AttributeError, RuntimeError):
+            pass
+    return result
+
+
+class _ResourceSampler:
+    """Sample the complete client process tree and accelerator allocations."""
+
+    def __init__(self, torch_module, *, interval: float = 0.02) -> None:
+        try:
+            import psutil
+        except ImportError as exc:
+            raise RuntimeError("edge benchmarking requires psutil; install drift[benchmark]") from exc
+        self._psutil = psutil
+        self._process = psutil.Process()
+        self._torch = torch_module
+        self._interval = interval
+        self._stop = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+        self.peak_rss_bytes = 0
+        self.peak_accelerator_bytes: Dict[str, int] = {}
+
+    def _rss(self) -> int:
+        processes = [self._process]
+        try:
+            processes.extend(self._process.children(recursive=True))
+        except self._psutil.Error:
+            pass
+        total = 0
+        for process in processes:
+            try:
+                total += process.memory_info().rss
+            except self._psutil.Error:
+                continue
+        return total
+
+    def sample(self) -> tuple[int, Dict[str, int]]:
+        rss = self._rss()
+        accelerator = _accelerator_allocated_bytes(self._torch)
+        self.peak_rss_bytes = max(self.peak_rss_bytes, rss)
+        for name, value in accelerator.items():
+            self.peak_accelerator_bytes[name] = max(self.peak_accelerator_bytes.get(name, 0), value)
+        return rss, accelerator
+
+    def _run(self) -> None:
+        while not self._stop.wait(self._interval):
+            self.sample()
+
+    def start(self) -> tuple[int, Dict[str, int]]:
+        baseline = self.sample()
+        self._thread = threading.Thread(target=self._run, name="drift-edge-resource-sampler", daemon=True)
+        self._thread.start()
+        return baseline
+
+    def close(self) -> None:
+        self.sample()
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=1)
+
+
+def benchmark_client_runtime(
+    manifest: ModelManifest,
+    loader: Callable[[], ModelRuntime],
+    *,
+    cache_dir: Path | str,
+    prompt: str = "Hello",
+    max_new_tokens: int = 8,
+) -> Dict[str, Any]:
+    """Load, generate through, close, and report one exact manifested client runtime."""
+    if not isinstance(prompt, str) or not prompt:
+        raise ValueError("prompt must be a non-empty string")
+    if isinstance(max_new_tokens, bool) or not isinstance(max_new_tokens, int) or max_new_tokens < 2:
+        raise ValueError("max_new_tokens must be an integer >= 2")
+
+    import torch
+
+    cache_dir = Path(cache_dir)
+    cache_before = directory_size(cache_dir)
+    cold_start = cache_is_empty(cache_dir)
+    sampler = _ResourceSampler(torch)
+    baseline_rss, accelerator_baseline = sampler.start()
+    runtime: Optional[ModelRuntime] = None
+    loaded_rss = baseline_rss
+    accelerator_loaded = accelerator_baseline
+    try:
+        load_started = time.perf_counter()
+        runtime = loader()
+        load_seconds = time.perf_counter() - load_started
+        loaded_rss, accelerator_loaded = sampler.sample()
+        local_components = client_component_memory(runtime.model)
+
+        tokenized = runtime.tokenizer(prompt, return_tensors="pt")
+        input_ids = tokenized["input_ids"] if isinstance(tokenized, dict) else tokenized.input_ids
+        prompt_tokens = int(input_ids.shape[-1])
+        streamer = _TokenTimingStreamer()
+        generation_started = time.perf_counter()
+        with torch.inference_mode():
+            outputs = runtime.model.generate(
+                input_ids,
+                streamer=streamer,
+                max_new_tokens=max_new_tokens,
+                min_new_tokens=max_new_tokens,
+                do_sample=False,
+            )
+        generation_ended = time.perf_counter()
+        if streamer.first_token_at is None:
+            raise RuntimeError("the model completed without emitting a first token to the benchmark streamer")
+        generated_tokens = int(outputs.shape[-1]) - prompt_tokens
+        if generated_tokens < 1:
+            raise RuntimeError("the model completed without generating any tokens")
+        first_token_seconds = streamer.first_token_at - generation_started
+        decode_ended = streamer.ended_at if streamer.ended_at is not None else generation_ended
+        decode_seconds = max(0.0, decode_ended - streamer.first_token_at)
+        decode_tokens = max(0, generated_tokens - 1)
+        sampler.sample()
+        output_ids = outputs[0].detach().cpu().tolist()
+        decoded = runtime.tokenizer.decode(outputs[0], skip_special_tokens=False)
+    finally:
+        try:
+            if runtime is not None and runtime.close is not None:
+                runtime.close()
+        finally:
+            sampler.close()
+
+    cache_after = directory_size(cache_dir)
+    accelerator_names = sorted(
+        set(accelerator_baseline) | set(accelerator_loaded) | set(sampler.peak_accelerator_bytes)
+    )
+    return {
+        "schema_version": EDGE_BENCHMARK_SCHEMA_VERSION,
+        "measured_at_unix": int(time.time()),
+        "runtime": {
+            "python": platform.python_version(),
+            "platform": platform.platform(),
+            "drift": drift.__version__,
+            "torch": torch.__version__,
+        },
+        "model": {
+            "id": manifest.name,
+            "manifest_digest": manifest.digest_id,
+            "repository": manifest.source.repository,
+            "revision": manifest.source.revision,
+            "dtype": manifest.runtime.dtype,
+        },
+        "workload": {
+            "prompt": prompt,
+            "prompt_tokens": prompt_tokens,
+            "requested_new_tokens": max_new_tokens,
+            "generated_tokens": generated_tokens,
+            "output_ids": output_ids,
+            "decoded": decoded,
+        },
+        "storage": {
+            "cold_start": cold_start,
+            "cache_bytes_before": cache_before,
+            "cache_bytes_after": cache_after,
+            "cache_growth_bytes": max(0, cache_after - cache_before),
+        },
+        "memory": {
+            "process_tree_rss_baseline_bytes": baseline_rss,
+            "process_tree_rss_loaded_bytes": loaded_rss,
+            "process_tree_rss_peak_bytes": sampler.peak_rss_bytes,
+            "process_tree_rss_peak_delta_bytes": max(0, sampler.peak_rss_bytes - baseline_rss),
+            "accelerators": {
+                name: {
+                    "allocated_baseline_bytes": accelerator_baseline.get(name, 0),
+                    "allocated_loaded_bytes": accelerator_loaded.get(name, 0),
+                    "allocated_peak_bytes": sampler.peak_accelerator_bytes.get(name, 0),
+                    "allocated_peak_delta_bytes": max(
+                        0, sampler.peak_accelerator_bytes.get(name, 0) - accelerator_baseline.get(name, 0)
+                    ),
+                }
+                for name in accelerator_names
+            },
+            "client_components": local_components,
+        },
+        "latency": {
+            "load_seconds": load_seconds,
+            "first_token_seconds": first_token_seconds,
+            "total_generation_seconds": generation_ended - generation_started,
+            "decode_seconds_after_first_token": decode_seconds,
+            "decode_tokens_per_second": decode_tokens / decode_seconds if decode_tokens and decode_seconds else None,
+        },
+    }

--- a/src/drift/node/keys.py
+++ b/src/drift/node/keys.py
@@ -16,6 +16,7 @@ from typing import Any, Dict, Optional, Tuple
 API_KEY_STORE_SCHEMA_VERSION = 1
 _KEY_HASH_DOMAIN = b"drift-local-api-key-v1\0"
 _KEY_ID_RE = re.compile(r"^key_[0-9a-f]{16}$")
+_CONTROL_KEY_RE = re.compile(r"^drift_control_[A-Za-z0-9_-]{43,}$")
 
 
 class ApiKeyStoreError(ValueError):
@@ -203,6 +204,14 @@ class ApiKeyStore:
                 matches = matches or active_match
             return matches
 
+    def contains(self, candidate: str) -> bool:
+        """Return whether the secret exists, including as a revoked record."""
+        if not isinstance(candidate, str) or not candidate:
+            return False
+        candidate_hash = _key_hash(candidate)
+        with self._lock:
+            return any(secrets.compare_digest(record.secret_hash, candidate_hash) for record in self._records.values())
+
     def list(self) -> Tuple[Dict[str, Any], ...]:
         with self._lock:
             return tuple(record.metadata() for record in sorted(self._records.values(), key=lambda item: item.key_id))
@@ -240,13 +249,15 @@ class ApiKeyStore:
             return record.metadata()
 
 
-def load_or_create_api_key(path: Path) -> Tuple[str, bool]:
+def _load_or_create_secret(path: Path, *, prefix: str) -> Tuple[str, bool]:
     """Load a dedicated secret file or create it atomically with private permissions.
 
     Native credential-store integration belongs to the desktop milestone. This
     headless bootstrap keeps the secret separate from ordinary JSON/TOML config and
     never writes it to application logs.
     """
+    if not isinstance(prefix, str) or not prefix:
+        raise ValueError("secret prefix must not be empty")
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
     try:
@@ -265,7 +276,7 @@ def load_or_create_api_key(path: Path) -> Tuple[str, bool]:
     if path.exists() or path.is_symlink():
         return read_existing()
 
-    key = f"drift_{secrets.token_urlsafe(32)}"
+    key = f"{prefix}{secrets.token_urlsafe(32)}"
     flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
     try:
         descriptor = os.open(path, flags, 0o600)
@@ -289,3 +300,16 @@ def load_or_create_api_key(path: Path) -> Tuple[str, bool]:
     except OSError:
         pass
     return key, True
+
+
+def load_or_create_api_key(path: Path) -> Tuple[str, bool]:
+    """Load or create a headless OpenAI client key."""
+    return _load_or_create_secret(path, prefix="drift_")
+
+
+def load_or_create_control_key(path: Path) -> Tuple[str, bool]:
+    """Load or create the privileged local control credential."""
+    key, created = _load_or_create_secret(path, prefix="drift_control_")
+    if _CONTROL_KEY_RE.fullmatch(key) is None:
+        raise ValueError("control key must use the drift_control_ key class with at least 256 bits of entropy")
+    return key, created

--- a/src/drift/node/keys.py
+++ b/src/drift/node/keys.py
@@ -1,0 +1,59 @@
+"""Local API-key persistence for the headless node bootstrap."""
+
+from __future__ import annotations
+
+import os
+import secrets
+from pathlib import Path
+from typing import Tuple
+
+
+def load_or_create_api_key(path: Path) -> Tuple[str, bool]:
+    """Load a dedicated secret file or create it atomically with private permissions.
+
+    Native credential-store integration belongs to the desktop milestone. This
+    headless bootstrap keeps the secret separate from ordinary JSON/TOML config and
+    never writes it to application logs.
+    """
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        path.parent.chmod(0o700)
+    except OSError:
+        pass
+
+    def read_existing() -> Tuple[str, bool]:
+        if path.is_symlink() or not path.is_file():
+            raise ValueError(f"API key path is not a regular file: {path}")
+        stored = path.read_text(encoding="utf-8").strip()
+        if not stored:
+            raise ValueError(f"API key file is empty: {path}")
+        return stored, False
+
+    if path.exists() or path.is_symlink():
+        return read_existing()
+
+    key = f"drift_{secrets.token_urlsafe(32)}"
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    try:
+        descriptor = os.open(path, flags, 0o600)
+    except FileExistsError:
+        return read_existing()
+
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8", newline="\n") as stream:
+            stream.write(key + "\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+    except BaseException:
+        try:
+            path.unlink()
+        except OSError:
+            pass
+        raise
+
+    try:
+        path.chmod(0o600)
+    except OSError:
+        pass
+    return key, True

--- a/src/drift/node/keys.py
+++ b/src/drift/node/keys.py
@@ -2,10 +2,242 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 import os
+import re
 import secrets
+import threading
+import time
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Tuple
+from typing import Any, Dict, Optional, Tuple
+
+API_KEY_STORE_SCHEMA_VERSION = 1
+_KEY_HASH_DOMAIN = b"drift-local-api-key-v1\0"
+_KEY_ID_RE = re.compile(r"^key_[0-9a-f]{16}$")
+
+
+class ApiKeyStoreError(ValueError):
+    pass
+
+
+class ApiKeyNotFoundError(LookupError):
+    pass
+
+
+class LastActiveKeyError(RuntimeError):
+    pass
+
+
+def _key_hash(secret: str) -> str:
+    return hashlib.sha256(_KEY_HASH_DOMAIN + secret.encode("utf-8")).hexdigest()
+
+
+@dataclass
+class _ApiKeyRecord:
+    key_id: str
+    label: str
+    secret_hash: str
+    created_at: int
+    revoked_at: Optional[int] = None
+
+    def metadata(self) -> Dict[str, Any]:
+        return {
+            "id": self.key_id,
+            "label": self.label,
+            "fingerprint": self.secret_hash[:12],
+            "created_at": self.created_at,
+            "revoked_at": self.revoked_at,
+        }
+
+
+class ApiKeyStore:
+    """Persistent labeled bearer-key hashes with atomic mutation and revocation."""
+
+    def __init__(self, path: Path | str) -> None:
+        self.path = Path(path)
+        self._lock = threading.RLock()
+        self._records = self._load()
+
+    def _load(self) -> Dict[str, _ApiKeyRecord]:
+        if not self.path.exists():
+            return {}
+        if self.path.is_symlink() or not self.path.is_file():
+            raise ApiKeyStoreError(f"API key store path is not a regular file: {self.path}")
+
+        def reject_duplicate_keys(pairs):
+            result = {}
+            for key, value in pairs:
+                if key in result:
+                    raise ApiKeyStoreError(f"API key store contains duplicate object key {key!r}")
+                result[key] = value
+            return result
+
+        try:
+            source = json.loads(self.path.read_text(encoding="utf-8"), object_pairs_hook=reject_duplicate_keys)
+        except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+            raise ApiKeyStoreError(f"Could not read API key store {self.path}: {exc}") from exc
+        if not isinstance(source, dict) or set(source) != {"schema_version", "keys"}:
+            raise ApiKeyStoreError("API key store must contain exactly schema_version and keys")
+        if (
+            isinstance(source["schema_version"], bool)
+            or not isinstance(source["schema_version"], int)
+            or source["schema_version"] != API_KEY_STORE_SCHEMA_VERSION
+        ):
+            raise ApiKeyStoreError(f"Unsupported API key store schema_version {source['schema_version']!r}")
+        if not isinstance(source["keys"], list):
+            raise ApiKeyStoreError("API key store keys must be an array")
+
+        records = {}
+        for index, item in enumerate(source["keys"]):
+            fields = {"id", "label", "secret_hash", "created_at", "revoked_at"}
+            if not isinstance(item, dict) or set(item) != fields:
+                raise ApiKeyStoreError(f"API key store keys[{index}] has invalid fields")
+            key_id, label, secret_hash = item["id"], item["label"], item["secret_hash"]
+            created_at, revoked_at = item["created_at"], item["revoked_at"]
+            if not isinstance(key_id, str) or _KEY_ID_RE.fullmatch(key_id) is None:
+                raise ApiKeyStoreError(f"API key store keys[{index}].id is invalid")
+            if not isinstance(label, str) or not label or len(label) > 64:
+                raise ApiKeyStoreError(f"API key store keys[{index}].label is invalid")
+            if (
+                not isinstance(secret_hash, str)
+                or len(secret_hash) != 64
+                or any(character not in "0123456789abcdef" for character in secret_hash)
+            ):
+                raise ApiKeyStoreError(f"API key store keys[{index}].secret_hash is invalid")
+            if isinstance(created_at, bool) or not isinstance(created_at, int) or created_at < 0:
+                raise ApiKeyStoreError(f"API key store keys[{index}].created_at is invalid")
+            if revoked_at is not None and (
+                isinstance(revoked_at, bool) or not isinstance(revoked_at, int) or revoked_at < created_at
+            ):
+                raise ApiKeyStoreError(f"API key store keys[{index}].revoked_at is invalid")
+            normalized = key_id.casefold()
+            if normalized in records:
+                raise ApiKeyStoreError(f"API key store contains duplicate id {key_id!r}")
+            records[normalized] = _ApiKeyRecord(key_id, label, secret_hash, created_at, revoked_at)
+        return records
+
+    def _write_locked(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            self.path.parent.chmod(0o700)
+        except OSError:
+            pass
+        document = {
+            "schema_version": API_KEY_STORE_SCHEMA_VERSION,
+            "keys": [
+                {
+                    "id": record.key_id,
+                    "label": record.label,
+                    "secret_hash": record.secret_hash,
+                    "created_at": record.created_at,
+                    "revoked_at": record.revoked_at,
+                }
+                for record in sorted(self._records.values(), key=lambda item: item.key_id)
+            ],
+        }
+        temporary = self.path.with_name(f".{self.path.name}.{secrets.token_hex(8)}.tmp")
+        descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        try:
+            with os.fdopen(descriptor, "w", encoding="utf-8", newline="\n") as stream:
+                json.dump(document, stream, ensure_ascii=False, allow_nan=False, separators=(",", ":"), sort_keys=True)
+                stream.write("\n")
+                stream.flush()
+                os.fsync(stream.fileno())
+            os.replace(temporary, self.path)
+            try:
+                self.path.chmod(0o600)
+            except OSError:
+                pass
+        except BaseException:
+            try:
+                temporary.unlink()
+            except OSError:
+                pass
+            raise
+
+    @staticmethod
+    def _validate_label(label: str) -> str:
+        if not isinstance(label, str) or not label.strip() or len(label) > 64:
+            raise ApiKeyStoreError("API key label must be a non-empty string of at most 64 characters")
+        return label.strip()
+
+    def ensure_key(self, secret: str, *, label: str) -> Dict[str, Any]:
+        if not isinstance(secret, str) or not secret:
+            raise ApiKeyStoreError("API key secret must not be empty")
+        label = self._validate_label(label)
+        secret_hash = _key_hash(secret)
+        with self._lock:
+            for record in self._records.values():
+                if secrets.compare_digest(record.secret_hash, secret_hash):
+                    if record.revoked_at is not None:
+                        raise ApiKeyStoreError("a revoked API key cannot be imported again")
+                    return record.metadata()
+            record = _ApiKeyRecord(
+                key_id=f"key_{secrets.token_hex(8)}",
+                label=label,
+                secret_hash=secret_hash,
+                created_at=int(time.time()),
+            )
+            self._records[record.key_id.casefold()] = record
+            try:
+                self._write_locked()
+            except BaseException:
+                self._records.pop(record.key_id.casefold(), None)
+                raise
+            return record.metadata()
+
+    def create(self, *, label: str) -> Tuple[Dict[str, Any], str]:
+        secret = f"drift_{secrets.token_urlsafe(32)}"
+        return self.ensure_key(secret, label=label), secret
+
+    def verify(self, candidate: str) -> bool:
+        if not isinstance(candidate, str) or not candidate:
+            return False
+        candidate_hash = _key_hash(candidate)
+        with self._lock:
+            matches = False
+            for record in self._records.values():
+                active_match = record.revoked_at is None and secrets.compare_digest(record.secret_hash, candidate_hash)
+                matches = matches or active_match
+            return matches
+
+    def list(self) -> Tuple[Dict[str, Any], ...]:
+        with self._lock:
+            return tuple(record.metadata() for record in sorted(self._records.values(), key=lambda item: item.key_id))
+
+    def update_label(self, key_id: str, *, label: str) -> Dict[str, Any]:
+        label = self._validate_label(label)
+        with self._lock:
+            record = self._records.get(key_id.casefold())
+            if record is None:
+                raise ApiKeyNotFoundError(f"unknown API key {key_id!r}")
+            previous_label = record.label
+            record.label = label
+            try:
+                self._write_locked()
+            except BaseException:
+                record.label = previous_label
+                raise
+            return record.metadata()
+
+    def revoke(self, key_id: str) -> Dict[str, Any]:
+        with self._lock:
+            record = self._records.get(key_id.casefold())
+            if record is None:
+                raise ApiKeyNotFoundError(f"unknown API key {key_id!r}")
+            if record.revoked_at is not None:
+                return record.metadata()
+            if sum(item.revoked_at is None for item in self._records.values()) <= 1:
+                raise LastActiveKeyError("cannot revoke the last active API key")
+            record.revoked_at = int(time.time())
+            try:
+                self._write_locked()
+            except BaseException:
+                record.revoked_at = None
+                raise
+            return record.metadata()
 
 
 def load_or_create_api_key(path: Path) -> Tuple[str, bool]:

--- a/src/drift/node/loading.py
+++ b/src/drift/node/loading.py
@@ -1,0 +1,105 @@
+"""Lazy construction and cleanup of manifested client runtimes."""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+from typing import Callable, Optional, Sequence
+
+from hivemind.utils.logging import get_logger
+
+from drift.model_manifest import ManifestArtifactVerifier, ModelManifest
+from drift.node.model_manager import ModelRuntime
+from drift.node.route_health import sequence_manager_route_health
+
+logger = get_logger(__name__)
+
+
+def make_manifest_loader(
+    manifest: ModelManifest,
+    *,
+    initial_peers: Sequence[str],
+    token: Optional[str] = None,
+    cache_dir: Optional[str] = None,
+    revocation_files: Sequence[str] = (),
+    request_timeout: float = 30,
+    max_retries: int = 3,
+) -> Callable[[], ModelRuntime]:
+    """Return a lazy loader pinned to one exact manifest and swarm namespace."""
+
+    def load() -> ModelRuntime:
+        import torch
+        from transformers import AutoTokenizer
+
+        from drift import AutoDistributedModelForCausalLM
+
+        verifier = ManifestArtifactVerifier(
+            manifest,
+            repository=manifest.source.repository,
+            revision=manifest.source.revision,
+            token=token,
+            cache_dir=cache_dir,
+        )
+        verifier.ensure_startup_metadata(include_tokenizer=True)
+        logger.info(f"Loading tokenizer and client-side weights for {manifest.digest_id}")
+        tokenizer = AutoTokenizer.from_pretrained(verifier.snapshot_root, local_files_only=True)
+        model = AutoDistributedModelForCausalLM.from_pretrained(
+            manifest.source.repository,
+            initial_peers=list(initial_peers),
+            dht_prefix=manifest.dht_prefix,
+            revision=manifest.source.revision,
+            manifest_digest=manifest.digest,
+            manifest_execution_profile=manifest.runtime.to_dict(),
+            revocation_files=[str(Path(path)) for path in revocation_files],
+            torch_dtype=getattr(torch, manifest.runtime.dtype),
+            token=token,
+            cache_dir=cache_dir,
+            request_timeout=request_timeout,
+            max_retries=max_retries,
+            max_backoff=5,
+            artifact_verifier=verifier,
+        )
+        return ModelRuntime(
+            model=model,
+            tokenizer=tokenizer,
+            close=_runtime_closer(model),
+            route_health=_runtime_route_observer(model),
+        )
+
+    return load
+
+
+def _runtime_closer(model) -> Callable[[], None]:
+    """Build an idempotent closer for a distributed Transformers client."""
+    lock = threading.Lock()
+    closed = False
+
+    def close() -> None:
+        nonlocal closed
+        with lock:
+            if closed:
+                return
+            closed = True
+
+        try:
+            remote_layers = model.transformer.h
+            sequence_manager = remote_layers.sequence_manager
+        except AttributeError:
+            logger.warning("Loaded model has no DRIFT sequence manager to shut down")
+            return
+
+        try:
+            sequence_manager.shutdown()
+        finally:
+            dht = getattr(sequence_manager, "dht", None)
+            if dht is not None and dht.is_alive():
+                dht.shutdown()
+
+    return close
+
+
+def _runtime_route_observer(model) -> Callable[[], dict]:
+    """Build a cheap observer over the loaded client's last routing snapshot."""
+    remote_layers = model.transformer.h
+    sequence_manager = remote_layers.sequence_manager
+    return lambda: sequence_manager_route_health(sequence_manager)

--- a/src/drift/node/loading.py
+++ b/src/drift/node/loading.py
@@ -102,4 +102,11 @@ def _runtime_route_observer(model) -> Callable[[], dict]:
     """Build a cheap observer over the loaded client's last routing snapshot."""
     remote_layers = model.transformer.h
     sequence_manager = remote_layers.sequence_manager
-    return lambda: sequence_manager_route_health(sequence_manager)
+
+    def observe() -> dict:
+        result = sequence_manager_route_health(sequence_manager)
+        result["source"] = "runtime"
+        result["last_error"] = None
+        return result
+
+    return observe

--- a/src/drift/node/model_manager.py
+++ b/src/drift/node/model_manager.py
@@ -156,6 +156,7 @@ class LoadedModel:
 class _ModelRecord:
     descriptor: ModelDescriptor
     loader: Callable[[], ModelRuntime]
+    route_health: Optional[Callable[[], Dict[str, Any]]] = None
     state: ModelState = ModelState.KNOWN
     runtime: Optional[ModelRuntime] = None
     last_error: Optional[str] = None
@@ -179,9 +180,16 @@ class ModelManager:
         self._lock = threading.RLock()
         self._capacity_changed = threading.Condition(self._lock)
         self._max_loaded_models = max_loaded_models
+        self._shutdown_callbacks: list[Callable[[], None]] = []
         self._closed = False
 
-    def register(self, descriptor: ModelDescriptor, loader: Callable[[], ModelRuntime]) -> None:
+    def register(
+        self,
+        descriptor: ModelDescriptor,
+        loader: Callable[[], ModelRuntime],
+        *,
+        route_health: Optional[Callable[[], Dict[str, Any]]] = None,
+    ) -> None:
         """Register a lazy runtime and reject every ambiguous alias up front."""
         if not callable(loader):
             raise TypeError("loader must be callable")
@@ -192,14 +200,32 @@ class ModelManager:
             conflicts = [value for value in identifiers if value.casefold() in self._identifiers]
             if conflicts:
                 raise ValueError(f"model identifier already registered: {conflicts[0]!r}")
-            self._records[descriptor.model_id] = _ModelRecord(descriptor=descriptor, loader=loader)
+            self._records[descriptor.model_id] = _ModelRecord(
+                descriptor=descriptor,
+                loader=loader,
+                route_health=route_health,
+            )
             for value in identifiers:
                 self._identifiers[value.casefold()] = descriptor.model_id
 
-    def register_manifest(self, manifest: ModelManifest, loader: Callable[[], ModelRuntime]) -> ModelDescriptor:
+    def register_manifest(
+        self,
+        manifest: ModelManifest,
+        loader: Callable[[], ModelRuntime],
+        *,
+        route_health: Optional[Callable[[], Dict[str, Any]]] = None,
+    ) -> ModelDescriptor:
         descriptor = ModelDescriptor.from_manifest(manifest)
-        self.register(descriptor, loader)
+        self.register(descriptor, loader, route_health=route_health)
         return descriptor
+
+    def add_shutdown_callback(self, callback: Callable[[], None]) -> None:
+        if not callable(callback):
+            raise TypeError("shutdown callback must be callable")
+        with self._lock:
+            if self._closed:
+                raise ModelManagerClosedError("model manager is shutting down")
+            self._shutdown_callbacks.append(callback)
 
     def register_loaded(
         self, model_id: str, model: Any, tokenizer: Any, *, aliases: Iterable[str] = ()
@@ -430,9 +456,12 @@ class ModelManager:
             for record in sorted(self._records.values(), key=lambda item: item.descriptor.model_id.casefold()):
                 route = None
                 state = record.state
-                if record.runtime is not None and record.runtime.route_health is not None:
+                route_reader = record.runtime.route_health if record.runtime is not None else None
+                if route_reader is None:
+                    route_reader = record.route_health
+                if route_reader is not None:
                     try:
-                        route = record.runtime.route_health()
+                        route = route_reader()
                     except Exception:
                         logger.exception("Failed to read route health for model %r", record.descriptor.model_id)
                         route = {"status": "unknown"}
@@ -461,6 +490,8 @@ class ModelManager:
                 return
             self._closed = True
             records = tuple(self._records.values())
+            shutdown_callbacks = tuple(self._shutdown_callbacks)
+            self._shutdown_callbacks.clear()
             for record in records:
                 record.state = ModelState.STOPPING
             self._capacity_changed.notify_all()
@@ -477,6 +508,12 @@ class ModelManager:
                         # Shutdown is best-effort across every configured model. A failed
                         # closer must not prevent later runtimes from releasing their DHTs.
                         logger.exception("Failed to close model runtime %r", record.descriptor.model_id)
+
+        for callback in shutdown_callbacks:
+            try:
+                callback()
+            except Exception:
+                logger.exception("Failed to close a model-manager service")
 
     def residency(self) -> Dict[str, Optional[int]]:
         """Return a stable runtime-budget snapshot for the control API."""

--- a/src/drift/node/model_manager.py
+++ b/src/drift/node/model_manager.py
@@ -1,0 +1,492 @@
+"""Thread-safe model registration, exact selection, and lazy runtime loading.
+
+One ``ModelManager`` is owned by the local node daemon.  The HTTP layer asks it to
+resolve each OpenAI ``model`` value, while the manager serializes first-load work per
+manifest and exposes a stable state snapshot to the local control API.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Callable, Dict, Iterable, Optional, Tuple
+
+from drift.model_manifest import ModelManifest
+
+logger = logging.getLogger(__name__)
+
+
+class ModelState(str, Enum):
+    KNOWN = "known"
+    DOWNLOADING = "downloading"
+    LOADING = "loading"
+    READY = "ready"
+    DEGRADED = "degraded"
+    UNAVAILABLE = "unavailable"
+    UNLOADING = "unloading"
+    STOPPING = "stopping"
+
+
+class ModelNotFoundError(LookupError):
+    """The requested identifier does not name a configured model."""
+
+
+class AmbiguousModelError(ModelNotFoundError):
+    """No model was requested and the manager has more than one choice."""
+
+
+class ModelManagerClosedError(RuntimeError):
+    """The node has started shutting down and will not load more models."""
+
+
+class ModelInUseError(RuntimeError):
+    """A resident model cannot be unloaded while requests still hold it."""
+
+
+class ModelUnloadError(RuntimeError):
+    """A resident runtime could not be released cleanly."""
+
+
+@dataclass(frozen=True)
+class ModelRuntime:
+    """The client-side objects required to serve one model."""
+
+    model: Any
+    tokenizer: Any
+    close: Optional[Callable[[], None]] = None
+    route_health: Optional[Callable[[], Dict[str, Any]]] = None
+
+
+@dataclass(frozen=True)
+class ModelDescriptor:
+    """Immutable identity and display metadata for one configured model."""
+
+    model_id: str
+    aliases: Tuple[str, ...] = ()
+    manifest_digest: Optional[str] = None
+    repository: Optional[str] = None
+    name: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        identifiers = (self.model_id, *self.aliases)
+        if any(not isinstance(value, str) or not value.strip() for value in identifiers):
+            raise ValueError("model identifiers must be non-empty strings")
+        normalized = [value.casefold() for value in identifiers]
+        if len(set(normalized)) != len(normalized):
+            raise ValueError("model id and aliases must be unique when compared case-insensitively")
+
+    @classmethod
+    def from_manifest(cls, manifest: ModelManifest) -> "ModelDescriptor":
+        # The manifest name is stable and human-readable. All declared API aliases and the
+        # content digest resolve to the same record, but are never silently mapped elsewhere.
+        aliases = tuple((*manifest.aliases, manifest.digest_id))
+        return cls(
+            model_id=manifest.name,
+            aliases=aliases,
+            manifest_digest=manifest.digest_id,
+            repository=manifest.source.repository,
+            name=manifest.name,
+        )
+
+
+@dataclass(frozen=True)
+class ModelSnapshot:
+    model_id: str
+    aliases: Tuple[str, ...]
+    manifest_digest: Optional[str]
+    repository: Optional[str]
+    state: ModelState
+    last_error: Optional[str]
+    loaded_at: Optional[float]
+    last_used_at: Optional[float]
+    active_requests: int
+    route: Optional[Dict[str, Any]]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.model_id,
+            "aliases": list(self.aliases),
+            "manifest_digest": self.manifest_digest,
+            "repository": self.repository,
+            "state": self.state.value,
+            "last_error": self.last_error,
+            "loaded_at": self.loaded_at,
+            "last_used_at": self.last_used_at,
+            "active_requests": self.active_requests,
+            "route": self.route,
+        }
+
+
+@dataclass
+class LoadedModel:
+    """A request-scoped lease on one loaded runtime.
+
+    Call :meth:`release` when the request is finished, or use the object as a
+    context manager. The lease is idempotent so error and cancellation paths may
+    release defensively without corrupting the manager's active-request count.
+    """
+
+    descriptor: ModelDescriptor
+    runtime: ModelRuntime
+    _release_callback: Optional[Callable[[], None]] = field(default=None, repr=False)
+    _released: bool = field(default=False, init=False, repr=False)
+    _release_lock: threading.Lock = field(default_factory=threading.Lock, init=False, repr=False)
+
+    def release(self) -> None:
+        with self._release_lock:
+            if self._released:
+                return
+            self._released = True
+            callback = self._release_callback
+            self._release_callback = None
+        if callback is not None:
+            callback()
+
+    def __enter__(self) -> "LoadedModel":
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        self.release()
+
+
+@dataclass
+class _ModelRecord:
+    descriptor: ModelDescriptor
+    loader: Callable[[], ModelRuntime]
+    state: ModelState = ModelState.KNOWN
+    runtime: Optional[ModelRuntime] = None
+    last_error: Optional[str] = None
+    loaded_at: Optional[float] = None
+    last_used_at: Optional[float] = None
+    active_requests: int = 0
+    close_failed: bool = False
+    load_lock: threading.Lock = field(default_factory=threading.Lock)
+
+
+class ModelManager:
+    """Own configured model identities and their lazily loaded client runtimes."""
+
+    def __init__(self, *, max_loaded_models: Optional[int] = None) -> None:
+        if max_loaded_models is not None and (
+            isinstance(max_loaded_models, bool) or not isinstance(max_loaded_models, int) or max_loaded_models < 1
+        ):
+            raise ValueError("max_loaded_models must be None or an integer >= 1")
+        self._records: Dict[str, _ModelRecord] = {}
+        self._identifiers: Dict[str, str] = {}
+        self._lock = threading.RLock()
+        self._capacity_changed = threading.Condition(self._lock)
+        self._max_loaded_models = max_loaded_models
+        self._closed = False
+
+    def register(self, descriptor: ModelDescriptor, loader: Callable[[], ModelRuntime]) -> None:
+        """Register a lazy runtime and reject every ambiguous alias up front."""
+        if not callable(loader):
+            raise TypeError("loader must be callable")
+        identifiers = (descriptor.model_id, *descriptor.aliases)
+        with self._lock:
+            if self._closed:
+                raise ModelManagerClosedError("model manager is shutting down")
+            conflicts = [value for value in identifiers if value.casefold() in self._identifiers]
+            if conflicts:
+                raise ValueError(f"model identifier already registered: {conflicts[0]!r}")
+            self._records[descriptor.model_id] = _ModelRecord(descriptor=descriptor, loader=loader)
+            for value in identifiers:
+                self._identifiers[value.casefold()] = descriptor.model_id
+
+    def register_manifest(self, manifest: ModelManifest, loader: Callable[[], ModelRuntime]) -> ModelDescriptor:
+        descriptor = ModelDescriptor.from_manifest(manifest)
+        self.register(descriptor, loader)
+        return descriptor
+
+    def register_loaded(
+        self, model_id: str, model: Any, tokenizer: Any, *, aliases: Iterable[str] = ()
+    ) -> ModelDescriptor:
+        """Adapt the existing single-model API to the manager without reloading it."""
+        descriptor = ModelDescriptor(model_id=model_id, aliases=tuple(aliases), name=model_id)
+        runtime = ModelRuntime(model=model, tokenizer=tokenizer)
+        self.register(descriptor, lambda: runtime)
+        record = self._record_for(model_id)
+        with self._lock:
+            record.runtime = runtime
+            record.state = ModelState.READY
+            now = time.time()
+            record.loaded_at = now
+            record.last_used_at = now
+        return descriptor
+
+    def _record_for(self, identifier: Optional[str]) -> _ModelRecord:
+        with self._lock:
+            if self._closed:
+                raise ModelManagerClosedError("model manager is shutting down")
+            if identifier is None:
+                if len(self._records) == 1:
+                    return next(iter(self._records.values()))
+                if not self._records:
+                    raise ModelNotFoundError("no models are configured")
+                raise AmbiguousModelError("model is required when more than one model is configured")
+            model_id = self._identifiers.get(identifier.casefold())
+            if model_id is None:
+                raise ModelNotFoundError(f"unknown model {identifier!r}")
+            return self._records[model_id]
+
+    def resolve(self, identifier: Optional[str]) -> ModelDescriptor:
+        return self._record_for(identifier).descriptor
+
+    def _resident_count_locked(self) -> int:
+        return sum(
+            record.runtime is not None or record.state in (ModelState.LOADING, ModelState.UNLOADING)
+            for record in self._records.values()
+        )
+
+    @staticmethod
+    def _close_runtime(runtime: ModelRuntime) -> None:
+        if runtime.close is not None:
+            runtime.close()
+
+    def _reserve_runtime_slot(self, target: _ModelRecord) -> None:
+        """Reserve bounded residency, evicting the least-recent idle runtime."""
+        while True:
+            candidate: Optional[_ModelRecord] = None
+            candidate_runtime: Optional[ModelRuntime] = None
+            with self._capacity_changed:
+                if self._closed:
+                    raise ModelManagerClosedError("model manager is shutting down")
+                if self._max_loaded_models is None or self._resident_count_locked() < self._max_loaded_models:
+                    target.state = ModelState.LOADING
+                    target.last_error = None
+                    self._capacity_changed.notify_all()
+                    return
+
+                idle = [
+                    record
+                    for record in self._records.values()
+                    if record is not target
+                    and record.runtime is not None
+                    and record.active_requests == 0
+                    and record.state in (ModelState.READY, ModelState.DEGRADED)
+                ]
+                if idle:
+                    candidate = min(
+                        idle,
+                        key=lambda record: (
+                            record.last_used_at if record.last_used_at is not None else float("-inf"),
+                            record.descriptor.model_id.casefold(),
+                        ),
+                    )
+                    candidate_runtime = candidate.runtime
+                    candidate.runtime = None
+                    candidate.state = ModelState.UNLOADING
+                else:
+                    failed_cleanup = next(
+                        (record for record in self._records.values() if record.close_failed),
+                        None,
+                    )
+                    if failed_cleanup is not None:
+                        raise ModelUnloadError(
+                            f"runtime budget is blocked by failed cleanup for "
+                            f"{failed_cleanup.descriptor.model_id!r}; restart the node"
+                        )
+                    self._capacity_changed.wait()
+                    continue
+
+            assert candidate is not None and candidate_runtime is not None
+            try:
+                self._close_runtime(candidate_runtime)
+            except Exception as exc:
+                with self._capacity_changed:
+                    candidate.runtime = candidate_runtime
+                    candidate.state = ModelState.UNAVAILABLE
+                    candidate.close_failed = True
+                    candidate.last_error = f"{type(exc).__name__}: {exc}"
+                    self._capacity_changed.notify_all()
+                raise ModelUnloadError(
+                    f"could not evict model {candidate.descriptor.model_id!r}: {type(exc).__name__}: {exc}"
+                ) from exc
+            else:
+                with self._capacity_changed:
+                    candidate.state = ModelState.KNOWN
+                    candidate.loaded_at = None
+                    candidate.close_failed = False
+                    candidate.last_error = None
+                    self._capacity_changed.notify_all()
+
+    def _lease_locked(self, record: _ModelRecord, runtime: ModelRuntime) -> LoadedModel:
+        record.active_requests += 1
+        record.last_used_at = time.time()
+        return LoadedModel(
+            descriptor=record.descriptor,
+            runtime=runtime,
+            _release_callback=lambda: self._release_lease(record),
+        )
+
+    def _release_lease(self, record: _ModelRecord) -> None:
+        with self._capacity_changed:
+            if record.active_requests > 0:
+                record.active_requests -= 1
+                record.last_used_at = time.time()
+            self._capacity_changed.notify_all()
+
+    def load(self, identifier: Optional[str]) -> LoadedModel:
+        """Acquire a ready runtime, invoking at most one loader at a time per model.
+
+        Failed models remain visible as ``unavailable``. A later request retries the loader,
+        allowing a temporarily missing artifact or route to recover without restarting the node.
+        The returned lease must be released when the request finishes.
+        """
+        record = self._record_for(identifier)
+        with record.load_lock:
+            with self._lock:
+                if self._closed:
+                    raise ModelManagerClosedError("model manager is shutting down")
+                if record.runtime is not None:
+                    if record.close_failed:
+                        raise ModelUnloadError(
+                            f"model {record.descriptor.model_id!r} has a runtime that failed cleanup; restart the node"
+                        )
+                    return self._lease_locked(record, record.runtime)
+            self._reserve_runtime_slot(record)
+            try:
+                runtime = record.loader()
+                if not isinstance(runtime, ModelRuntime):
+                    raise TypeError("model loader must return ModelRuntime")
+            except BaseException as exc:
+                with self._lock:
+                    record.state = ModelState.STOPPING if self._closed else ModelState.UNAVAILABLE
+                    record.last_error = f"{type(exc).__name__}: {exc}"
+                    self._capacity_changed.notify_all()
+                raise
+            with self._lock:
+                if self._closed:
+                    record.state = ModelState.STOPPING
+                else:
+                    record.runtime = runtime
+                    record.state = ModelState.READY
+                    record.close_failed = False
+                    now = time.time()
+                    record.loaded_at = now
+                    record.last_used_at = now
+                    lease = self._lease_locked(record, runtime)
+                    self._capacity_changed.notify_all()
+                    return lease
+
+            # Shutdown won the race with a slow loader. Release the newly created runtime
+            # instead of publishing it after the node stopped accepting work.
+            if runtime.close is not None:
+                runtime.close()
+            raise ModelManagerClosedError("model manager shut down while the model was loading")
+
+    def unload(self, identifier: str) -> bool:
+        """Unload one idle runtime.
+
+        Returns ``False`` when the model is configured but not resident. An active
+        request is a hard conflict: callers must retry after the lease is released.
+        """
+        record = self._record_for(identifier)
+        with record.load_lock:
+            with self._capacity_changed:
+                if self._closed:
+                    raise ModelManagerClosedError("model manager is shutting down")
+                if record.active_requests:
+                    raise ModelInUseError(
+                        f"model {record.descriptor.model_id!r} has {record.active_requests} active request(s)"
+                    )
+                if record.close_failed:
+                    raise ModelUnloadError(
+                        f"model {record.descriptor.model_id!r} has a runtime that failed cleanup; restart the node"
+                    )
+                runtime = record.runtime
+                if runtime is None:
+                    return False
+                record.runtime = None
+                record.state = ModelState.UNLOADING
+
+            try:
+                self._close_runtime(runtime)
+            except Exception as exc:
+                with self._capacity_changed:
+                    record.runtime = runtime
+                    record.state = ModelState.UNAVAILABLE
+                    record.close_failed = True
+                    record.last_error = f"{type(exc).__name__}: {exc}"
+                    self._capacity_changed.notify_all()
+                raise ModelUnloadError(
+                    f"could not unload model {record.descriptor.model_id!r}: {type(exc).__name__}: {exc}"
+                ) from exc
+
+            with self._capacity_changed:
+                record.state = ModelState.KNOWN
+                record.loaded_at = None
+                record.close_failed = False
+                record.last_error = None
+                self._capacity_changed.notify_all()
+            return True
+
+    def snapshots(self) -> Tuple[ModelSnapshot, ...]:
+        with self._lock:
+            snapshots = []
+            for record in sorted(self._records.values(), key=lambda item: item.descriptor.model_id.casefold()):
+                route = None
+                state = record.state
+                if record.runtime is not None and record.runtime.route_health is not None:
+                    try:
+                        route = record.runtime.route_health()
+                    except Exception:
+                        logger.exception("Failed to read route health for model %r", record.descriptor.model_id)
+                        route = {"status": "unknown"}
+                    if state is ModelState.READY and route.get("status") != "complete":
+                        state = ModelState.DEGRADED
+                snapshots.append(
+                    ModelSnapshot(
+                        model_id=record.descriptor.model_id,
+                        aliases=record.descriptor.aliases,
+                        manifest_digest=record.descriptor.manifest_digest,
+                        repository=record.descriptor.repository,
+                        state=state,
+                        last_error=record.last_error,
+                        loaded_at=record.loaded_at,
+                        last_used_at=record.last_used_at,
+                        active_requests=record.active_requests,
+                        route=route,
+                    )
+                )
+            return tuple(snapshots)
+
+    def shutdown(self) -> None:
+        """Stop accepting loads and release every initialized runtime once."""
+        with self._lock:
+            if self._closed:
+                return
+            self._closed = True
+            records = tuple(self._records.values())
+            for record in records:
+                record.state = ModelState.STOPPING
+            self._capacity_changed.notify_all()
+
+        for record in records:
+            # Synchronize with an in-flight loader before touching its runtime.
+            with record.load_lock:
+                runtime = record.runtime
+                record.runtime = None
+                if runtime is not None and runtime.close is not None:
+                    try:
+                        runtime.close()
+                    except Exception:
+                        # Shutdown is best-effort across every configured model. A failed
+                        # closer must not prevent later runtimes from releasing their DHTs.
+                        logger.exception("Failed to close model runtime %r", record.descriptor.model_id)
+
+    def residency(self) -> Dict[str, Optional[int]]:
+        """Return a stable runtime-budget snapshot for the control API."""
+        with self._lock:
+            return {
+                "max_loaded_models": self._max_loaded_models,
+                "resident_models": self._resident_count_locked(),
+            }
+
+    @property
+    def closed(self) -> bool:
+        with self._lock:
+            return self._closed

--- a/src/drift/node/route_health.py
+++ b/src/drift/node/route_health.py
@@ -3,7 +3,42 @@
 from __future__ import annotations
 
 import time
-from typing import Any, Dict
+from typing import Any, Dict, Sequence
+
+from drift.data_structures import RemoteModuleInfo, ServerState
+
+
+def _coverage_health(replica_sets: Sequence[set], *, updated_age: float) -> Dict[str, Any]:
+    peer_ids = set()
+    replica_counts = []
+    missing_blocks = []
+    for block_index, block_peers in enumerate(replica_sets):
+        replica_counts.append(len(block_peers))
+        peer_ids.update(block_peers)
+        if not block_peers:
+            missing_blocks.append(block_index)
+
+    total_blocks = len(replica_sets)
+    covered_blocks = total_blocks - len(missing_blocks)
+    return {
+        "status": "complete" if not missing_blocks else "incomplete",
+        "total_blocks": total_blocks,
+        "covered_blocks": covered_blocks,
+        "missing_blocks": missing_blocks,
+        "minimum_replicas": min(replica_counts, default=0),
+        "replica_counts": replica_counts,
+        "peer_count": len(peer_ids),
+        "last_updated_age": max(0.0, updated_age),
+    }
+
+
+def module_infos_route_health(module_infos: Sequence[RemoteModuleInfo]) -> Dict[str, Any]:
+    """Summarize verified DHT module records for lightweight discovery."""
+    replica_sets = [
+        {peer_id for peer_id, server_info in module_info.servers.items() if server_info.state is ServerState.ONLINE}
+        for module_info in module_infos
+    ]
+    return _coverage_health(replica_sets, updated_age=0.0)
 
 
 def sequence_manager_route_health(sequence_manager) -> Dict[str, Any]:
@@ -28,24 +63,5 @@ def sequence_manager_route_health(sequence_manager) -> Dict[str, Any]:
                 "last_updated_age": None,
             }
 
-        peer_ids = set()
-        replica_counts = []
-        missing_blocks = []
-        for block_index, spans in enumerate(sequence_info.spans_containing_block):
-            block_peers = {span.peer_id for span in spans}
-            replica_counts.append(len(block_peers))
-            peer_ids.update(block_peers)
-            if not block_peers:
-                missing_blocks.append(block_index)
-
-        covered_blocks = total_blocks - len(missing_blocks)
-        return {
-            "status": "complete" if not missing_blocks else "incomplete",
-            "total_blocks": total_blocks,
-            "covered_blocks": covered_blocks,
-            "missing_blocks": missing_blocks,
-            "minimum_replicas": min(replica_counts, default=0),
-            "replica_counts": replica_counts,
-            "peer_count": len(peer_ids),
-            "last_updated_age": max(0.0, time.perf_counter() - sequence_info.last_updated_time),
-        }
+        replica_sets = [{span.peer_id for span in spans} for spans in sequence_info.spans_containing_block]
+        return _coverage_health(replica_sets, updated_age=time.perf_counter() - sequence_info.last_updated_time)

--- a/src/drift/node/route_health.py
+++ b/src/drift/node/route_health.py
@@ -1,0 +1,51 @@
+"""Read-only route coverage snapshots from a loaded client sequence manager."""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Dict
+
+
+def sequence_manager_route_health(sequence_manager) -> Dict[str, Any]:
+    """Summarize the sequence manager's last verified DHT view without refreshing it.
+
+    The control API must stay cheap and side-effect free. A status request therefore
+    reads the routing thread's existing snapshot; it never starts downloads, probes,
+    or DHT traffic itself.
+    """
+    with sequence_manager.lock_changes:
+        sequence_info = sequence_manager.state.sequence_info
+        total_blocks = len(sequence_info.block_uids)
+        if sequence_info.last_updated_time is None:
+            return {
+                "status": "unknown",
+                "total_blocks": total_blocks,
+                "covered_blocks": None,
+                "missing_blocks": None,
+                "minimum_replicas": None,
+                "replica_counts": None,
+                "peer_count": None,
+                "last_updated_age": None,
+            }
+
+        peer_ids = set()
+        replica_counts = []
+        missing_blocks = []
+        for block_index, spans in enumerate(sequence_info.spans_containing_block):
+            block_peers = {span.peer_id for span in spans}
+            replica_counts.append(len(block_peers))
+            peer_ids.update(block_peers)
+            if not block_peers:
+                missing_blocks.append(block_index)
+
+        covered_blocks = total_blocks - len(missing_blocks)
+        return {
+            "status": "complete" if not missing_blocks else "incomplete",
+            "total_blocks": total_blocks,
+            "covered_blocks": covered_blocks,
+            "missing_blocks": missing_blocks,
+            "minimum_replicas": min(replica_counts, default=0),
+            "replica_counts": replica_counts,
+            "peer_count": len(peer_ids),
+            "last_updated_age": max(0.0, time.perf_counter() - sequence_info.last_updated_time),
+        }

--- a/src/drift/node/server.py
+++ b/src/drift/node/server.py
@@ -5,12 +5,13 @@ from __future__ import annotations
 import asyncio
 import secrets
 import time
-from typing import List
+from typing import List, Optional
 
 from fastapi import HTTPException, Request
 from pydantic import BaseModel
 
 from drift.api.server import create_app
+from drift.node.keys import ApiKeyNotFoundError, ApiKeyStore, ApiKeyStoreError, LastActiveKeyError
 from drift.node.model_manager import (
     ModelInUseError,
     ModelManager,
@@ -18,6 +19,7 @@ from drift.node.model_manager import (
     ModelNotFoundError,
     ModelUnloadError,
 )
+from drift.node.worker_supervisor import WorkerNotFoundError, WorkerSupervisor
 
 CONTROL_API_VERSION = 1
 
@@ -26,21 +28,34 @@ class ModelUnloadRequest(BaseModel):
     model: str
 
 
+class ApiKeyCreateRequest(BaseModel):
+    label: str
+
+
+class ApiKeyUpdateRequest(BaseModel):
+    label: str
+
+
 def create_node_app(
     model_manager: ModelManager,
     *,
-    api_keys: List[str],
+    api_keys: Optional[List[str]] = None,
+    api_key_store: Optional[ApiKeyStore] = None,
     host: str = "127.0.0.1",
     port: int = 8080,
     max_concurrent: int = 1,
     default_max_tokens: int = 512,
+    worker_supervisor: Optional[WorkerSupervisor] = None,
 ):
     """Compose the OpenAI API and authenticated local control surface."""
-    if not api_keys or any(not isinstance(key, str) or not key for key in api_keys):
-        raise ValueError("the node control API requires at least one non-empty API key")
+    if api_key_store is None and (not api_keys or any(not isinstance(key, str) or not key for key in api_keys)):
+        raise ValueError("the node control API requires an API key store or at least one non-empty API key")
+    if api_key_store is not None and api_keys:
+        raise ValueError("pass either api_key_store or api_keys, not both")
     app = create_app(
         model_manager=model_manager,
         api_keys=api_keys,
+        api_key_verifier=api_key_store.verify if api_key_store is not None else None,
         max_concurrent=max_concurrent,
         default_max_tokens=default_max_tokens,
     )
@@ -49,7 +64,12 @@ def create_node_app(
     def check_auth(request: Request) -> None:
         auth = request.headers.get("authorization", "")
         candidate = auth[len("Bearer ") :] if auth.startswith("Bearer ") else ""
-        if not any(secrets.compare_digest(candidate, key) for key in api_keys):
+        valid = (
+            api_key_store.verify(candidate)
+            if api_key_store is not None
+            else any(secrets.compare_digest(candidate, key) for key in api_keys)
+        )
+        if not valid:
             raise HTTPException(status_code=401, detail="Invalid API key")
 
     @app.get("/control/v1/status")
@@ -62,6 +82,7 @@ def create_node_app(
             "openai_base_url": f"http://{'[' + host + ']' if ':' in host else host}:{port}/v1",
             "runtime_budget": model_manager.residency(),
             "models": [snapshot.to_dict() for snapshot in model_manager.snapshots()],
+            "workers": list(worker_supervisor.snapshots()) if worker_supervisor is not None else [],
         }
 
     @app.post("/control/v1/models/unload")
@@ -83,6 +104,87 @@ def create_node_app(
             raise HTTPException(status_code=503, detail=str(exc)) from exc
         return {"model": descriptor.model_id, "unloaded": unloaded}
 
+    @app.get("/control/v1/workers")
+    async def list_workers(request: Request):
+        check_auth(request)
+        return {"workers": list(worker_supervisor.snapshots()) if worker_supervisor is not None else []}
+
+    def require_key_store() -> ApiKeyStore:
+        if api_key_store is None:
+            raise HTTPException(status_code=501, detail="persistent API-key management is not configured")
+        return api_key_store
+
+    @app.get("/control/v1/keys")
+    async def list_api_keys(request: Request):
+        check_auth(request)
+        return {"keys": list(require_key_store().list())}
+
+    @app.post("/control/v1/keys", status_code=201)
+    async def create_api_key(body: ApiKeyCreateRequest, request: Request):
+        check_auth(request)
+        try:
+            metadata, secret = require_key_store().create(label=body.label)
+        except ApiKeyStoreError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
+        return {"key": metadata, "secret": secret}
+
+    @app.delete("/control/v1/keys/{key_id}")
+    async def revoke_api_key(key_id: str, request: Request):
+        check_auth(request)
+        try:
+            metadata = require_key_store().revoke(key_id)
+        except ApiKeyNotFoundError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        except LastActiveKeyError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+        return {"key": metadata}
+
+    @app.patch("/control/v1/keys/{key_id}")
+    async def update_api_key(key_id: str, body: ApiKeyUpdateRequest, request: Request):
+        check_auth(request)
+        try:
+            metadata = require_key_store().update_label(key_id, label=body.label)
+        except ApiKeyNotFoundError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        except ApiKeyStoreError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
+        return {"key": metadata}
+
+    async def worker_action(worker_id: str, action: str):
+        if worker_supervisor is None:
+            raise HTTPException(status_code=404, detail="no contribution workers are configured")
+        try:
+            loop = asyncio.get_running_loop()
+            operation = {
+                "start": worker_supervisor.start_worker,
+                "pause": worker_supervisor.pause_worker,
+                "restart": worker_supervisor.restart_worker,
+            }[action]
+            changed = await loop.run_in_executor(None, operation, worker_id)
+            snapshot = worker_supervisor.snapshot(worker_id)
+        except WorkerNotFoundError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        except RuntimeError as exc:
+            raise HTTPException(status_code=503, detail=str(exc)) from exc
+        return {"changed": changed, "worker": snapshot}
+
+    @app.post("/control/v1/workers/{worker_id}/start")
+    async def start_worker(worker_id: str, request: Request):
+        check_auth(request)
+        return await worker_action(worker_id, "start")
+
+    @app.post("/control/v1/workers/{worker_id}/pause")
+    async def pause_worker(worker_id: str, request: Request):
+        check_auth(request)
+        return await worker_action(worker_id, "pause")
+
+    @app.post("/control/v1/workers/{worker_id}/restart")
+    async def restart_worker(worker_id: str, request: Request):
+        check_auth(request)
+        return await worker_action(worker_id, "restart")
+
+    if worker_supervisor is not None:
+        app.router.add_event_handler("shutdown", worker_supervisor.shutdown)
     app.router.add_event_handler("shutdown", model_manager.shutdown)
     app.state.model_manager = model_manager
     return app

--- a/src/drift/node/server.py
+++ b/src/drift/node/server.py
@@ -1,0 +1,88 @@
+"""HTTP composition for the persistent local node."""
+
+from __future__ import annotations
+
+import asyncio
+import secrets
+import time
+from typing import List
+
+from fastapi import HTTPException, Request
+from pydantic import BaseModel
+
+from drift.api.server import create_app
+from drift.node.model_manager import (
+    ModelInUseError,
+    ModelManager,
+    ModelManagerClosedError,
+    ModelNotFoundError,
+    ModelUnloadError,
+)
+
+CONTROL_API_VERSION = 1
+
+
+class ModelUnloadRequest(BaseModel):
+    model: str
+
+
+def create_node_app(
+    model_manager: ModelManager,
+    *,
+    api_keys: List[str],
+    host: str = "127.0.0.1",
+    port: int = 8080,
+    max_concurrent: int = 1,
+    default_max_tokens: int = 512,
+):
+    """Compose the OpenAI API and authenticated local control surface."""
+    if not api_keys or any(not isinstance(key, str) or not key for key in api_keys):
+        raise ValueError("the node control API requires at least one non-empty API key")
+    app = create_app(
+        model_manager=model_manager,
+        api_keys=api_keys,
+        max_concurrent=max_concurrent,
+        default_max_tokens=default_max_tokens,
+    )
+    started_at = int(time.time())
+
+    def check_auth(request: Request) -> None:
+        auth = request.headers.get("authorization", "")
+        candidate = auth[len("Bearer ") :] if auth.startswith("Bearer ") else ""
+        if not any(secrets.compare_digest(candidate, key) for key in api_keys):
+            raise HTTPException(status_code=401, detail="Invalid API key")
+
+    @app.get("/control/v1/status")
+    async def node_status(request: Request):
+        check_auth(request)
+        return {
+            "api_version": CONTROL_API_VERSION,
+            "status": "stopping" if model_manager.closed else "running",
+            "started_at": started_at,
+            "openai_base_url": f"http://{'[' + host + ']' if ':' in host else host}:{port}/v1",
+            "runtime_budget": model_manager.residency(),
+            "models": [snapshot.to_dict() for snapshot in model_manager.snapshots()],
+        }
+
+    @app.post("/control/v1/models/unload")
+    async def unload_model(body: ModelUnloadRequest, request: Request):
+        check_auth(request)
+        if not body.model.strip():
+            raise HTTPException(status_code=422, detail="model must be a non-empty string")
+        try:
+            descriptor = model_manager.resolve(body.model)
+            loop = asyncio.get_running_loop()
+            unloaded = await loop.run_in_executor(None, model_manager.unload, body.model)
+        except ModelNotFoundError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        except ModelInUseError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+        except ModelManagerClosedError as exc:
+            raise HTTPException(status_code=503, detail="Node is shutting down") from exc
+        except ModelUnloadError as exc:
+            raise HTTPException(status_code=503, detail=str(exc)) from exc
+        return {"model": descriptor.model_id, "unloaded": unloaded}
+
+    app.router.add_event_handler("shutdown", model_manager.shutdown)
+    app.state.model_manager = model_manager
+    return app

--- a/src/drift/node/server.py
+++ b/src/drift/node/server.py
@@ -41,6 +41,7 @@ def create_node_app(
     *,
     api_keys: Optional[List[str]] = None,
     api_key_store: Optional[ApiKeyStore] = None,
+    control_keys: Optional[List[str]] = None,
     host: str = "127.0.0.1",
     port: int = 8080,
     max_concurrent: int = 1,
@@ -49,9 +50,22 @@ def create_node_app(
 ):
     """Compose the OpenAI API and authenticated local control surface."""
     if api_key_store is None and (not api_keys or any(not isinstance(key, str) or not key for key in api_keys)):
-        raise ValueError("the node control API requires an API key store or at least one non-empty API key")
+        raise ValueError("the node OpenAI API requires an API key store or at least one non-empty API key")
     if api_key_store is not None and api_keys:
         raise ValueError("pass either api_key_store or api_keys, not both")
+    if not control_keys or any(not isinstance(key, str) or not key for key in control_keys):
+        raise ValueError("the node control API requires at least one non-empty control key")
+    if len(set(control_keys)) != len(control_keys):
+        raise ValueError("control keys must not contain duplicates")
+    if api_key_store is not None:
+        overlaps = any(api_key_store.contains(key) for key in control_keys)
+    else:
+        overlaps = any(
+            secrets.compare_digest(control_key, api_key) for control_key in control_keys for api_key in api_keys
+        )
+    if overlaps:
+        raise ValueError("control keys must be distinct from OpenAI API keys")
+    control_keys = tuple(control_keys)
     app = create_app(
         model_manager=model_manager,
         api_keys=api_keys,
@@ -61,20 +75,16 @@ def create_node_app(
     )
     started_at = int(time.time())
 
-    def check_auth(request: Request) -> None:
+    def check_control_auth(request: Request) -> None:
         auth = request.headers.get("authorization", "")
         candidate = auth[len("Bearer ") :] if auth.startswith("Bearer ") else ""
-        valid = (
-            api_key_store.verify(candidate)
-            if api_key_store is not None
-            else any(secrets.compare_digest(candidate, key) for key in api_keys)
-        )
+        valid = any(secrets.compare_digest(candidate, key) for key in control_keys)
         if not valid:
-            raise HTTPException(status_code=401, detail="Invalid API key")
+            raise HTTPException(status_code=401, detail="Invalid control key")
 
     @app.get("/control/v1/status")
     async def node_status(request: Request):
-        check_auth(request)
+        check_control_auth(request)
         return {
             "api_version": CONTROL_API_VERSION,
             "status": "stopping" if model_manager.closed else "running",
@@ -87,7 +97,7 @@ def create_node_app(
 
     @app.post("/control/v1/models/unload")
     async def unload_model(body: ModelUnloadRequest, request: Request):
-        check_auth(request)
+        check_control_auth(request)
         if not body.model.strip():
             raise HTTPException(status_code=422, detail="model must be a non-empty string")
         try:
@@ -106,7 +116,7 @@ def create_node_app(
 
     @app.get("/control/v1/workers")
     async def list_workers(request: Request):
-        check_auth(request)
+        check_control_auth(request)
         return {"workers": list(worker_supervisor.snapshots()) if worker_supervisor is not None else []}
 
     def require_key_store() -> ApiKeyStore:
@@ -116,12 +126,12 @@ def create_node_app(
 
     @app.get("/control/v1/keys")
     async def list_api_keys(request: Request):
-        check_auth(request)
+        check_control_auth(request)
         return {"keys": list(require_key_store().list())}
 
     @app.post("/control/v1/keys", status_code=201)
     async def create_api_key(body: ApiKeyCreateRequest, request: Request):
-        check_auth(request)
+        check_control_auth(request)
         try:
             metadata, secret = require_key_store().create(label=body.label)
         except ApiKeyStoreError as exc:
@@ -130,7 +140,7 @@ def create_node_app(
 
     @app.delete("/control/v1/keys/{key_id}")
     async def revoke_api_key(key_id: str, request: Request):
-        check_auth(request)
+        check_control_auth(request)
         try:
             metadata = require_key_store().revoke(key_id)
         except ApiKeyNotFoundError as exc:
@@ -141,7 +151,7 @@ def create_node_app(
 
     @app.patch("/control/v1/keys/{key_id}")
     async def update_api_key(key_id: str, body: ApiKeyUpdateRequest, request: Request):
-        check_auth(request)
+        check_control_auth(request)
         try:
             metadata = require_key_store().update_label(key_id, label=body.label)
         except ApiKeyNotFoundError as exc:
@@ -170,17 +180,17 @@ def create_node_app(
 
     @app.post("/control/v1/workers/{worker_id}/start")
     async def start_worker(worker_id: str, request: Request):
-        check_auth(request)
+        check_control_auth(request)
         return await worker_action(worker_id, "start")
 
     @app.post("/control/v1/workers/{worker_id}/pause")
     async def pause_worker(worker_id: str, request: Request):
-        check_auth(request)
+        check_control_auth(request)
         return await worker_action(worker_id, "pause")
 
     @app.post("/control/v1/workers/{worker_id}/restart")
     async def restart_worker(worker_id: str, request: Request):
-        check_auth(request)
+        check_control_auth(request)
         return await worker_action(worker_id, "restart")
 
     if worker_supervisor is not None:

--- a/src/drift/node/worker_supervisor.py
+++ b/src/drift/node/worker_supervisor.py
@@ -1,0 +1,314 @@
+"""Isolated contribution-worker process supervision for the local node."""
+
+from __future__ import annotations
+
+import collections
+import logging
+import os
+import subprocess
+import threading
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Callable, Deque, Dict, Optional, Sequence, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+class WorkerState(str, Enum):
+    PAUSED = "paused"
+    STARTING = "starting"
+    RUNNING = "running"
+    STOPPING = "stopping"
+    CRASHED = "crashed"
+
+
+class WorkerNotFoundError(LookupError):
+    pass
+
+
+@dataclass(frozen=True)
+class WorkerLaunch:
+    worker_id: str
+    model_id: str
+    command: Tuple[str, ...]
+    auto_start: bool = False
+    auto_restart: bool = True
+    restart_backoff: float = 5.0
+    environment: Tuple[Tuple[str, str], ...] = field(default=(), repr=False)
+
+    def __post_init__(self) -> None:
+        if not self.worker_id or not self.command:
+            raise ValueError("worker id and command must not be empty")
+        if self.restart_backoff <= 0:
+            raise ValueError("worker restart_backoff must be positive")
+        if any(not name or not isinstance(name, str) or not isinstance(value, str) for name, value in self.environment):
+            raise ValueError("worker environment names and values must be strings")
+
+
+@dataclass
+class _WorkerRecord:
+    launch: WorkerLaunch
+    state: WorkerState = WorkerState.PAUSED
+    desired_running: bool = False
+    process: Optional[subprocess.Popen] = None
+    last_exit_code: Optional[int] = None
+    last_error: Optional[str] = None
+    started_at: Optional[float] = None
+    restart_count: int = 0
+    next_restart_at: float = 0.0
+    recent_logs: Deque[str] = field(default_factory=lambda: collections.deque(maxlen=50))
+
+
+class WorkerSupervisor:
+    """Own worker subprocesses while keeping failures outside the API process."""
+
+    def __init__(
+        self,
+        launches: Sequence[WorkerLaunch],
+        *,
+        stop_timeout: float = 10.0,
+        poll_period: float = 0.25,
+        popen: Callable[..., subprocess.Popen] = subprocess.Popen,
+    ) -> None:
+        if stop_timeout <= 0 or poll_period <= 0:
+            raise ValueError("worker supervisor timeouts must be positive")
+        self._records: Dict[str, _WorkerRecord] = {}
+        for launch in launches:
+            normalized = launch.worker_id.casefold()
+            if normalized in self._records:
+                raise ValueError(f"duplicate worker id {launch.worker_id!r}")
+            self._records[normalized] = _WorkerRecord(launch=launch, desired_running=launch.auto_start)
+        self._stop_timeout = stop_timeout
+        self._poll_period = poll_period
+        self._popen = popen
+        self._lock = threading.RLock()
+        self._stop = threading.Event()
+        self._monitor: Optional[threading.Thread] = None
+        self._started = False
+        self._closed = False
+
+    def _record(self, worker_id: str) -> _WorkerRecord:
+        with self._lock:
+            record = self._records.get(worker_id.casefold())
+            if record is None:
+                raise WorkerNotFoundError(f"unknown worker {worker_id!r}")
+            return record
+
+    @staticmethod
+    def _creation_flags() -> int:
+        return getattr(subprocess, "CREATE_NO_WINDOW", 0) | getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+
+    def _spawn_locked(self, record: _WorkerRecord) -> bool:
+        if self._closed:
+            raise RuntimeError("worker supervisor is closed")
+        if record.process is not None and record.process.poll() is None:
+            return False
+        record.state = WorkerState.STARTING
+        environment = os.environ.copy()
+        environment.update(record.launch.environment)
+        environment["PYTHONUNBUFFERED"] = "1"
+        try:
+            process = self._popen(
+                list(record.launch.command),
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                bufsize=1,
+                env=environment,
+                creationflags=self._creation_flags(),
+            )
+        except Exception as exc:
+            record.process = None
+            record.state = WorkerState.CRASHED
+            record.last_error = f"{type(exc).__name__}: {exc}"
+            record.next_restart_at = time.monotonic() + record.launch.restart_backoff
+            return False
+
+        if record.started_at is not None:
+            record.restart_count += 1
+        record.process = process
+        record.state = WorkerState.RUNNING
+        record.last_error = None
+        record.last_exit_code = None
+        record.started_at = time.time()
+        thread = threading.Thread(
+            target=self._drain_output,
+            args=(record, process),
+            name=f"drift-worker-log-{record.launch.worker_id}",
+            daemon=True,
+        )
+        thread.start()
+        return True
+
+    def _drain_output(self, record: _WorkerRecord, process: subprocess.Popen) -> None:
+        stream = process.stdout
+        if stream is None:
+            return
+        try:
+            for line in stream:
+                message = line.rstrip("\r\n")
+                with self._lock:
+                    record.recent_logs.append(message)
+                logger.info("worker[%s] %s", record.launch.worker_id, message)
+        except Exception:
+            logger.exception("Failed to read logs for worker %r", record.launch.worker_id)
+        finally:
+            stream.close()
+
+    def _refresh_locked(self, record: _WorkerRecord) -> None:
+        process = record.process
+        if process is None or record.state is WorkerState.STOPPING:
+            return
+        exit_code = process.poll()
+        if exit_code is None:
+            return
+        record.process = None
+        record.last_exit_code = exit_code
+        if record.desired_running:
+            record.state = WorkerState.CRASHED
+            record.last_error = f"worker exited with code {exit_code}"
+            record.next_restart_at = time.monotonic() + record.launch.restart_backoff
+        else:
+            record.state = WorkerState.PAUSED
+
+    def _monitor_loop(self) -> None:
+        while not self._stop.wait(self._poll_period):
+            with self._lock:
+                for record in self._records.values():
+                    self._refresh_locked(record)
+                    if (
+                        record.desired_running
+                        and record.process is None
+                        and record.launch.auto_restart
+                        and time.monotonic() >= record.next_restart_at
+                    ):
+                        self._spawn_locked(record)
+
+    def start_service(self) -> None:
+        with self._lock:
+            if self._closed:
+                raise RuntimeError("worker supervisor is closed")
+            if self._started:
+                return
+            self._started = True
+            for record in self._records.values():
+                if record.desired_running:
+                    self._spawn_locked(record)
+            self._monitor = threading.Thread(
+                target=self._monitor_loop,
+                name="drift-worker-supervisor",
+                daemon=True,
+            )
+            self._monitor.start()
+
+    def start_worker(self, worker_id: str) -> bool:
+        record = self._record(worker_id)
+        with self._lock:
+            record.desired_running = True
+            return self._spawn_locked(record)
+
+    def _terminate(self, process: subprocess.Popen) -> int:
+        if process.poll() is None:
+            process.terminate()
+            try:
+                return process.wait(timeout=self._stop_timeout)
+            except subprocess.TimeoutExpired:
+                process.kill()
+        return process.wait(timeout=self._stop_timeout)
+
+    def pause_worker(self, worker_id: str) -> bool:
+        record = self._record(worker_id)
+        with self._lock:
+            record.desired_running = False
+            process = record.process
+            if process is None:
+                record.state = WorkerState.PAUSED
+                return False
+            record.state = WorkerState.STOPPING
+        try:
+            exit_code = self._terminate(process)
+        except Exception as exc:
+            with self._lock:
+                record.state = WorkerState.CRASHED
+                record.last_error = f"{type(exc).__name__}: {exc}"
+            raise RuntimeError(f"failed to pause worker {record.launch.worker_id!r}: {exc}") from exc
+        with self._lock:
+            if record.process is process:
+                record.process = None
+            record.last_exit_code = exit_code
+            record.state = WorkerState.PAUSED
+        return True
+
+    def restart_worker(self, worker_id: str) -> bool:
+        self.pause_worker(worker_id)
+        return self.start_worker(worker_id)
+
+    def snapshots(self) -> Tuple[Dict[str, Any], ...]:
+        with self._lock:
+            result = []
+            for record in sorted(self._records.values(), key=lambda item: item.launch.worker_id.casefold()):
+                self._refresh_locked(record)
+                result.append(
+                    {
+                        "id": record.launch.worker_id,
+                        "model": record.launch.model_id,
+                        "state": record.state.value,
+                        "desired_running": record.desired_running,
+                        "auto_restart": record.launch.auto_restart,
+                        "pid": record.process.pid if record.process is not None else None,
+                        "started_at": record.started_at,
+                        "restart_count": record.restart_count,
+                        "last_exit_code": record.last_exit_code,
+                        "last_error": record.last_error,
+                        "recent_logs": list(record.recent_logs),
+                    }
+                )
+            return tuple(result)
+
+    def snapshot(self, worker_id: str) -> Dict[str, Any]:
+        record = self._record(worker_id)
+        with self._lock:
+            self._refresh_locked(record)
+            return next(
+                snapshot
+                for snapshot in self.snapshots()
+                if snapshot["id"].casefold() == record.launch.worker_id.casefold()
+            )
+
+    @property
+    def launches(self) -> Tuple[WorkerLaunch, ...]:
+        with self._lock:
+            return tuple(record.launch for record in self._records.values())
+
+    def shutdown(self) -> None:
+        with self._lock:
+            if self._closed:
+                return
+            self._closed = True
+            self._stop.set()
+            records = tuple(self._records.values())
+            monitor = self._monitor
+            for record in records:
+                record.desired_running = False
+        for record in records:
+            process = record.process
+            if process is not None:
+                with self._lock:
+                    record.state = WorkerState.STOPPING
+                try:
+                    exit_code = self._terminate(process)
+                except Exception as exc:
+                    with self._lock:
+                        record.last_error = f"{type(exc).__name__}: {exc}"
+                    logger.exception("Failed to stop worker %r", record.launch.worker_id)
+                else:
+                    with self._lock:
+                        record.last_exit_code = exit_code
+                        record.process = None
+                        record.state = WorkerState.PAUSED
+        if monitor is not None:
+            monitor.join(timeout=5)

--- a/tests/test_api_keys.py
+++ b/tests/test_api_keys.py
@@ -2,7 +2,7 @@ import json
 
 import pytest
 
-from drift.cli.run_node import _prepare_api_key_store
+from drift.cli.run_node import _prepare_api_key_store, _prepare_control_key
 from drift.node.keys import ApiKeyStore, ApiKeyStoreError, LastActiveKeyError
 
 
@@ -25,6 +25,7 @@ def test_labeled_api_keys_persist_as_hashes_and_revoke(tmp_path):
     reopened.revoke(bootstrap_metadata["id"])
     renamed = reopened.update_label(bootstrap_metadata["id"], label="retired bootstrap")
     assert not reopened.verify(bootstrap)
+    assert reopened.contains(bootstrap)
     assert reopened.verify(created_secret)
     assert renamed["label"] == "retired bootstrap"
     assert reopened.list()[0]["fingerprint"]
@@ -47,6 +48,26 @@ def test_restart_does_not_reimport_a_revoked_bootstrap_key(tmp_path):
     assert reopened.verify(replacement_secret)
     assert next(item for item in reopened.list() if item["id"] == bootstrap["id"])["revoked_at"] is not None
     assert next(item for item in reopened.list() if item["id"] == replacement["id"])["revoked_at"] is None
+
+
+def test_control_key_is_stable_separate_and_supports_an_explicit_path(tmp_path):
+    api_store, api_path, _ = _prepare_api_key_store(tmp_path, [])
+    control_key, control_path, created = _prepare_control_key(tmp_path, None)
+    reopened, reopened_path, created_again = _prepare_control_key(tmp_path, None)
+
+    assert created is True
+    assert created_again is False
+    assert control_path == reopened_path == tmp_path / "control-api.key"
+    assert control_key == reopened
+    assert control_key.startswith("drift_control_")
+    assert not api_store.verify(control_key)
+    assert api_path.read_text(encoding="utf-8").strip() != control_key
+
+    custom_path = tmp_path / "native-bridge" / "control.key"
+    custom, selected_path, custom_created = _prepare_control_key(tmp_path, custom_path)
+    assert custom_created is True
+    assert selected_path == custom_path
+    assert custom_path.read_text(encoding="utf-8").strip() == custom
 
 
 def test_key_store_rejects_duplicate_json_keys(tmp_path):

--- a/tests/test_api_keys.py
+++ b/tests/test_api_keys.py
@@ -1,0 +1,94 @@
+import json
+
+import pytest
+
+from drift.cli.run_node import _prepare_api_key_store
+from drift.node.keys import ApiKeyStore, ApiKeyStoreError, LastActiveKeyError
+
+
+def test_labeled_api_keys_persist_as_hashes_and_revoke(tmp_path):
+    path = tmp_path / "api-keys.json"
+    store = ApiKeyStore(path)
+    bootstrap = "drift_bootstrap-secret"
+    bootstrap_metadata = store.ensure_key(bootstrap, label="bootstrap")
+    created_metadata, created_secret = store.create(label="desktop client")
+
+    assert store.verify(bootstrap)
+    assert store.verify(created_secret)
+    assert {item["label"] for item in store.list()} == {"bootstrap", "desktop client"}
+    contents = path.read_text(encoding="utf-8")
+    assert bootstrap not in contents
+    assert created_secret not in contents
+    assert "secret_hash" in contents
+
+    reopened = ApiKeyStore(path)
+    reopened.revoke(bootstrap_metadata["id"])
+    renamed = reopened.update_label(bootstrap_metadata["id"], label="retired bootstrap")
+    assert not reopened.verify(bootstrap)
+    assert reopened.verify(created_secret)
+    assert renamed["label"] == "retired bootstrap"
+    assert reopened.list()[0]["fingerprint"]
+    with pytest.raises(LastActiveKeyError):
+        reopened.revoke(created_metadata["id"])
+
+
+def test_restart_does_not_reimport_a_revoked_bootstrap_key(tmp_path):
+    store, key_path, _ = _prepare_api_key_store(tmp_path, [])
+    bootstrap_secret = key_path.read_text(encoding="utf-8").strip()
+    bootstrap = store.list()[0]
+    replacement, replacement_secret = store.create(label="replacement")
+    store.revoke(bootstrap["id"])
+
+    reopened, reopened_key_path, created = _prepare_api_key_store(tmp_path, [])
+
+    assert reopened_key_path is None
+    assert created is False
+    assert not reopened.verify(bootstrap_secret)
+    assert reopened.verify(replacement_secret)
+    assert next(item for item in reopened.list() if item["id"] == bootstrap["id"])["revoked_at"] is not None
+    assert next(item for item in reopened.list() if item["id"] == replacement["id"])["revoked_at"] is None
+
+
+def test_key_store_rejects_duplicate_json_keys(tmp_path):
+    path = tmp_path / "api-keys.json"
+    path.write_text('{"schema_version":1,"schema_version":1,"keys":[]}', encoding="utf-8")
+
+    with pytest.raises(ApiKeyStoreError, match="duplicate object key"):
+        ApiKeyStore(path)
+
+
+def test_key_store_rejects_unknown_fields(tmp_path):
+    path = tmp_path / "api-keys.json"
+    path.write_text(json.dumps({"schema_version": 1, "keys": [], "secret": "no"}), encoding="utf-8")
+
+    with pytest.raises(ApiKeyStoreError, match="exactly"):
+        ApiKeyStore(path)
+
+
+def test_failed_mutation_does_not_change_in_memory_key_state(monkeypatch, tmp_path):
+    store = ApiKeyStore(tmp_path / "api-keys.json")
+    first = store.ensure_key("first-secret", label="first")
+    store.ensure_key("second-secret", label="second")
+    before = store.list()
+    monkeypatch.setattr(store, "_write_locked", lambda: (_ for _ in ()).throw(OSError("disk full")))
+
+    with pytest.raises(OSError, match="disk full"):
+        store.update_label(first["id"], label="changed")
+    assert store.list() == before
+
+    with pytest.raises(OSError, match="disk full"):
+        store.revoke(first["id"])
+    assert store.list() == before
+
+    with pytest.raises(OSError, match="disk full"):
+        store.create(label="third")
+    assert store.list() == before
+
+
+@pytest.mark.parametrize("schema_version", [True, "1", 2])
+def test_key_store_rejects_non_exact_schema_versions(tmp_path, schema_version):
+    path = tmp_path / "api-keys.json"
+    path.write_text(json.dumps({"schema_version": schema_version, "keys": []}), encoding="utf-8")
+
+    with pytest.raises(ApiKeyStoreError, match="schema_version"):
+        ApiKeyStore(path)

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,0 +1,160 @@
+import threading
+import time
+from types import SimpleNamespace
+
+from drift.data_structures import RemoteModuleInfo, ServerState
+from drift.model_manifest import ModelManifest
+from drift.node.discovery import CoverageTarget, ModelCoverageDiscovery
+
+
+class FakeDHT:
+    def __init__(self):
+        self.alive = True
+        self.shutdown_calls = 0
+
+    def is_alive(self):
+        return self.alive
+
+    def shutdown(self):
+        self.alive = False
+        self.shutdown_calls += 1
+
+
+class StrictFakeDHT(FakeDHT):
+    def is_alive(self):
+        # Mimic Hivemind's short shutdown race: process liveness may remain true
+        # after its control pipe has already closed.
+        return True
+
+    def shutdown(self):
+        if self.shutdown_calls:
+            raise OSError("handle is closed")
+        self.shutdown_calls += 1
+
+
+def test_unloaded_discovery_reports_verified_complete_coverage():
+    manifest = ModelManifest.load("tests/data/model_manifest_v1_vector.json")
+    dht = FakeDHT()
+    refreshed = threading.Event()
+    calls = []
+
+    def lookup(selected_dht, uids, **kwargs):
+        calls.append((selected_dht, uids, kwargs))
+        peer = object()
+        refreshed.set()
+        return [RemoteModuleInfo(uid, {peer: SimpleNamespace(state=ServerState.ONLINE)}) for uid in uids]
+
+    discovery = ModelCoverageDiscovery(
+        [CoverageTarget(manifest, ("peer-one",))],
+        update_period=60,
+        startup_timeout=2,
+        dht_factory=lambda **kwargs: dht,
+        lookup=lookup,
+    )
+    discovery.start()
+    assert refreshed.wait(timeout=1)
+
+    health = discovery.snapshot(manifest.digest_id)
+    assert health["source"] == "discovery"
+    assert health["status"] == "complete"
+    assert health["covered_blocks"] == manifest.model.num_blocks
+    assert health["minimum_replicas"] == 1
+    assert health["last_error"] is None
+    assert calls[0][0] is dht
+    assert calls[0][2]["manifest_digest"] == manifest.digest
+    assert calls[0][2]["manifest_execution_profile"] == manifest.runtime.to_dict()
+    assert calls[0][2]["latest"] is True
+
+    discovery.close()
+    discovery.close()
+    assert dht.shutdown_calls == 1
+
+
+def test_models_with_the_same_peers_share_one_dht_but_keep_independent_guards():
+    first = ModelManifest.load("tests/data/model_manifest_v1_vector.json")
+    second_source = first.to_dict()
+    second_source["name"] = "Second discovery model"
+    second_source["aliases"] = ["second-discovery"]
+    second = ModelManifest.from_dict(second_source)
+    dht = FakeDHT()
+    refreshed = threading.Event()
+    factory_calls = []
+    lookups = []
+
+    def factory(**kwargs):
+        factory_calls.append(kwargs)
+        return dht
+
+    def lookup(selected_dht, uids, **kwargs):
+        lookups.append(kwargs)
+        if len(lookups) == 2:
+            refreshed.set()
+        peer = object()
+        return [RemoteModuleInfo(uid, {peer: SimpleNamespace(state=ServerState.ONLINE)}) for uid in uids]
+
+    discovery = ModelCoverageDiscovery(
+        [CoverageTarget(first, ("shared-peer",)), CoverageTarget(second, ("shared-peer",))],
+        update_period=60,
+        startup_timeout=1,
+        dht_factory=factory,
+        lookup=lookup,
+    )
+    discovery.start()
+    assert refreshed.wait(timeout=1)
+
+    assert len(factory_calls) == 1
+    assert {call["manifest_digest"] for call in lookups} == {first.digest, second.digest}
+    assert lookups[0]["replay_guard"] is not lookups[1]["replay_guard"]
+    assert discovery.snapshot(first.digest_id)["status"] == "complete"
+    assert discovery.snapshot(second.digest_id)["status"] == "complete"
+    discovery.close()
+
+
+def test_discovery_failure_is_observable_without_blocking_startup():
+    manifest = ModelManifest.load("tests/data/model_manifest_v1_vector.json")
+    attempted = threading.Event()
+
+    def fail_factory(**kwargs):
+        attempted.set()
+        raise RuntimeError("seed unavailable")
+
+    discovery = ModelCoverageDiscovery(
+        [CoverageTarget(manifest, ("missing-peer",))],
+        update_period=60,
+        startup_timeout=0.1,
+        dht_factory=fail_factory,
+    )
+    discovery.start()
+    assert attempted.wait(timeout=1)
+    deadline = time.monotonic() + 1
+    while discovery.snapshot(manifest.digest_id)["last_error"] is None and time.monotonic() < deadline:
+        time.sleep(0.01)
+
+    health = discovery.snapshot(manifest.digest_id)
+    assert health["status"] == "unknown"
+    assert health["covered_blocks"] is None
+    assert health["last_error"] == "RuntimeError: seed unavailable"
+    discovery.close()
+
+
+def test_discovery_shutdown_calls_each_dht_only_once_across_thread_race():
+    manifest = ModelManifest.load("tests/data/model_manifest_v1_vector.json")
+    dht = StrictFakeDHT()
+    refreshed = threading.Event()
+
+    def lookup(selected_dht, uids, **kwargs):
+        refreshed.set()
+        return [RemoteModuleInfo(uid, {}) for uid in uids]
+
+    discovery = ModelCoverageDiscovery(
+        [CoverageTarget(manifest, ("peer-one",))],
+        update_period=60,
+        startup_timeout=1,
+        dht_factory=lambda **kwargs: dht,
+        lookup=lookup,
+    )
+    discovery.start()
+    assert refreshed.wait(timeout=1)
+    discovery.close()
+
+    assert dht.shutdown_calls == 1

--- a/tests/test_edge_benchmark.py
+++ b/tests/test_edge_benchmark.py
@@ -1,0 +1,85 @@
+import time
+
+import torch
+
+from drift.model_manifest import ModelManifest
+from drift.node.edge_benchmark import benchmark_client_runtime, cache_is_empty, client_component_memory
+from drift.node.model_manager import ModelRuntime
+
+
+class _Tokenizer:
+    def __call__(self, text, return_tensors=None):
+        return {"input_ids": torch.tensor([[1, 2]])}
+
+    def decode(self, ids, **kwargs):
+        return " ".join(str(value) for value in torch.as_tensor(ids).flatten().tolist())
+
+
+class _Model(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.embedding = torch.nn.Embedding(4, 3)
+        self.head = torch.nn.Linear(3, 4, bias=False)
+
+    def get_input_embeddings(self):
+        return self.embedding
+
+    def get_output_embeddings(self):
+        return self.head
+
+    def generate(self, input_ids, streamer, max_new_tokens, **kwargs):
+        streamer.put(input_ids)
+        generated = []
+        for token in range(10, 10 + max_new_tokens):
+            time.sleep(0.002)
+            value = torch.tensor([[token]])
+            generated.append(value)
+            streamer.put(value)
+        streamer.end()
+        return torch.cat([input_ids, *generated], dim=1)
+
+
+def test_client_component_memory_deduplicates_tied_weights():
+    model = _Model()
+    model.head.weight = model.embedding.weight
+
+    result = client_component_memory(model)
+
+    assert result["components"]["input_embeddings"]["parameter_bytes"] == 4 * 3 * 4
+    assert result["components"]["output_head"]["parameter_bytes"] == 4 * 3 * 4
+    assert result["unique_parameter_bytes"] == 4 * 3 * 4
+
+
+def test_edge_benchmark_reports_cache_memory_and_token_timing(tmp_path):
+    manifest = ModelManifest.load("tests/data/model_manifest_v1_vector.json")
+    cache_dir = tmp_path / "cache"
+    closed = []
+
+    def loader():
+        cache_dir.mkdir()
+        (cache_dir / "artifact.bin").write_bytes(b"0123456789")
+        return ModelRuntime(_Model(), _Tokenizer(), close=lambda: closed.append(True))
+
+    assert cache_is_empty(cache_dir)
+    result = benchmark_client_runtime(
+        manifest,
+        loader,
+        cache_dir=cache_dir,
+        prompt="Hello",
+        max_new_tokens=3,
+    )
+
+    assert closed == [True]
+    assert result["schema_version"] == 1
+    assert result["model"]["manifest_digest"] == manifest.digest_id
+    assert result["storage"] == {
+        "cold_start": True,
+        "cache_bytes_before": 0,
+        "cache_bytes_after": 10,
+        "cache_growth_bytes": 10,
+    }
+    assert result["workload"]["prompt_tokens"] == 2
+    assert result["workload"]["generated_tokens"] == 3
+    assert result["latency"]["first_token_seconds"] > 0
+    assert result["latency"]["decode_tokens_per_second"] > 0
+    assert result["memory"]["process_tree_rss_peak_bytes"] > 0

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -164,6 +164,34 @@ def test_snapshot_marks_loaded_incomplete_routes_as_degraded():
     assert snapshot.route == route
 
 
+def test_unloaded_model_can_publish_lightweight_discovery_health():
+    manager = ModelManager()
+    route = {"status": "complete", "source": "discovery"}
+    manager.register(
+        ModelDescriptor("model"),
+        lambda: ModelRuntime(object(), object()),
+        route_health=lambda: route,
+    )
+
+    snapshot = manager.snapshots()[0]
+
+    assert snapshot.state is ModelState.KNOWN
+    assert snapshot.route == route
+
+
+def test_shutdown_callbacks_run_once_even_when_one_fails(caplog):
+    manager = ModelManager()
+    calls = []
+    manager.add_shutdown_callback(lambda: (_ for _ in ()).throw(RuntimeError("service failed")))
+    manager.add_shutdown_callback(lambda: calls.append("closed"))
+
+    manager.shutdown()
+    manager.shutdown()
+
+    assert calls == ["closed"]
+    assert "Failed to close a model-manager service" in caplog.text
+
+
 def test_bounded_residency_evicts_the_least_recent_idle_model():
     manager = ModelManager(max_loaded_models=2)
     closed = []

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -1,0 +1,242 @@
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from drift.model_manifest import ModelManifest
+from drift.node.model_manager import (
+    AmbiguousModelError,
+    ModelDescriptor,
+    ModelInUseError,
+    ModelManager,
+    ModelManagerClosedError,
+    ModelRuntime,
+    ModelState,
+    ModelUnloadError,
+)
+
+
+def test_manifest_registration_resolves_name_alias_and_digest():
+    manifest = ModelManifest.load("tests/data/model_manifest_v1_vector.json")
+    manager = ModelManager()
+    manager.register_manifest(manifest, lambda: ModelRuntime(object(), object()))
+
+    for identifier in (manifest.name, *manifest.aliases, manifest.digest_id):
+        assert manager.resolve(identifier).manifest_digest == manifest.digest_id
+    assert manager.snapshots()[0].state is ModelState.KNOWN
+
+
+def test_manager_rejects_alias_collisions_case_insensitively():
+    manager = ModelManager()
+    manager.register(ModelDescriptor("First", aliases=("shared",)), lambda: ModelRuntime(object(), object()))
+
+    with pytest.raises(ValueError, match="already registered"):
+        manager.register(ModelDescriptor("Second", aliases=("SHARED",)), lambda: ModelRuntime(object(), object()))
+
+
+def test_lazy_load_is_serialized_and_published_once():
+    manager = ModelManager()
+    calls = 0
+    calls_lock = threading.Lock()
+    runtime = ModelRuntime(object(), object())
+
+    def loader():
+        nonlocal calls
+        with calls_lock:
+            calls += 1
+        time.sleep(0.02)
+        return runtime
+
+    manager.register(ModelDescriptor("model", aliases=("alias",)), loader)
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        loaded = list(executor.map(lambda _: manager.load("alias"), range(8)))
+
+    assert calls == 1
+    assert all(item.runtime is runtime for item in loaded)
+    assert manager.snapshots()[0].state is ModelState.READY
+
+
+def test_failed_lazy_load_is_visible_and_can_retry():
+    manager = ModelManager()
+    attempts = 0
+
+    def loader():
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("temporary failure")
+        return ModelRuntime(object(), object())
+
+    manager.register(ModelDescriptor("model"), loader)
+    with pytest.raises(RuntimeError, match="temporary failure"):
+        manager.load("model")
+    failed = manager.snapshots()[0]
+    assert failed.state is ModelState.UNAVAILABLE
+    assert failed.last_error == "RuntimeError: temporary failure"
+
+    assert manager.load("model").descriptor.model_id == "model"
+    assert manager.snapshots()[0].state is ModelState.READY
+
+
+def test_omitted_model_is_only_valid_for_one_registration():
+    manager = ModelManager()
+    manager.register_loaded("one", object(), object())
+    assert manager.load(None).descriptor.model_id == "one"
+    manager.register_loaded("two", object(), object())
+
+    with pytest.raises(AmbiguousModelError, match="model is required"):
+        manager.load(None)
+
+
+def test_shutdown_closes_loaded_runtime_once_and_blocks_new_loads():
+    manager = ModelManager()
+    close_calls = 0
+
+    def close():
+        nonlocal close_calls
+        close_calls += 1
+
+    manager.register(ModelDescriptor("model"), lambda: ModelRuntime(object(), object(), close=close))
+    manager.load("model")
+    manager.shutdown()
+    manager.shutdown()
+
+    assert close_calls == 1
+    assert manager.closed
+    assert manager.snapshots()[0].state is ModelState.STOPPING
+    with pytest.raises(ModelManagerClosedError):
+        manager.load("model")
+
+
+def test_shutdown_continues_after_one_runtime_close_fails(caplog):
+    manager = ModelManager()
+    second_closed = []
+
+    def fail_close():
+        raise RuntimeError("close failed")
+
+    manager.register(ModelDescriptor("first"), lambda: ModelRuntime(None, None, fail_close))
+    manager.register(ModelDescriptor("second"), lambda: ModelRuntime(None, None, lambda: second_closed.append(True)))
+    manager.load("first")
+    manager.load("second")
+
+    manager.shutdown()
+
+    assert second_closed == [True]
+    assert "Failed to close model runtime 'first'" in caplog.text
+
+
+def test_runtime_lease_blocks_unload_until_released():
+    manager = ModelManager(max_loaded_models=1)
+    closed = []
+    manager.register(
+        ModelDescriptor("model", aliases=("alias",)),
+        lambda: ModelRuntime(object(), object(), close=lambda: closed.append("model")),
+    )
+
+    lease = manager.load("alias")
+    assert manager.snapshots()[0].active_requests == 1
+    with pytest.raises(ModelInUseError, match="1 active request"):
+        manager.unload("model")
+
+    lease.release()
+    lease.release()
+    assert manager.snapshots()[0].active_requests == 0
+    assert manager.unload("alias") is True
+    assert manager.unload("alias") is False
+    assert closed == ["model"]
+    assert manager.snapshots()[0].state is ModelState.KNOWN
+
+
+def test_snapshot_marks_loaded_incomplete_routes_as_degraded():
+    manager = ModelManager()
+    route = {"status": "incomplete", "covered_blocks": 1, "missing_blocks": [1]}
+    manager.register(
+        ModelDescriptor("model"),
+        lambda: ModelRuntime(object(), object(), route_health=lambda: route),
+    )
+
+    manager.load("model").release()
+    snapshot = manager.snapshots()[0]
+
+    assert snapshot.state is ModelState.DEGRADED
+    assert snapshot.route == route
+
+
+def test_bounded_residency_evicts_the_least_recent_idle_model():
+    manager = ModelManager(max_loaded_models=2)
+    closed = []
+    for name in ("alpha", "beta", "gamma"):
+        manager.register(
+            ModelDescriptor(name),
+            lambda selected=name: ModelRuntime(object(), object(), close=lambda: closed.append(selected)),
+        )
+
+    manager.load("alpha").release()
+    time.sleep(0.002)
+    manager.load("beta").release()
+    time.sleep(0.002)
+    manager.load("alpha").release()
+    time.sleep(0.002)
+    manager.load("gamma").release()
+
+    snapshots = {snapshot.model_id: snapshot for snapshot in manager.snapshots()}
+    assert snapshots["alpha"].state is ModelState.READY
+    assert snapshots["beta"].state is ModelState.KNOWN
+    assert snapshots["gamma"].state is ModelState.READY
+    assert manager.residency() == {"max_loaded_models": 2, "resident_models": 2}
+    assert closed == ["beta"]
+
+
+def test_capacity_waits_instead_of_evicting_an_active_runtime():
+    manager = ModelManager(max_loaded_models=1)
+    closed = []
+    attempted_second = threading.Event()
+    manager.register(
+        ModelDescriptor("first"),
+        lambda: ModelRuntime(object(), object(), close=lambda: closed.append("first")),
+    )
+    manager.register(ModelDescriptor("second"), lambda: ModelRuntime(object(), object()))
+    first = manager.load("first")
+
+    def load_second():
+        attempted_second.set()
+        return manager.load("second")
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        pending = executor.submit(load_second)
+        assert attempted_second.wait(timeout=1)
+        time.sleep(0.02)
+        assert not pending.done()
+        first.release()
+        second = pending.result(timeout=1)
+
+    assert closed == ["first"]
+    assert second.descriptor.model_id == "second"
+    second.release()
+
+
+def test_failed_cleanup_keeps_its_runtime_slot_reserved():
+    manager = ModelManager(max_loaded_models=1)
+    manager.register(
+        ModelDescriptor("broken"),
+        lambda: ModelRuntime(object(), object(), close=lambda: (_ for _ in ()).throw(RuntimeError("close failed"))),
+    )
+    manager.register(ModelDescriptor("other"), lambda: ModelRuntime(object(), object()))
+    manager.load("broken").release()
+
+    with pytest.raises(ModelUnloadError, match="close failed"):
+        manager.unload("broken")
+
+    snapshot = {item.model_id: item for item in manager.snapshots()}["broken"]
+    assert snapshot.state is ModelState.UNAVAILABLE
+    assert manager.residency() == {"max_loaded_models": 1, "resident_models": 1}
+    with pytest.raises(ModelUnloadError, match="failed cleanup"):
+        manager.load("other")
+
+
+@pytest.mark.parametrize("value", [0, -1, True, 1.5])
+def test_runtime_budget_must_be_a_positive_integer(value):
+    with pytest.raises(ValueError, match="max_loaded_models"):
+        ModelManager(max_loaded_models=value)

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -8,7 +8,7 @@ from fastapi.testclient import TestClient
 
 from drift.cli.run_node import _validate_args, build_parser
 from drift.model_manifest import ModelManifest
-from drift.node.keys import load_or_create_api_key
+from drift.node.keys import ApiKeyStore, load_or_create_api_key
 from drift.node.loading import make_manifest_loader
 from drift.node.model_manager import ModelDescriptor, ModelManager, ModelRuntime, ModelState
 from drift.node.server import create_node_app
@@ -110,6 +110,90 @@ def test_node_refuses_to_unload_a_model_with_an_active_lease():
         )
         assert response.status_code == 409
         lease.release()
+
+
+def test_authenticated_worker_controls_are_routed_through_supervisor():
+    class FakeSupervisor:
+        def __init__(self):
+            self.state = "paused"
+            self.calls = []
+            self.closed = False
+
+        def snapshots(self):
+            return ({"id": "worker", "model": "model", "state": self.state},)
+
+        def snapshot(self, worker_id):
+            assert worker_id == "worker"
+            return self.snapshots()[0]
+
+        def start_worker(self, worker_id):
+            self.calls.append(("start", worker_id))
+            self.state = "running"
+            return True
+
+        def pause_worker(self, worker_id):
+            self.calls.append(("pause", worker_id))
+            self.state = "paused"
+            return True
+
+        def restart_worker(self, worker_id):
+            self.calls.append(("restart", worker_id))
+            self.state = "running"
+            return True
+
+        def shutdown(self):
+            self.closed = True
+
+    manager = ModelManager()
+    manager.register(ModelDescriptor("model"), lambda: ModelRuntime(FakeModel(), FakeTokenizer()))
+    supervisor = FakeSupervisor()
+    app = create_node_app(manager, api_keys=["secret"], worker_supervisor=supervisor)
+    headers = {"Authorization": "Bearer secret"}
+
+    with TestClient(app) as client:
+        assert client.get("/control/v1/workers").status_code == 401
+        assert client.get("/control/v1/workers", headers=headers).json()["workers"][0]["state"] == "paused"
+        for action in ("start", "pause", "restart"):
+            response = client.post(f"/control/v1/workers/worker/{action}", headers=headers)
+            assert response.status_code == 200
+            assert response.json()["changed"] is True
+
+    assert supervisor.calls == [("start", "worker"), ("pause", "worker"), ("restart", "worker")]
+    assert supervisor.closed
+
+
+def test_persistent_key_crud_updates_authentication_immediately(tmp_path):
+    store = ApiKeyStore(tmp_path / "api-keys.json")
+    first_secret = "drift_first-secret"
+    first = store.ensure_key(first_secret, label="bootstrap")
+    manager = ModelManager()
+    manager.register(ModelDescriptor("model"), lambda: ModelRuntime(FakeModel(), FakeTokenizer()))
+    app = create_node_app(manager, api_key_store=store)
+    first_headers = {"Authorization": f"Bearer {first_secret}"}
+
+    with TestClient(app) as client:
+        listed = client.get("/control/v1/keys", headers=first_headers)
+        assert listed.status_code == 200
+        assert listed.json()["keys"] == [first]
+        assert "secret_hash" not in listed.text
+
+        created = client.post("/control/v1/keys", headers=first_headers, json={"label": "second client"})
+        assert created.status_code == 201
+        second_secret = created.json()["secret"]
+        second = created.json()["key"]
+        second_headers = {"Authorization": f"Bearer {second_secret}"}
+        assert client.get("/v1/models", headers=second_headers).status_code == 200
+        renamed = client.patch(
+            f"/control/v1/keys/{second['id']}", headers=second_headers, json={"label": "renamed client"}
+        )
+        assert renamed.status_code == 200
+        assert renamed.json()["key"]["label"] == "renamed client"
+
+        revoked = client.delete(f"/control/v1/keys/{first['id']}", headers=second_headers)
+        assert revoked.status_code == 200
+        assert revoked.json()["key"]["revoked_at"] is not None
+        assert client.get("/v1/models", headers=first_headers).status_code == 401
+        assert client.delete(f"/control/v1/keys/{second['id']}", headers=second_headers).status_code == 409
 
 
 def test_node_parser_requires_explicit_network_opt_in():

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -8,7 +8,7 @@ from fastapi.testclient import TestClient
 
 from drift.cli.run_node import _validate_args, build_parser
 from drift.model_manifest import ModelManifest
-from drift.node.keys import ApiKeyStore, load_or_create_api_key
+from drift.node.keys import ApiKeyStore, load_or_create_api_key, load_or_create_control_key
 from drift.node.loading import make_manifest_loader
 from drift.node.model_manager import ModelDescriptor, ModelManager, ModelRuntime, ModelState
 from drift.node.server import create_node_app
@@ -50,6 +50,23 @@ def test_local_api_key_rejects_non_file_path(tmp_path):
         load_or_create_api_key(key_path)
 
 
+def test_local_control_key_is_stable_and_uses_a_distinct_key_class(tmp_path):
+    key_path = tmp_path / "secrets" / "control-api.key"
+    first, created = load_or_create_control_key(key_path)
+    second, created_again = load_or_create_control_key(key_path)
+
+    assert created is True
+    assert created_again is False
+    assert first == second
+    assert first.startswith("drift_control_")
+    assert key_path.read_text(encoding="utf-8").strip() == first
+
+    invalid_path = tmp_path / "secrets" / "invalid-control.key"
+    invalid_path.write_text("drift_client-key", encoding="utf-8")
+    with pytest.raises(ValueError, match="drift_control_ key class"):
+        load_or_create_control_key(invalid_path)
+
+
 def test_node_status_requires_auth_and_reports_lazy_model():
     manager = ModelManager(max_loaded_models=1)
     loads = []
@@ -62,12 +79,21 @@ def test_node_status_requires_auth_and_reports_lazy_model():
         ),
         lambda: loads.append(True) or ModelRuntime(FakeModel(), FakeTokenizer()),
     )
-    app = create_node_app(manager, api_keys=["secret"], host="127.0.0.1", port=8080)
+    app = create_node_app(
+        manager,
+        api_keys=["client-secret"],
+        control_keys=["control-secret"],
+        host="127.0.0.1",
+        port=8080,
+    )
 
     with TestClient(app) as client:
         assert client.get("/control/v1/status").status_code == 401
-        headers = {"Authorization": "Bearer secret"}
-        status = client.get("/control/v1/status", headers=headers)
+        client_headers = {"Authorization": "Bearer client-secret"}
+        control_headers = {"Authorization": "Bearer control-secret"}
+        assert client.get("/control/v1/status", headers=client_headers).status_code == 401
+        assert client.get("/v1/models", headers=control_headers).status_code == 401
+        status = client.get("/control/v1/status", headers=control_headers)
         assert status.status_code == 200
         body = status.json()
         assert body["api_version"] == 1
@@ -79,7 +105,7 @@ def test_node_status_requires_auth_and_reports_lazy_model():
 
         response = client.post(
             "/v1/completions",
-            headers=headers,
+            headers=client_headers,
             json={"model": "tiny", "prompt": "hello", "temperature": 0},
         )
         assert response.status_code == 200
@@ -88,7 +114,7 @@ def test_node_status_requires_auth_and_reports_lazy_model():
         assert manager.snapshots()[0].state is ModelState.READY
         assert manager.snapshots()[0].active_requests == 0
 
-        unloaded = client.post("/control/v1/models/unload", headers=headers, json={"model": "tiny"})
+        unloaded = client.post("/control/v1/models/unload", headers=control_headers, json={"model": "tiny"})
         assert unloaded.status_code == 200
         assert unloaded.json() == {"model": "Tiny Test", "unloaded": True}
         assert manager.snapshots()[0].state is ModelState.KNOWN
@@ -99,13 +125,13 @@ def test_node_status_requires_auth_and_reports_lazy_model():
 def test_node_refuses_to_unload_a_model_with_an_active_lease():
     manager = ModelManager(max_loaded_models=1)
     manager.register(ModelDescriptor("model"), lambda: ModelRuntime(FakeModel(), FakeTokenizer()))
-    app = create_node_app(manager, api_keys=["secret"])
+    app = create_node_app(manager, api_keys=["client-secret"], control_keys=["control-secret"])
 
     with TestClient(app) as client:
         lease = manager.load("model")
         response = client.post(
             "/control/v1/models/unload",
-            headers={"Authorization": "Bearer secret"},
+            headers={"Authorization": "Bearer control-secret"},
             json={"model": "model"},
         )
         assert response.status_code == 409
@@ -147,11 +173,17 @@ def test_authenticated_worker_controls_are_routed_through_supervisor():
     manager = ModelManager()
     manager.register(ModelDescriptor("model"), lambda: ModelRuntime(FakeModel(), FakeTokenizer()))
     supervisor = FakeSupervisor()
-    app = create_node_app(manager, api_keys=["secret"], worker_supervisor=supervisor)
-    headers = {"Authorization": "Bearer secret"}
+    app = create_node_app(
+        manager,
+        api_keys=["client-secret"],
+        control_keys=["control-secret"],
+        worker_supervisor=supervisor,
+    )
+    headers = {"Authorization": "Bearer control-secret"}
 
     with TestClient(app) as client:
         assert client.get("/control/v1/workers").status_code == 401
+        assert client.get("/control/v1/workers", headers={"Authorization": "Bearer client-secret"}).status_code == 401
         assert client.get("/control/v1/workers", headers=headers).json()["workers"][0]["state"] == "paused"
         for action in ("start", "pause", "restart"):
             response = client.post(f"/control/v1/workers/worker/{action}", headers=headers)
@@ -168,32 +200,59 @@ def test_persistent_key_crud_updates_authentication_immediately(tmp_path):
     first = store.ensure_key(first_secret, label="bootstrap")
     manager = ModelManager()
     manager.register(ModelDescriptor("model"), lambda: ModelRuntime(FakeModel(), FakeTokenizer()))
-    app = create_node_app(manager, api_key_store=store)
+    app = create_node_app(manager, api_key_store=store, control_keys=["drift_control-secret"])
     first_headers = {"Authorization": f"Bearer {first_secret}"}
+    control_headers = {"Authorization": "Bearer drift_control-secret"}
 
     with TestClient(app) as client:
-        listed = client.get("/control/v1/keys", headers=first_headers)
+        assert client.get("/control/v1/keys", headers=first_headers).status_code == 401
+        assert client.get("/v1/models", headers=control_headers).status_code == 401
+        listed = client.get("/control/v1/keys", headers=control_headers)
         assert listed.status_code == 200
         assert listed.json()["keys"] == [first]
         assert "secret_hash" not in listed.text
 
-        created = client.post("/control/v1/keys", headers=first_headers, json={"label": "second client"})
+        created = client.post("/control/v1/keys", headers=control_headers, json={"label": "second client"})
         assert created.status_code == 201
         second_secret = created.json()["secret"]
         second = created.json()["key"]
         second_headers = {"Authorization": f"Bearer {second_secret}"}
         assert client.get("/v1/models", headers=second_headers).status_code == 200
+        assert client.get("/control/v1/status", headers=second_headers).status_code == 401
         renamed = client.patch(
-            f"/control/v1/keys/{second['id']}", headers=second_headers, json={"label": "renamed client"}
+            f"/control/v1/keys/{second['id']}", headers=control_headers, json={"label": "renamed client"}
         )
         assert renamed.status_code == 200
         assert renamed.json()["key"]["label"] == "renamed client"
 
-        revoked = client.delete(f"/control/v1/keys/{first['id']}", headers=second_headers)
+        revoked = client.delete(f"/control/v1/keys/{first['id']}", headers=control_headers)
         assert revoked.status_code == 200
         assert revoked.json()["key"]["revoked_at"] is not None
         assert client.get("/v1/models", headers=first_headers).status_code == 401
-        assert client.delete(f"/control/v1/keys/{second['id']}", headers=second_headers).status_code == 409
+        assert client.delete(f"/control/v1/keys/{second['id']}", headers=control_headers).status_code == 409
+
+
+def test_node_requires_control_credentials_distinct_from_openai_keys(tmp_path):
+    manager = ModelManager()
+    manager.register(ModelDescriptor("model"), lambda: ModelRuntime(FakeModel(), FakeTokenizer()))
+
+    with pytest.raises(ValueError, match="requires at least one non-empty control key"):
+        create_node_app(manager, api_keys=["client-secret"])
+    with pytest.raises(ValueError, match="distinct from OpenAI API keys"):
+        create_node_app(manager, api_keys=["same-secret"], control_keys=["same-secret"])
+    with pytest.raises(ValueError, match="must not contain duplicates"):
+        create_node_app(manager, api_keys=["client-secret"], control_keys=["control-secret", "control-secret"])
+
+    store = ApiKeyStore(tmp_path / "api-keys.json")
+    store.ensure_key("stored-secret", label="client")
+    with pytest.raises(ValueError, match="distinct from OpenAI API keys"):
+        create_node_app(manager, api_key_store=store, control_keys=["stored-secret"])
+
+    store.ensure_key("second-secret", label="second client")
+    stored_id = next(item["id"] for item in store.list() if item["label"] == "client")
+    store.revoke(stored_id)
+    with pytest.raises(ValueError, match="distinct from OpenAI API keys"):
+        create_node_app(manager, api_key_store=store, control_keys=["stored-secret"])
 
 
 def test_node_parser_requires_explicit_network_opt_in():
@@ -208,8 +267,9 @@ def test_node_parser_requires_explicit_network_opt_in():
 
 def test_node_parser_accepts_config_mode_and_rejects_ambiguous_model_options():
     parser = build_parser()
-    config_args = parser.parse_args(["--config", "node.json"])
+    config_args = parser.parse_args(["--config", "node.json", "--control_key_path", "private/control.key"])
     _validate_args(parser, config_args)
+    assert config_args.control_key_path.as_posix() == "private/control.key"
 
     both = parser.parse_args(
         [

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -1,0 +1,228 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient
+
+from drift.cli.run_node import _validate_args, build_parser
+from drift.model_manifest import ModelManifest
+from drift.node.keys import load_or_create_api_key
+from drift.node.loading import make_manifest_loader
+from drift.node.model_manager import ModelDescriptor, ModelManager, ModelRuntime, ModelState
+from drift.node.server import create_node_app
+
+
+class FakeTokenizer:
+    def apply_chat_template(self, messages, **kwargs):
+        return {"input_ids": torch.tensor([[1, 2]])}
+
+    def __call__(self, text, **kwargs):
+        return SimpleNamespace(input_ids=torch.tensor([[1, 2]]))
+
+    def decode(self, ids, **kwargs):
+        return "done"
+
+
+class FakeModel:
+    def generate(self, input_ids, **kwargs):
+        return torch.cat([input_ids, torch.tensor([[3]])], dim=1)
+
+
+def test_local_api_key_is_stable_and_not_overwritten(tmp_path):
+    key_path = tmp_path / "secrets" / "local-api.key"
+    first, created = load_or_create_api_key(key_path)
+    second, created_again = load_or_create_api_key(key_path)
+
+    assert created is True
+    assert created_again is False
+    assert first == second
+    assert first.startswith("drift_")
+    assert key_path.read_text(encoding="utf-8").strip() == first
+
+
+def test_local_api_key_rejects_non_file_path(tmp_path):
+    key_path = tmp_path / "local-api.key"
+    key_path.mkdir()
+
+    with pytest.raises(ValueError, match="not a regular file"):
+        load_or_create_api_key(key_path)
+
+
+def test_node_status_requires_auth_and_reports_lazy_model():
+    manager = ModelManager(max_loaded_models=1)
+    loads = []
+    manager.register(
+        ModelDescriptor(
+            "Tiny Test",
+            aliases=("tiny",),
+            manifest_digest="sha256:" + "a" * 64,
+            repository="org/tiny",
+        ),
+        lambda: loads.append(True) or ModelRuntime(FakeModel(), FakeTokenizer()),
+    )
+    app = create_node_app(manager, api_keys=["secret"], host="127.0.0.1", port=8080)
+
+    with TestClient(app) as client:
+        assert client.get("/control/v1/status").status_code == 401
+        headers = {"Authorization": "Bearer secret"}
+        status = client.get("/control/v1/status", headers=headers)
+        assert status.status_code == 200
+        body = status.json()
+        assert body["api_version"] == 1
+        assert body["openai_base_url"] == "http://127.0.0.1:8080/v1"
+        assert body["runtime_budget"] == {"max_loaded_models": 1, "resident_models": 0}
+        assert body["models"][0]["state"] == "known"
+        assert body["models"][0]["aliases"] == ["tiny"]
+        assert loads == []
+
+        response = client.post(
+            "/v1/completions",
+            headers=headers,
+            json={"model": "tiny", "prompt": "hello", "temperature": 0},
+        )
+        assert response.status_code == 200
+        assert response.json()["model"] == "Tiny Test"
+        assert loads == [True]
+        assert manager.snapshots()[0].state is ModelState.READY
+        assert manager.snapshots()[0].active_requests == 0
+
+        unloaded = client.post("/control/v1/models/unload", headers=headers, json={"model": "tiny"})
+        assert unloaded.status_code == 200
+        assert unloaded.json() == {"model": "Tiny Test", "unloaded": True}
+        assert manager.snapshots()[0].state is ModelState.KNOWN
+
+    assert manager.closed
+
+
+def test_node_refuses_to_unload_a_model_with_an_active_lease():
+    manager = ModelManager(max_loaded_models=1)
+    manager.register(ModelDescriptor("model"), lambda: ModelRuntime(FakeModel(), FakeTokenizer()))
+    app = create_node_app(manager, api_keys=["secret"])
+
+    with TestClient(app) as client:
+        lease = manager.load("model")
+        response = client.post(
+            "/control/v1/models/unload",
+            headers={"Authorization": "Bearer secret"},
+            json={"model": "model"},
+        )
+        assert response.status_code == 409
+        lease.release()
+
+
+def test_node_parser_requires_explicit_network_opt_in():
+    parser = build_parser()
+    args = parser.parse_args(["manifest.json", "--initial_peers", "/ip4/127.0.0.1/tcp/1/p2p/fake", "--host", "0.0.0.0"])
+    with pytest.raises(SystemExit):
+        _validate_args(parser, args)
+
+    args.allow_network = True
+    _validate_args(parser, args)
+
+
+def test_node_parser_accepts_config_mode_and_rejects_ambiguous_model_options():
+    parser = build_parser()
+    config_args = parser.parse_args(["--config", "node.json"])
+    _validate_args(parser, config_args)
+
+    both = parser.parse_args(
+        [
+            "manifest.json",
+            "--config",
+            "node.json",
+            "--initial_peers",
+            "/ip4/127.0.0.1/tcp/1/p2p/fake",
+        ]
+    )
+    with pytest.raises(SystemExit):
+        _validate_args(parser, both)
+
+    scoped_override = parser.parse_args(["--config", "node.json", "--initial_peers", "/ip4/127.0.0.1/tcp/1/p2p/fake"])
+    with pytest.raises(SystemExit):
+        _validate_args(parser, scoped_override)
+
+    non_finite_timeout = parser.parse_args(
+        [
+            "manifest.json",
+            "--initial_peers",
+            "/ip4/127.0.0.1/tcp/1/p2p/fake",
+            "--request_timeout",
+            "NaN",
+        ]
+    )
+    with pytest.raises(SystemExit):
+        _validate_args(parser, non_finite_timeout)
+
+
+def test_manifest_loader_pins_identity_and_closes_client_dht(monkeypatch, tmp_path):
+    manifest = ModelManifest.load("tests/data/model_manifest_v1_vector.json")
+    calls = SimpleNamespace(metadata=[], tokenizer=None, model=None, shutdown=0, dht_shutdown=0)
+
+    class FakeVerifier:
+        def __init__(self, checked_manifest, **kwargs):
+            assert checked_manifest is manifest
+            assert kwargs["repository"] == manifest.source.repository
+            assert kwargs["revision"] == manifest.source.revision
+            self.snapshot_root = tmp_path
+
+        def ensure_startup_metadata(self, **kwargs):
+            calls.metadata.append(kwargs)
+
+    class FakeAutoTokenizer:
+        @classmethod
+        def from_pretrained(cls, source, **kwargs):
+            calls.tokenizer = (source, kwargs)
+            return FakeTokenizer()
+
+    class FakeDHT:
+        def is_alive(self):
+            return True
+
+        def shutdown(self):
+            calls.dht_shutdown += 1
+
+    class FakeSequenceManager:
+        dht = FakeDHT()
+
+        def shutdown(self):
+            calls.shutdown += 1
+
+    fake_model = FakeModel()
+    fake_model.transformer = SimpleNamespace(h=SimpleNamespace(sequence_manager=FakeSequenceManager()))
+
+    class FakeAutoModel:
+        @classmethod
+        def from_pretrained(cls, repository, **kwargs):
+            calls.model = (repository, kwargs)
+            return fake_model
+
+    monkeypatch.setattr("drift.node.loading.ManifestArtifactVerifier", FakeVerifier)
+    monkeypatch.setattr("transformers.AutoTokenizer", FakeAutoTokenizer)
+    monkeypatch.setattr("drift.AutoDistributedModelForCausalLM", FakeAutoModel)
+
+    runtime = make_manifest_loader(
+        manifest,
+        initial_peers=["/ip4/127.0.0.1/tcp/1/p2p/fake"],
+        revocation_files=["revoked.json"],
+        request_timeout=7,
+        max_retries=2,
+    )()
+
+    assert calls.metadata == [{"include_tokenizer": True}]
+    assert calls.tokenizer == (tmp_path, {"local_files_only": True})
+    repository, kwargs = calls.model
+    assert repository == manifest.source.repository
+    assert kwargs["revision"] == manifest.source.revision
+    assert kwargs["dht_prefix"] == manifest.dht_prefix
+    assert kwargs["manifest_digest"] == manifest.digest
+    assert kwargs["manifest_execution_profile"] == manifest.runtime.to_dict()
+    assert kwargs["request_timeout"] == 7
+    assert kwargs["max_retries"] == 2
+    assert kwargs["artifact_verifier"].snapshot_root == tmp_path
+
+    runtime.close()
+    runtime.close()
+    assert calls.shutdown == 1
+    assert calls.dht_shutdown == 1

--- a/tests/test_node_config.py
+++ b/tests/test_node_config.py
@@ -1,0 +1,109 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from drift.cli.run_node import _build_model_manager
+from drift.model_manifest import ModelManifest
+from drift.node.config import NODE_CONFIG_SCHEMA_VERSION, NodeConfig, NodeConfigError, NodeModelConfig
+from drift.node.model_manager import ModelRuntime, ModelState
+
+
+def _config_dict(**overrides):
+    source = {
+        "schema_version": 1,
+        "max_loaded_models": 1,
+        "models": [
+            {
+                "manifest": "manifests/one.json",
+                "initial_peers": ["/ip4/127.0.0.1/tcp/31337/p2p/one"],
+                "cache_dir": "cache/one",
+                "revocation_files": ["trust/revoked.json"],
+                "request_timeout": 7.5,
+                "max_retries": 2,
+            }
+        ],
+    }
+    source.update(overrides)
+    return source
+
+
+def test_node_config_resolves_paths_relative_to_its_own_directory(tmp_path):
+    config = NodeConfig.from_json(json.dumps(_config_dict()), base_dir=tmp_path)
+
+    assert config.schema_version == NODE_CONFIG_SCHEMA_VERSION
+    assert config.max_loaded_models == 1
+    model = config.models[0]
+    assert model.manifest_path == (tmp_path / "manifests/one.json").resolve()
+    assert model.cache_dir == (tmp_path / "cache/one").resolve()
+    assert model.revocation_files == ((tmp_path / "trust/revoked.json").resolve(),)
+    assert model.request_timeout == 7.5
+    assert model.max_retries == 2
+
+
+def test_node_config_is_strict_and_does_not_accept_secrets(tmp_path):
+    source = _config_dict()
+    source["models"][0]["token"] = "must-not-live-here"
+
+    with pytest.raises(NodeConfigError, match="unknown field.*token"):
+        NodeConfig.from_dict(source, base_dir=tmp_path)
+
+
+@pytest.mark.parametrize(
+    "source, message",
+    [
+        ('{"schema_version":1,"schema_version":1,"models":[]}', "duplicate object key"),
+        (json.dumps(_config_dict(max_loaded_models=0)), "max_loaded_models"),
+        (json.dumps(_config_dict(models=[])), "non-empty JSON array"),
+        (
+            json.dumps(
+                _config_dict(
+                    models=[{"manifest": "one.json", "initial_peers": []}],
+                )
+            ),
+            "initial_peers",
+        ),
+    ],
+)
+def test_node_config_rejects_malformed_inputs(tmp_path, source, message):
+    with pytest.raises(NodeConfigError, match=message):
+        NodeConfig.from_json(source, base_dir=tmp_path)
+
+
+def test_build_manager_registers_multiple_manifests_without_loading(monkeypatch, tmp_path):
+    first = ModelManifest.load("tests/data/model_manifest_v1_vector.json")
+    second_dict = first.to_dict()
+    second_dict["name"] = "Second Test Model"
+    second_dict["aliases"] = ["second-test"]
+    second = ModelManifest.from_dict(second_dict)
+    first_path = tmp_path / "first.json"
+    second_path = tmp_path / "second.json"
+    first_path.write_text(first.canonical_json(), encoding="utf-8")
+    second_path.write_text(second.canonical_json(), encoding="utf-8")
+    loader_calls = []
+
+    def fake_make_loader(manifest, **kwargs):
+        loader_calls.append((manifest.digest_id, kwargs))
+        return lambda: ModelRuntime(object(), object())
+
+    monkeypatch.setattr("drift.cli.run_node.make_manifest_loader", fake_make_loader)
+    config = NodeConfig(
+        schema_version=1,
+        max_loaded_models=1,
+        models=(
+            NodeModelConfig(first_path, ("peer-one",)),
+            NodeModelConfig(second_path, ("peer-two",), cache_dir=Path("cache"), request_timeout=9, max_retries=4),
+        ),
+    )
+
+    manager, descriptors = _build_model_manager(config, token="provider-token")
+
+    assert [descriptor.model_id for descriptor in descriptors] == [first.name, second.name]
+    assert [snapshot.state for snapshot in manager.snapshots()] == [ModelState.KNOWN, ModelState.KNOWN]
+    assert manager.residency() == {"max_loaded_models": 1, "resident_models": 0}
+    assert loader_calls[0][1]["initial_peers"] == ("peer-one",)
+    assert loader_calls[1][1]["initial_peers"] == ("peer-two",)
+    assert loader_calls[1][1]["cache_dir"] == "cache"
+    assert loader_calls[1][1]["request_timeout"] == 9
+    assert loader_calls[1][1]["max_retries"] == 4
+    assert all(call[1]["token"] == "provider-token" for call in loader_calls)

--- a/tests/test_node_config.py
+++ b/tests/test_node_config.py
@@ -1,11 +1,12 @@
 import json
+import sys
 from pathlib import Path
 
 import pytest
 
-from drift.cli.run_node import _build_model_manager
+from drift.cli.run_node import _build_model_manager, _build_worker_supervisor
 from drift.model_manifest import ModelManifest
-from drift.node.config import NODE_CONFIG_SCHEMA_VERSION, NodeConfig, NodeConfigError, NodeModelConfig
+from drift.node.config import NODE_CONFIG_SCHEMA_VERSION, NodeConfig, NodeConfigError, NodeModelConfig, WorkerConfig
 from drift.node.model_manager import ModelRuntime, ModelState
 
 
@@ -13,6 +14,8 @@ def _config_dict(**overrides):
     source = {
         "schema_version": 1,
         "max_loaded_models": 1,
+        "discovery_update_period": 12,
+        "discovery_startup_timeout": 4,
         "models": [
             {
                 "manifest": "manifests/one.json",
@@ -33,6 +36,8 @@ def test_node_config_resolves_paths_relative_to_its_own_directory(tmp_path):
 
     assert config.schema_version == NODE_CONFIG_SCHEMA_VERSION
     assert config.max_loaded_models == 1
+    assert config.discovery_update_period == 12
+    assert config.discovery_startup_timeout == 4
     model = config.models[0]
     assert model.manifest_path == (tmp_path / "manifests/one.json").resolve()
     assert model.cache_dir == (tmp_path / "cache/one").resolve()
@@ -47,6 +52,38 @@ def test_node_config_is_strict_and_does_not_accept_secrets(tmp_path):
 
     with pytest.raises(NodeConfigError, match="unknown field.*token"):
         NodeConfig.from_dict(source, base_dir=tmp_path)
+
+
+def test_node_config_parses_strict_worker_controls(tmp_path):
+    source = _config_dict(
+        workers=[
+            {
+                "id": "gpu-0",
+                "model": "tiny-test",
+                "identity_path": "secrets/gpu-0.key",
+                "block_indices": "0:4",
+                "enabled": True,
+                "auto_restart": False,
+                "restart_backoff": 2,
+                "device": "cuda:0",
+                "cache_dir": "worker-cache",
+                "max_disk_space": "20GiB",
+                "throughput": 1.5,
+                "port": 31337,
+                "public_ip": "203.0.113.4",
+            }
+        ]
+    )
+
+    worker = NodeConfig.from_dict(source, base_dir=tmp_path).workers[0]
+
+    assert worker.worker_id == "gpu-0"
+    assert worker.identity_path == (tmp_path / "secrets/gpu-0.key").resolve()
+    assert worker.block_indices == "0:4"
+    assert worker.enabled is True
+    assert worker.auto_restart is False
+    assert worker.throughput == 1.5
+    assert worker.port == 31337
 
 
 @pytest.mark.parametrize(
@@ -96,7 +133,7 @@ def test_build_manager_registers_multiple_manifests_without_loading(monkeypatch,
         ),
     )
 
-    manager, descriptors = _build_model_manager(config, token="provider-token")
+    manager, descriptors, discovery = _build_model_manager(config, token="provider-token")
 
     assert [descriptor.model_id for descriptor in descriptors] == [first.name, second.name]
     assert [snapshot.state for snapshot in manager.snapshots()] == [ModelState.KNOWN, ModelState.KNOWN]
@@ -107,3 +144,44 @@ def test_build_manager_registers_multiple_manifests_without_loading(monkeypatch,
     assert loader_calls[1][1]["request_timeout"] == 9
     assert loader_calls[1][1]["max_retries"] == 4
     assert all(call[1]["token"] == "provider-token" for call in loader_calls)
+    assert discovery.snapshot(first.digest_id)["status"] == "unknown"
+    manager.shutdown()
+
+
+def test_worker_supervisor_command_is_pinned_to_configured_manifest(monkeypatch, tmp_path):
+    manifest = ModelManifest.load("tests/data/model_manifest_v1_vector.json")
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(manifest.canonical_json(), encoding="utf-8")
+    monkeypatch.setattr(
+        "drift.cli.run_node.make_manifest_loader",
+        lambda *args, **kwargs: lambda: ModelRuntime(object(), object()),
+    )
+    config = NodeConfig(
+        schema_version=1,
+        max_loaded_models=1,
+        models=(NodeModelConfig(manifest_path, ("peer-one",)),),
+        workers=(
+            WorkerConfig(
+                worker_id="worker",
+                model=manifest.aliases[0],
+                identity_path=tmp_path / "worker.key",
+                num_blocks=2,
+                throughput=1.25,
+            ),
+        ),
+    )
+    manager, _, _ = _build_model_manager(config, token=None)
+
+    supervisor = _build_worker_supervisor(config, manager, token="provider-token")
+    launch = supervisor.launches[0]
+
+    assert launch.model_id == manifest.name
+    assert launch.command[:4] == (sys.executable, "-m", "drift.cli", "server")
+    assert "--model_manifest" in launch.command
+    assert str(manifest_path) in launch.command
+    assert launch.command[launch.command.index("--num_blocks") + 1] == "2"
+    assert launch.command[launch.command.index("--throughput") + 1] == "1.25"
+    assert "provider-token" not in launch.command
+    assert launch.environment == (("HF_TOKEN", "provider-token"),)
+    supervisor.shutdown()
+    manager.shutdown()

--- a/tests/test_official_openai_client.py
+++ b/tests/test_official_openai_client.py
@@ -1,0 +1,102 @@
+"""Compatibility gate against the official OpenAI Python client over a real TCP socket."""
+
+import socket
+import threading
+import time
+from contextlib import contextmanager
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+pytest.importorskip("fastapi")
+openai = pytest.importorskip("openai")
+uvicorn = pytest.importorskip("uvicorn")
+
+from drift.api.server import create_app
+
+
+class _Tokenizer:
+    eos_token_id = 0
+
+    def apply_chat_template(self, messages, **kwargs):
+        return {"input_ids": torch.tensor([[1, 2]])}
+
+    def __call__(self, text, return_tensors=None):
+        return SimpleNamespace(input_ids=torch.tensor([[1, 2]]))
+
+    def decode(self, ids, **kwargs):
+        return " ".join(f"tok{token}" for token in torch.as_tensor(ids).flatten().tolist())
+
+
+class _Model:
+    def generate(self, input_ids, streamer=None, max_new_tokens=None, **kwargs):
+        tokens = [101, 102, 103][:max_new_tokens]
+        outputs = torch.cat([input_ids, torch.tensor([tokens])], dim=1)
+        if streamer is not None:
+            streamer.put(input_ids)
+            for token in tokens:
+                streamer.put(torch.tensor([[token]]))
+            streamer.end()
+        return outputs
+
+
+@contextmanager
+def _live_server(app):
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    listener.bind(("127.0.0.1", 0))
+    port = listener.getsockname()[1]
+    server = uvicorn.Server(uvicorn.Config(app, log_level="error", lifespan="off"))
+    thread = threading.Thread(target=server.run, kwargs={"sockets": [listener]}, daemon=True)
+    thread.start()
+    deadline = time.monotonic() + 5
+    while not server.started and thread.is_alive() and time.monotonic() < deadline:
+        time.sleep(0.01)
+    if not server.started:
+        server.should_exit = True
+        thread.join(timeout=2)
+        listener.close()
+        raise RuntimeError("the localhost compatibility server did not start")
+    try:
+        yield f"http://127.0.0.1:{port}/v1"
+    finally:
+        server.should_exit = True
+        thread.join(timeout=5)
+        listener.close()
+        assert not thread.is_alive(), "the localhost compatibility server did not stop"
+
+
+def test_official_python_client_models_completions_chat_and_streaming():
+    app = create_app(_Model(), _Tokenizer(), model_name="local-test", api_keys=["local-key"])
+    with _live_server(app) as base_url:
+        client = openai.OpenAI(api_key="local-key", base_url=base_url, max_retries=0, timeout=5)
+
+        models = client.models.list()
+        completion = client.completions.create(model="local-test", prompt="hello", max_tokens=2, temperature=0)
+        chat = client.chat.completions.create(
+            model="local-test", messages=[{"role": "user", "content": "hello"}], max_tokens=3, temperature=0
+        )
+        stream = client.chat.completions.create(
+            model="local-test",
+            messages=[{"role": "user", "content": "hello"}],
+            max_tokens=3,
+            temperature=0,
+            stream=True,
+        )
+        streamed = "".join(chunk.choices[0].delta.content or "" for chunk in stream if chunk.choices)
+
+        assert [model.id for model in models.data] == ["local-test"]
+        assert completion.model == "local-test"
+        assert completion.choices[0].text == "tok101 tok102"
+        assert chat.model == "local-test"
+        assert chat.choices[0].message.content == "tok101 tok102 tok103"
+        assert streamed.replace(" ", "") == "tok101tok102tok103"
+
+
+def test_official_python_client_observes_bearer_authentication():
+    app = create_app(_Model(), _Tokenizer(), model_name="local-test", api_keys=["local-key"])
+    with _live_server(app) as base_url:
+        client = openai.OpenAI(api_key="wrong-key", base_url=base_url, max_retries=0, timeout=5)
+        with pytest.raises(openai.AuthenticationError):
+            client.models.list()

--- a/tests/test_openai_api.py
+++ b/tests/test_openai_api.py
@@ -4,9 +4,12 @@ mapping, non-streaming and SSE responses, auth. No swarm, no network -- the mode
 are minimal fakes; the streaming path still runs through the real transformers TextIteratorStreamer.
 """
 
+import asyncio
 import json
+import threading
 from types import SimpleNamespace
 
+import httpx
 import pytest
 import torch
 
@@ -14,6 +17,7 @@ pytest.importorskip("fastapi")
 from fastapi.testclient import TestClient
 
 from drift.api.server import build_generate_kwargs, create_app, message_text, trim_stop_strings
+from drift.node.model_manager import ModelDescriptor, ModelManager, ModelRuntime, ModelState
 
 NEW_TOKENS = [101, 102, 103]
 
@@ -105,6 +109,32 @@ def test_chat_completion_non_stream(api):
     assert api.model.last_gen_kwargs["do_sample"] is False
 
 
+def test_requested_model_must_resolve_exactly(api):
+    response = api.client.post(
+        "/v1/chat/completions",
+        json={"model": "different/model", "messages": [{"role": "user", "content": "hi"}]},
+    )
+    assert response.status_code == 404
+    assert "unknown model" in response.json()["detail"]
+
+
+def test_multi_model_requests_require_and_select_a_registered_model():
+    first, second = FakeModel(), FakeModel()
+    manager = ModelManager()
+    manager.register_loaded("first", first, FakeTokenizer())
+    manager.register_loaded("second", second, FakeTokenizer(), aliases=("second-alias",))
+    client = TestClient(create_app(model_manager=manager))
+
+    missing = client.post("/v1/completions", json={"prompt": "hi"})
+    assert missing.status_code == 400
+
+    selected = client.post("/v1/completions", json={"model": "second-alias", "prompt": "hi"})
+    assert selected.status_code == 200
+    assert selected.json()["model"] == "second"
+    assert first.last_gen_kwargs is None
+    assert second.last_gen_kwargs is not None
+
+
 def test_chat_completion_finish_reason_length(api):
     response = api.client.post(
         "/v1/chat/completions",
@@ -171,3 +201,72 @@ def test_api_cli_rejects_revocations_outside_manifest_mode(monkeypatch):
     )
     with pytest.raises(SystemExit):
         run_api.main()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_lazy_load_releases_its_eventual_runtime_lease():
+    loader_started = threading.Event()
+    allow_loader_to_finish = threading.Event()
+    manager = ModelManager(max_loaded_models=1)
+
+    def loader():
+        loader_started.set()
+        assert allow_loader_to_finish.wait(timeout=2)
+        return ModelRuntime(FakeModel(), FakeTokenizer())
+
+    manager.register(ModelDescriptor("model"), loader)
+    app = create_app(model_manager=manager)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        request = asyncio.create_task(client.post("/v1/completions", json={"model": "model", "prompt": "hi"}))
+        loop = asyncio.get_running_loop()
+        assert await loop.run_in_executor(None, loader_started.wait, 1)
+        request.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await request
+        allow_loader_to_finish.set()
+
+        for _ in range(100):
+            snapshot = manager.snapshots()[0]
+            if snapshot.state is ModelState.READY and snapshot.active_requests == 0:
+                break
+            await asyncio.sleep(0.01)
+        else:
+            pytest.fail("cancelled load left a runtime lease active")
+
+    manager.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_generation_keeps_lease_until_executor_finishes():
+    generation_started = threading.Event()
+    allow_generation_to_finish = threading.Event()
+
+    class BlockingModel(FakeModel):
+        def generate(self, input_ids, **kwargs):
+            generation_started.set()
+            assert allow_generation_to_finish.wait(timeout=2)
+            return torch.cat([input_ids, torch.tensor([[101]])], dim=1)
+
+    manager = ModelManager(max_loaded_models=1)
+    manager.register_loaded("model", BlockingModel(), FakeTokenizer())
+    app = create_app(model_manager=manager)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        request = asyncio.create_task(client.post("/v1/completions", json={"model": "model", "prompt": "hi"}))
+        loop = asyncio.get_running_loop()
+        assert await loop.run_in_executor(None, generation_started.wait, 1)
+        request.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await request
+
+        assert manager.snapshots()[0].active_requests == 1
+        allow_generation_to_finish.set()
+        for _ in range(100):
+            if manager.snapshots()[0].active_requests == 0:
+                break
+            await asyncio.sleep(0.01)
+        else:
+            pytest.fail("cancelled generation released its runtime too early or stranded the lease")
+
+    manager.shutdown()

--- a/tests/test_openai_api.py
+++ b/tests/test_openai_api.py
@@ -45,6 +45,8 @@ class FakeModel:
 
     def generate(self, input_ids, tokenizer=None, streamer=None, max_new_tokens=None, **kwargs):
         self.last_gen_kwargs = dict(kwargs, max_new_tokens=max_new_tokens)
+        if tokenizer is not None:
+            self.last_gen_kwargs["tokenizer"] = tokenizer
         new_tokens = NEW_TOKENS[: max_new_tokens if max_new_tokens is not None else len(NEW_TOKENS)]
         output_ids = torch.cat([input_ids, torch.tensor([new_tokens])], dim=1)
         if streamer is not None:
@@ -116,6 +118,19 @@ def test_requested_model_must_resolve_exactly(api):
     )
     assert response.status_code == 404
     assert "unknown model" in response.json()["detail"]
+
+
+def test_tokenizer_generate_kwarg_is_only_sent_for_stop_strings(api):
+    plain = api.client.post("/v1/completions", json={"model": "fake/model", "prompt": "hi", "temperature": 0})
+    assert plain.status_code == 200
+    assert "tokenizer" not in api.model.last_gen_kwargs
+
+    stopped = api.client.post(
+        "/v1/completions",
+        json={"model": "fake/model", "prompt": "hi", "temperature": 0, "stop": "tok102"},
+    )
+    assert stopped.status_code == 200
+    assert api.model.last_gen_kwargs["tokenizer"].__class__ is FakeTokenizer
 
 
 def test_multi_model_requests_require_and_select_a_registered_model():

--- a/tests/test_route_health.py
+++ b/tests/test_route_health.py
@@ -1,0 +1,66 @@
+import time
+from types import SimpleNamespace
+
+from drift.node.route_health import sequence_manager_route_health
+
+
+class Lock:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return None
+
+
+def _manager(spans_by_block, *, updated=True):
+    return SimpleNamespace(
+        lock_changes=Lock(),
+        state=SimpleNamespace(
+            sequence_info=SimpleNamespace(
+                block_uids=tuple(f"block-{index}" for index in range(len(spans_by_block))),
+                spans_containing_block=tuple(spans_by_block),
+                last_updated_time=time.perf_counter() if updated else None,
+            )
+        ),
+    )
+
+
+def test_route_health_distinguishes_unknown_from_missing_coverage():
+    unknown = sequence_manager_route_health(_manager([[], []], updated=False))
+
+    assert unknown["status"] == "unknown"
+    assert unknown["total_blocks"] == 2
+    assert unknown["covered_blocks"] is None
+    assert unknown["missing_blocks"] is None
+
+
+def test_route_health_reports_complete_coverage_and_replica_counts():
+    peer_a, peer_b = object(), object()
+    health = sequence_manager_route_health(
+        _manager(
+            [
+                [SimpleNamespace(peer_id=peer_a)],
+                [SimpleNamespace(peer_id=peer_a), SimpleNamespace(peer_id=peer_b)],
+                [SimpleNamespace(peer_id=peer_b)],
+            ]
+        )
+    )
+
+    assert health["status"] == "complete"
+    assert health["covered_blocks"] == 3
+    assert health["missing_blocks"] == []
+    assert health["replica_counts"] == [1, 2, 1]
+    assert health["minimum_replicas"] == 1
+    assert health["peer_count"] == 2
+    assert health["last_updated_age"] >= 0
+
+
+def test_route_health_reports_exact_missing_blocks():
+    health = sequence_manager_route_health(
+        _manager([[SimpleNamespace(peer_id=object())], [], [SimpleNamespace(peer_id=object())], []])
+    )
+
+    assert health["status"] == "incomplete"
+    assert health["covered_blocks"] == 2
+    assert health["missing_blocks"] == [1, 3]
+    assert health["minimum_replicas"] == 0

--- a/tests/test_route_health.py
+++ b/tests/test_route_health.py
@@ -1,7 +1,8 @@
 import time
 from types import SimpleNamespace
 
-from drift.node.route_health import sequence_manager_route_health
+from drift.data_structures import RemoteModuleInfo, ServerState
+from drift.node.route_health import module_infos_route_health, sequence_manager_route_health
 
 
 class Lock:
@@ -64,3 +65,23 @@ def test_route_health_reports_exact_missing_blocks():
     assert health["covered_blocks"] == 2
     assert health["missing_blocks"] == [1, 3]
     assert health["minimum_replicas"] == 0
+
+
+def test_module_info_health_ignores_joining_workers():
+    online, joining = object(), object()
+    health = module_infos_route_health(
+        [
+            RemoteModuleInfo(
+                "model.0",
+                {
+                    online: SimpleNamespace(state=ServerState.ONLINE),
+                    joining: SimpleNamespace(state=ServerState.JOINING),
+                },
+            ),
+            RemoteModuleInfo("model.1", {joining: SimpleNamespace(state=ServerState.JOINING)}),
+        ]
+    )
+
+    assert health["status"] == "incomplete"
+    assert health["replica_counts"] == [1, 0]
+    assert health["missing_blocks"] == [1]

--- a/tests/test_worker_supervisor.py
+++ b/tests/test_worker_supervisor.py
@@ -1,0 +1,60 @@
+import sys
+import time
+
+from drift.node.worker_supervisor import WorkerLaunch, WorkerState, WorkerSupervisor
+
+
+def _wait_for(predicate, timeout=2):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.01)
+    raise AssertionError("condition was not reached before timeout")
+
+
+def test_supervisor_starts_and_pauses_an_isolated_worker_process():
+    launch = WorkerLaunch(
+        "worker",
+        "model",
+        (
+            sys.executable,
+            "-c",
+            "import os,time; print(os.environ['DRIFT_WORKER_TEST_VALUE'], flush=True); time.sleep(30)",
+        ),
+        auto_restart=False,
+        environment=(("DRIFT_WORKER_TEST_VALUE", "configured"),),
+    )
+    supervisor = WorkerSupervisor([launch], stop_timeout=2, poll_period=0.01)
+    supervisor.start_service()
+
+    assert supervisor.start_worker("WORKER") is True
+    _wait_for(lambda: supervisor.snapshot("worker")["state"] == WorkerState.RUNNING.value)
+    assert supervisor.snapshot("worker")["pid"] is not None
+    _wait_for(lambda: supervisor.snapshot("worker")["recent_logs"] == ["configured"])
+
+    assert supervisor.pause_worker("worker") is True
+    snapshot = supervisor.snapshot("worker")
+    assert snapshot["state"] == WorkerState.PAUSED.value
+    assert snapshot["pid"] is None
+    assert snapshot["recent_logs"] == ["configured"]
+    supervisor.shutdown()
+
+
+def test_crashed_worker_restarts_without_affecting_supervisor():
+    launch = WorkerLaunch(
+        "worker",
+        "model",
+        (sys.executable, "-c", "raise SystemExit(7)"),
+        auto_start=True,
+        auto_restart=True,
+        restart_backoff=0.02,
+    )
+    supervisor = WorkerSupervisor([launch], stop_timeout=2, poll_period=0.01)
+    supervisor.start_service()
+
+    _wait_for(lambda: supervisor.snapshot("worker")["restart_count"] >= 1)
+    assert supervisor.snapshot("worker")["desired_running"] is True
+    supervisor.pause_worker("worker")
+    assert supervisor.snapshot("worker")["state"] == WorkerState.PAUSED.value
+    supervisor.shutdown()

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -496,6 +496,15 @@ wheels = [
 ]
 
 [[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
 name = "drift"
 source = { editable = "." }
 dependencies = [
@@ -522,9 +531,19 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+api = [
+    { name = "fastapi" },
+    { name = "uvicorn" },
+]
+benchmark = [
+    { name = "psutil" },
+]
 dev = [
     { name = "black" },
+    { name = "fastapi" },
+    { name = "httpx" },
     { name = "isort" },
+    { name = "openai" },
     { name = "psutil" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -539,13 +558,18 @@ requires-dist = [
     { name = "black", marker = "extra == 'dev'", specifier = "==22.3.0" },
     { name = "cpufeature", marker = "platform_machine == 'x86_64'", specifier = ">=0.2.0" },
     { name = "dijkstar", specifier = ">=2.6.0" },
+    { name = "fastapi", marker = "extra == 'api'", specifier = ">=0.115" },
+    { name = "fastapi", marker = "extra == 'dev'", specifier = ">=0.115" },
     { name = "hivemind", marker = "sys_platform != 'win32'", specifier = ">=1.1.12,<1.2" },
+    { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27" },
     { name = "huggingface-hub", specifier = ">=0.30" },
     { name = "humanfriendly" },
     { name = "isort", marker = "extra == 'dev'", specifier = "==5.10.1" },
     { name = "numpy", specifier = ">=1.26" },
+    { name = "openai", marker = "extra == 'dev'", specifier = ">=2,<3" },
     { name = "packaging", specifier = ">=20.9" },
     { name = "peft", specifier = ">=0.17" },
+    { name = "psutil", marker = "extra == 'benchmark'", specifier = ">=5.9" },
     { name = "psutil", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'", specifier = "==6.2.5" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = "==0.16.0" },
@@ -557,8 +581,9 @@ requires-dist = [
     { name = "tokenizers", specifier = ">=0.21" },
     { name = "torch", specifier = ">=2.6,<2.7" },
     { name = "transformers", specifier = ">=5.13,<5.14" },
+    { name = "uvicorn", marker = "extra == 'api'", specifier = ">=0.30" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["api", "benchmark", "dev"]
 
 [[package]]
 name = "exceptiongroup"
@@ -570,6 +595,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.141.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8a/02/91e3416a8fdd715abb903a952a6bec7cdd8d14eed55d415fc8595524c319/fastapi-0.141.1.tar.gz", hash = "sha256:e8822fc40db1e1858054d7a949a888695bc9bdce70139178e33bd2871a453ca1", size = 425799, upload-time = "2026-07-29T17:18:05.568Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/03/10388a42375ee7e4ac9b94eb2c5c569c8b5795e377e701c9ac3ad63de890/fastapi-0.141.1-py3-none-any.whl", hash = "sha256:bfb91aa2d334c61cb35ba9a116fc123b3d3df31640b801cf57a7a78ec3f603b3", size = 131954, upload-time = "2026-07-29T17:18:04.364Z" },
 ]
 
 [[package]]
@@ -873,6 +914,105 @@ wheels = [
 ]
 
 [[package]]
+name = "jiter"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/1f/10936e16d8860c70698a1aa939a46aa0224813b782bce4e000e637da0b2d/jiter-0.16.0.tar.gz", hash = "sha256:7b24c3492c5f4f84a37946ad9cf504910cf6a782d6a4e0689b6673c5894b4a1c", size = 176431, upload-time = "2026-06-29T13:05:13.657Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/d8/b959609e44012a42b1f3e5ba98ea3b33c7e41e6d4b77cd8f00fd19b1d3ad/jiter-0.16.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:c5fc4f8def331036a7b8e981b4347ebe409981edbc8308a5ea842b8c3614fa6c", size = 310082, upload-time = "2026-06-29T13:02:31.356Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/3d/4d7f5667ea0e0548534ba880b84bb3d12924fd133aa83ad6c6c80fca3d76/jiter-0.16.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5a71d0d2014c3275043e1170bf3d4e771493cb0dcf07be54c567155f4d8ee64b", size = 315643, upload-time = "2026-06-29T13:02:33.204Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/83/bed2dcb5c9f3e1ccfcbc67dda48265fe7d5ad0c9cadda5fe95f6e3b87f94/jiter-0.16.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:741eed508c233a76313a1c7b001f8f21b82f14327e9196ae8bd29a2cc164ae84", size = 341363, upload-time = "2026-06-29T13:02:34.853Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/2f/6bb3c3dda668ebc0445689c81a2b0f26a82b10843d67ed9c9b2c3edc177f/jiter-0.16.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3fb7bc819187b56dc48aa5c833aaf92257da8e07efdb9306156667bd2eeb491c", size = 365483, upload-time = "2026-06-29T13:02:36.295Z" },
+    { url = "https://files.pythonhosted.org/packages/92/35/8a045ccb39164e70dcdae696413b661771f148b68b12b175c3a04d901937/jiter-0.16.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7c9610fd25ebccb43fca584136f5c2fbb26802447eccd430dfdbab95a0fd5126", size = 461219, upload-time = "2026-06-29T13:02:38.116Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/99/22292dbbf0ed0c610cfe5ddc7f3bd67237a412f121318f865196e62a07bd/jiter-0.16.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4a1d68ff7ca1d3b5dee20a97a3decda7d5f15003823bf6d140c81f8561d3bc5c", size = 374905, upload-time = "2026-06-29T13:02:40.357Z" },
+    { url = "https://files.pythonhosted.org/packages/29/ac/2f55ccb1f0eeafa6d89d24caf52f6f0944a59290ee199e9ade62177dca42/jiter-0.16.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fb08c276dd02dac3a284acdd02cacc630d2e3cd6572a4b85519f35cbd133c3de", size = 348320, upload-time = "2026-06-29T13:02:41.923Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e3/7d88b9174c40064fabc07c84a9b62e6b10f5644562ec0e0a29392edbe978/jiter-0.16.0-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:8fc4d94713c4697347e38faf7d6ef91547c142219bdcfc7220c4870879974244", size = 356519, upload-time = "2026-06-29T13:02:43.436Z" },
+    { url = "https://files.pythonhosted.org/packages/27/57/c4a33aeef513a9d5e26e31534e0bcc752d6ea0e54c94ddb7b68bade669c2/jiter-0.16.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a0f05e229edb29e68cdd0ccb83cea13b64263416120cf943767a6fd72e6787f", size = 394204, upload-time = "2026-06-29T13:02:44.987Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/70/c6c23e76ebb3766b111bc399437bbc9f870a76e2a92e10b2a5f561d57372/jiter-0.16.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:2c842cbf374a8daf50b2c04212995bee34ca2ac2cdc29a901b4cdb072c9c4131", size = 521477, upload-time = "2026-06-29T13:02:46.724Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/d3/0001c8c0c5976af2625bb1cfb1895e8ec693b6589fe4574b8e6fc2c85501/jiter-0.16.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:5ed466aee31294d7cdcd4d37dfe5c42c97bc29d9a5f00eacf24504358309cb9b", size = 552187, upload-time = "2026-06-29T13:02:48.144Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/76/311b718e07e85740e48619c0632b36f7e0b8d113984499e436452ed13a9a/jiter-0.16.0-cp310-cp310-win32.whl", hash = "sha256:b42e9ff5376819c053da25809a8d4b6fa6e473b4856ebe42e298ac958be3d7f9", size = 206513, upload-time = "2026-06-29T13:02:49.515Z" },
+    { url = "https://files.pythonhosted.org/packages/db/7f/ac680eeb0777dc0eb7dc824800ba27880d7f6bc712e362d34ad8ee559f36/jiter-0.16.0-cp310-cp310-win_amd64.whl", hash = "sha256:10438939205546132189c8e74a2d536a707841f3a25cd7c74ee91fe503407a26", size = 199505, upload-time = "2026-06-29T13:02:50.829Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/3f/fae6cc967d120ec89e31c5418a51176d8278b3087fbb384a9176754f353c/jiter-0.16.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:67fddeda1688f0cce2d2ae83ccf8a80f79936f2d2997d6cc2261f82fdb54a4d3", size = 309289, upload-time = "2026-06-29T13:02:52.301Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/e3/97c6c3562c077f6247d6e6ce5c82562500b6316c0d928e97e106b7a1321a/jiter-0.16.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c90c0f63df322be920eda6ce622e3083d8906ba267f8220fe7873213b8b4430e", size = 315181, upload-time = "2026-06-29T13:02:53.964Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/89/d8d073f8aa2667e46c6c0873f86fe4a512bba4293cc730f626a076211a62/jiter-0.16.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:64c0203212098470032aabcde9356fc168f377aade3e43def61dfe17e92f2037", size = 340939, upload-time = "2026-06-29T13:02:55.412Z" },
+    { url = "https://files.pythonhosted.org/packages/87/c9/db4fda3ed73fb864139305e935e5b8b38a5a24692a5a9dd356c22f1b9c8d/jiter-0.16.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:12288303c9844e61e1651d02a9a6f6633e47d39f897d6991d1427161ce6b746e", size = 364932, upload-time = "2026-06-29T13:02:57.28Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/74/52b5e86241057f52ddd7c9a580f90effb51f9d06239f6fc612279b91a838/jiter-0.16.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5cf109d010b4b05a105afb3d43be36a21322d345ad3111e13d15f680afef0e5b", size = 461132, upload-time = "2026-06-29T13:02:58.994Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/87/544a700f7447c1f31c5d7833821a4daa5683165c2d5a094fbf5b5800c3dc/jiter-0.16.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:62c1b7fe1f77925acf5af68b6140b8810fa87dfd4dc0a9c8568ec2fa2a10429c", size = 374857, upload-time = "2026-06-29T13:03:00.455Z" },
+    { url = "https://files.pythonhosted.org/packages/40/cd/0fcc3f7d39183674d5bfa9ec640faaeb506c60be7c8f94625dfba366e37c/jiter-0.16.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8597d23c87f59294f83bcb6229b9ed1fccee13dbba967b46930d2f1759466fee", size = 347053, upload-time = "2026-06-29T13:03:02.045Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/ae/c7e64e7932ad597fa395b61440b249ada6366716e25c6e08dd2afbd021e6/jiter-0.16.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:3126a5dbad56401989ac769aca0cb56005bfb3e2366eea0ca99d1a91c3c1ee03", size = 356153, upload-time = "2026-06-29T13:03:03.706Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/1c/1c719044f14da814e1a060191ab19b96f3e99207bc5b4bfc6d6be34b3f80/jiter-0.16.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c4b4717bdb35ae456f831a6b08d01880fff399887a6bbc526a583a406e484eea", size = 393956, upload-time = "2026-06-29T13:03:05.165Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/dc/7b2f303a2847207e265503853a2d964a55354cffd62a5f2936c155486798/jiter-0.16.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:adff21bc78edfe086c15eb495b900306076de378dc2337c132401fc39bd79c91", size = 521081, upload-time = "2026-06-29T13:03:06.886Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/5f/501cf6e1e09caeb420195179ffc6f62aca603f1220ec53fd80d0d70b3e56/jiter-0.16.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:dab907db06fc593645e73109acf4581ba5b548897d28b9348dc41ddc8343b2d3", size = 552085, upload-time = "2026-06-29T13:03:08.339Z" },
+    { url = "https://files.pythonhosted.org/packages/79/54/aa5be86520113b79455c3877f3d1f07a348098df4083ba3688e9537e52dd/jiter-0.16.0-cp311-cp311-win32.whl", hash = "sha256:560b2cf3fb03240cd34f27409a238547488708f05b7c3924f571a60422251ec7", size = 206755, upload-time = "2026-06-29T13:03:09.653Z" },
+    { url = "https://files.pythonhosted.org/packages/64/ec/2feb893eb330bd69b413866f4d5daada33c3962f1c6f270c91ca2d87fdf9/jiter-0.16.0-cp311-cp311-win_amd64.whl", hash = "sha256:e431cfc9caf44c1d5459ff77d4e64cbf85fddb6a35dad836a15c6a9ec23087c1", size = 199155, upload-time = "2026-06-29T13:03:10.979Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9c/ca040d94415048a3666fc237774df8151c96f8d2b661cbe3b184acc95876/jiter-0.16.0-cp311-cp311-win_arm64.whl", hash = "sha256:2a8e9e39cf083016137aa5cadafe3188adc2ba6ba1fbf1e5d18889ad3e9ad056", size = 194403, upload-time = "2026-06-29T13:03:12.341Z" },
+    { url = "https://files.pythonhosted.org/packages/83/2b/52ace16ed031354f0539749a49e4bf33797d82bea5137910835fa4b09793/jiter-0.16.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:67c3bc1760f8c99d805dcab4e644027142a53b1d5d861f18780ebdbd5d40b72a", size = 306943, upload-time = "2026-06-29T13:03:14.035Z" },
+    { url = "https://files.pythonhosted.org/packages/94/2e/34957c2c1b661c252ba9bcc60ae0bddc27e0f7202c6073326a13c5390eec/jiter-0.16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5af7780e4a26bd7d0d989592bf9ef12ebf806b74ab709223ecca37c749872ea9", size = 307779, upload-time = "2026-06-29T13:03:15.418Z" },
+    { url = "https://files.pythonhosted.org/packages/88/6c/59bd309cab4460c54cf1079f3eb7fe7af6a4c895c5c957a53378693bad2b/jiter-0.16.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d5bf78d0e05e45cfdd66558893938d59afe3d1b1a824a202039b20e607d25a72", size = 335826, upload-time = "2026-06-29T13:03:17.11Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/8c/f5ef7b65f0df47afa16596969defb281ebb86e96df346d62be6fd853d620/jiter-0.16.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f4444a83f946605990c98f625cdd3d2725bfb818158760c5748c653170a20e0e", size = 362573, upload-time = "2026-06-29T13:03:18.781Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0b/ace4354da061ee38844a0c27dc2c21eecd27aea119e8da324bea987522d0/jiter-0.16.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3a23f0e4f957e1be65752d2dfac9a5a06b1917af8dc85deb639c3b9d02e31290", size = 457979, upload-time = "2026-06-29T13:03:20.293Z" },
+    { url = "https://files.pythonhosted.org/packages/55/40/c0253d3772eb9dcd8e6606ee9b2d53ec8e5b814589c47f140aa585f21eaa/jiter-0.16.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c22a488f7b9218e245a0025a9ba6b100e2e54700831cf4cf16833a27fba3ad01", size = 372302, upload-time = "2026-06-29T13:03:21.739Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/d2/4839422241aa12860ce597b20068727094ba0bc480723c74924ca5bad483/jiter-0.16.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:46add52f4ad47a08bfb1219f3e673da972191489a33016edefdb5ea55bfa8c48", size = 343805, upload-time = "2026-06-29T13:03:23.384Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/59/e196888a05befdda7dbe299b722d56f2f6eec65402bc34c0a3306d595feb/jiter-0.16.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:9c8a956fd72c2cf1e730d01ea080341f13aa0a97a4a33b51abebe725b7ae9ca9", size = 351107, upload-time = "2026-06-29T13:03:24.815Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/74/4cd9e0fca65232136400354b630fbfcd2de634e22ccbb96567725981b548/jiter-0.16.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:561926e0573ffe4a32498420a76d64b16c513e1ab413b9d28158a8764ac701e5", size = 388441, upload-time = "2026-06-29T13:03:26.266Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/8c/554691e48bc711299c0a293dd8a6179e24b2d66a54dc295421fcf64569c0/jiter-0.16.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:44d019fa8cdaf89bf29c71b39e3712143fdd0ac76725c6ef954f9957a5ea8730", size = 516354, upload-time = "2026-06-29T13:03:28.02Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/cb/01e9d69dc2cc6759d4f91e230b34489c4fdb2518992650633f9e20bece89/jiter-0.16.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:0df91907609837f33341b8e6fe73b95991fdaa57caf1a0fbd343dffe826f386f", size = 547880, upload-time = "2026-06-29T13:03:29.534Z" },
+    { url = "https://files.pythonhosted.org/packages/79/70/2953195f1c6ad00f49fa67e13df7e60acb3dd4f387101bc15abccddd905e/jiter-0.16.0-cp312-cp312-win32.whl", hash = "sha256:51d7b836acb0108d7c77df1742332cac2a1fa04a74d6dacec46e7091f0e91274", size = 203473, upload-time = "2026-06-29T13:03:31.025Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/05/2909a8b10699a4d560f8c502b6b2c5f3991b682b1922c1eedda242b225bd/jiter-0.16.0-cp312-cp312-win_amd64.whl", hash = "sha256:1878349266f8ee36ecb1375cc5ba2f115f35fd9f0a1a4119e725e379126647f7", size = 196905, upload-time = "2026-06-29T13:03:32.472Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a9/6b82bb1c8d7790d602489b967b982a909e5d092875a6c2ade96444c8dfc5/jiter-0.16.0-cp312-cp312-win_arm64.whl", hash = "sha256:2ed5738ae4af18271a51a528b8811b0cbfa4a1858de9d83359e4169855d6a331", size = 190618, upload-time = "2026-06-29T13:03:34.672Z" },
+    { url = "https://files.pythonhosted.org/packages/91/c0/555fc60473d30d66894ba825e63615e3be7524fac23858356afa7a38906c/jiter-0.16.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:41977aa5654023948c2dae2a81cbf9c43343954bef1cd59a154dd15a4d84c195", size = 306203, upload-time = "2026-06-29T13:03:36.243Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/2b/c3eaf16f5d7c9bad66ea32f40a95bd169b29a91217fcc7f081375157e99c/jiter-0.16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d28bb3c26762358dadf3e5bf0bccd29ae987d65e6988d2e6f49829c76b003c09", size = 306489, upload-time = "2026-06-29T13:03:37.846Z" },
+    { url = "https://files.pythonhosted.org/packages/96/3f/02fdfc6705cad96127d883af5c34e4867f554f29ec7705ec1a46156400a9/jiter-0.16.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0542a7189c26920778658fc8fcf2af8bae05bae9924577f71804acef37996536", size = 335453, upload-time = "2026-06-29T13:03:39.221Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a6/e4bda5920d4b0d7c5dfb7174ce4a6b2e4d3e11c9162c452ef0eab4cdbdbd/jiter-0.16.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8fb8de1e23a0cb2a7f53c335049c7b72b6db41aa6227cdcc0972a1de5cb39450", size = 361625, upload-time = "2026-06-29T13:03:40.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/97/4e6b59b2c6e55cbb3e183595f81ad65dcfb21c915fee5e19e335df21bc55/jiter-0.16.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b72d0b2990ca754a9102779ac98d8597b7cb31678958562214a007f909eab78e", size = 456958, upload-time = "2026-06-29T13:03:42.074Z" },
+    { url = "https://files.pythonhosted.org/packages/15/e0/97e9557686d2f94f4b93786eccb7eed28e9228ad132ea8237f44727314a7/jiter-0.16.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d5f91b1c27fc22a57993d5a5cb8a627cb8ed4b10502716fac1ffbfe1d19d84e8", size = 372017, upload-time = "2026-06-29T13:03:43.658Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/94/db768b6938e0df35c86beeba3dfbbb025c9ee5c19e1aa271f2396e50864d/jiter-0.16.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c682bea068a90b764577bdb78a60a4c1d1606daf9cd4c893832a37c7cc9d9026", size = 343320, upload-time = "2026-06-29T13:03:45.226Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/d6/5a59d938244a30735fe62d9433fd325f9021ea29d89780ea4596ea93bc89/jiter-0.16.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:8d031aabecc4f1b6276adfb42e3aabb77c89d468bf616600e8d3a11328929053", size = 350520, upload-time = "2026-06-29T13:03:46.671Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f8/c4a857f49c9af125f6bbcac7e3eee7f7978ed89682833062e2dbf62576b1/jiter-0.16.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:eab2cd170150e70153de16896a1774e3a1dca80154c56b54d7a812c479a7165e", size = 387550, upload-time = "2026-06-29T13:03:48.361Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/d6/5fbc2f7d6b67b754caa61a993a2e626e815dec47ffc2f9e35f01adfebec7/jiter-0.16.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:6edb63a46e65a82c26800a868e49b2cac30dd5a4218b88d74bc2c848c8ad60bb", size = 515424, upload-time = "2026-06-29T13:03:49.881Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/54/284f0164b64a5fed915fea6ba7e9ba9b3d8d37c67d59cf2e3bb99d45cdfe/jiter-0.16.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:659039cc50b5addcc35fcc87ae2c1833b7c0a8e5326ef631a75e4478447bcf84", size = 546981, upload-time = "2026-06-29T13:03:51.363Z" },
+    { url = "https://files.pythonhosted.org/packages/13/c5/2a467585a576594384e1d2c43e1224deaafc085f24e243529cf98beef8e1/jiter-0.16.0-cp313-cp313-win32.whl", hash = "sha256:c9c53be232c2e206ef9cdbad81a48bfa74c3d3f08bcf8124630a8a748aad993e", size = 202853, upload-time = "2026-06-29T13:03:53.015Z" },
+    { url = "https://files.pythonhosted.org/packages/88/6a/de61d04b9eec69c71719968d2f716532a3bc121170c44a39e14979c6be81/jiter-0.16.0-cp313-cp313-win_amd64.whl", hash = "sha256:baad945ed47f163ad833314f8e3288c396118934f94e7bbb9e243ce4b341a4fd", size = 196160, upload-time = "2026-06-29T13:03:54.447Z" },
+    { url = "https://files.pythonhosted.org/packages/19/4b/b390ed59bafb3f31d008d1218578f10327714484b334439947f7e5b11e7f/jiter-0.16.0-cp313-cp313-win_arm64.whl", hash = "sha256:3c1fd2dbe1b0af19e987f03fe66c5f5bd105a2229c1aff4ab14890b24f41d21a", size = 189862, upload-time = "2026-06-29T13:03:55.754Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/89/bc4f1b57d5da938fd344a466396541e586d161320d70bffd929aaafcd8f4/jiter-0.16.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:b2c61484666ad42726029af0c00ef4541f0f3b5cdc550221f56c2343208018ee", size = 308239, upload-time = "2026-06-29T13:03:57.205Z" },
+    { url = "https://files.pythonhosted.org/packages/65/7a/c415453e5213001bf3b411ff65dec3d303b0e76a4a2cfea9768cd4960994/jiter-0.16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:63efadc657488f45db1c676d81e704cac2abf3fdb892def1faea61db053127e2", size = 308928, upload-time = "2026-06-29T13:03:58.643Z" },
+    { url = "https://files.pythonhosted.org/packages/11/fc/1f4fb7ebf9a724c7741994f4aae18fba1e2f3133df14521a79194952c34a/jiter-0.16.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cf0d73f50e7b6935677854f6e8e31d499ca7064dd24734f703e060f5b237d883", size = 336998, upload-time = "2026-06-29T13:04:00.071Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/8d/72cadaac05ccfa7cc3a0a2232862e6c72443ca40cf300ba8b57f9f18b69b/jiter-0.16.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bf3ea07d9bc8e7d03a9fbc051295462e6dbc295b894fd72457c3136e3e43d898", size = 362112, upload-time = "2026-06-29T13:04:01.52Z" },
+    { url = "https://files.pythonhosted.org/packages/58/4a/c4b0d5f651fda90a24ffce9f8d56cde462a2e09d31ae3de3c68cef34c04e/jiter-0.16.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:26798522707abb47d767db536e4148ceac1b14446bf028ee85e579a2e043cfe5", size = 459807, upload-time = "2026-06-29T13:04:03.214Z" },
+    { url = "https://files.pythonhosted.org/packages/80/58/ef77879ea9aa56b50824edc5a445e226422c7a8d211f3fd2a56bcb9493cf/jiter-0.16.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bc837c1b9631be10abfe0191537fe8009838204cec7e44827401ace390ddb567", size = 373181, upload-time = "2026-06-29T13:04:04.629Z" },
+    { url = "https://files.pythonhosted.org/packages/49/2e/ffbc3f254e4d8a66da3062c624a7df4b7c2b2cf9e1fe43cf394b3e104041/jiter-0.16.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:49060fd70737fad59d33ba9dcc0d83247dc9e77187de26053a19c16c9f32bd69", size = 344927, upload-time = "2026-06-29T13:04:06.067Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/f6/0be5dc6d64a89f80aa8fec984f94dedb2973e251edcae55841d60786d578/jiter-0.16.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:adbb8edeadd431bc4477879d5d371ece7cb1334486584e0f252656dd7ffada29", size = 352754, upload-time = "2026-06-29T13:04:07.477Z" },
+    { url = "https://files.pythonhosted.org/packages/da/6e/7d31243b3b91cd261dd19e9d3557fc3251a80883d3d8049c86174e7ab7af/jiter-0.16.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:31aaee5b80f672c1dc21272bcfb9cbdcfc1ea04ff50f00ed5af500b80c44fa93", size = 390553, upload-time = "2026-06-29T13:04:08.92Z" },
+    { url = "https://files.pythonhosted.org/packages/25/33/51ae371fde3c88897520f62b4d5f8b27ad7103e2bb10812ff52195609853/jiter-0.16.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:6722bcef4ffc86c835574b1b2fac6b33b9fb4a889c781e67950e891591f3c55a", size = 516900, upload-time = "2026-06-29T13:04:10.407Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/45/6449b3d123ea439ba79507c657288f461d55049e7bcbdc2cf8eb8210f491/jiter-0.16.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:5ab4f50ff971b611d656554ea10b75f80097392c827bc32923c6eeb6386c8b00", size = 548754, upload-time = "2026-06-29T13:04:12.046Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/e7/fd2fb11ae3e2649333da3aa170d04d7b3000bbdc3b270f6513382fdf4e04/jiter-0.16.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:710cc51d4ebdcd3c1f70b232c1db1ea1344a075770422bbd4bede5708335acbe", size = 122381, upload-time = "2026-06-29T13:04:13.413Z" },
+    { url = "https://files.pythonhosted.org/packages/26/80/f0b147a62c315a164ed2168908286ca302310824c218d3aae52b06c0c9a9/jiter-0.16.0-cp314-cp314-win32.whl", hash = "sha256:57b37fc887a32d44798e4d8ebfa7c9683ff3da1d5bf38f08d1bb3573ccb39106", size = 204578, upload-time = "2026-06-29T13:04:14.813Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/e6/4758a14304b4523a6f5adb2419340086aa3593bd4327c2b25b5948a90548/jiter-0.16.0-cp314-cp314-win_amd64.whl", hash = "sha256:cbd18dd5e2df96b580487b5745adf57ef64ad89ba2d9662fc3c19386acce7db8", size = 198154, upload-time = "2026-06-29T13:04:16.272Z" },
+    { url = "https://files.pythonhosted.org/packages/26/be/41fa54a2e7ea41d6c99f1dc5b1f0fd4cb474680304b5d268dd518e81da3a/jiter-0.16.0-cp314-cp314-win_arm64.whl", hash = "sha256:a32d2027a9fa67f109ff245a3252ece3ccc32cc56703e1deab6cc846a59e0585", size = 191458, upload-time = "2026-06-29T13:04:17.707Z" },
+    { url = "https://files.pythonhosted.org/packages/81/6b/59127338b86d9fe4d99418f5a15118bea778103ee0fe9d9dd7e0af174e95/jiter-0.16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2577196f4474ef3fc4779a088a23b0897bbf86f9ea3679c372d45b8383b43207", size = 316739, upload-time = "2026-06-29T13:04:19.663Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/95/49461034d5388196d3dabf98748935f017b7785d8f3f5349f834bcc4ed0d/jiter-0.16.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:616e89e008a93c01104161c75b4988e58716b01d62307ebfe161e52a56d2a818", size = 340911, upload-time = "2026-06-29T13:04:21.257Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/97/a4369f2fb82cb3dda13b98622f31249b2e014b223fe64ee534413ad72294/jiter-0.16.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0e2e9efbe042210df657bade597f66d6d75723e3d8f45a12ea6d8167ff8bbce3", size = 361747, upload-time = "2026-06-29T13:04:22.677Z" },
+    { url = "https://files.pythonhosted.org/packages/28/51/49b6ed456261646e1906016a6760367a28aacd3c24805e4e5fe64116c1db/jiter-0.16.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3f4d9e473a5ce7d27fef8b848df4dc16e283893d3f53b4a585e72c9595f3c284", size = 460225, upload-time = "2026-06-29T13:04:24.441Z" },
+    { url = "https://files.pythonhosted.org/packages/33/b5/5689aff4f66c5b60be63106e591dbfcba2190df97d2c9c7cf052361ddb98/jiter-0.16.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8d30a4a1c87713060c8d1cc59a7b6c8fb6b8ef0a6900368014c76c87922a2929", size = 373169, upload-time = "2026-06-29T13:04:25.884Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/96/3ae1b85ee0d6d6cab254fb7f8da018272b932bbf2d69b07e98aa2a96c746/jiter-0.16.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bae96332410f866e5900d809298b1ed82735932986c672495f9701daacd80620", size = 350332, upload-time = "2026-06-29T13:04:27.302Z" },
+    { url = "https://files.pythonhosted.org/packages/15/32/c99d7bafd78986556c95bf60ce84c6cc98786eac56066c12d7f828bb6747/jiter-0.16.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:da3d7ec75dc83bb18bca888b5edfae0656a26849056c59e05a7728badd17e7af", size = 353377, upload-time = "2026-06-29T13:04:28.731Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4b/f99a8e571287c3dec766bcc18528bbe8e8fb5365522ab5e6d64c93e87066/jiter-0.16.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ee6162b77d49a9939229df666dfa8af3e656b6701b54c4c84966d740e189264e", size = 387746, upload-time = "2026-06-29T13:04:30.319Z" },
+    { url = "https://files.pythonhosted.org/packages/75/69/c78a5b3f71040e34eb5917df26fb7ae9a2174cad1ccbf277512507c53a6e/jiter-0.16.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:63ffdbdae7d4499f4cda14eadc12ddcabef0fc0c081191bdc2247489cb698077", size = 517292, upload-time = "2026-06-29T13:04:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/f7/095b38eda4c70d03651c403f29a5590f16d12ddc5d544aac9f9cddf72277/jiter-0.16.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a111256a7193bea0759267b10385e5870949c239ed7b6ddbaaf57573edb38734", size = 549259, upload-time = "2026-06-29T13:04:33.721Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/c5/6a0207d90e5f656d95af98ebd0934f382d37674416f215aeda2ff8063e51/jiter-0.16.0-cp314-cp314t-win32.whl", hash = "sha256:de5ba8763e56b793561f43bed197c9ea55776daa5e9a6b91eed68a909bc9cdbf", size = 206523, upload-time = "2026-06-29T13:04:35.068Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/31/c757d5f30a8980fd945ce7b98be10be9e4ff59c7c42f5fd86804c2e87db8/jiter-0.16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b8a3f9a6008048fe9def7bf465180564a6e458047d2ce499149cfbe73c3ae9db", size = 200366, upload-time = "2026-06-29T13:04:36.61Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/a2/d88de6d313d734a544a7901353ad5db67cb38dcfcd91713b7979dafc345d/jiter-0.16.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0fa25b09b13075c46f5bc174f2690525a925a4fc2f7c82969a2bbabff22386ce", size = 190516, upload-time = "2026-06-29T13:04:38.004Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d3/8e278946d43eeca2585b4dd0834a887cd71136329b837f3a16ed86a8b4b0/jiter-0.16.0-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:850ccb1d7eedb4200f4014b1c0e8a577de114fc3cd88faad646dcc9bc4bb12ad", size = 304518, upload-time = "2026-06-29T13:05:00.172Z" },
+    { url = "https://files.pythonhosted.org/packages/72/43/28d4ef495028bf0506a413d4db3f4eb3e7288a382e0f065f306a17bbeb5e/jiter-0.16.0-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:e34e97bda77eb63242a410243c071e28ac7e0d8c0948c5ee658498690a4b2f2f", size = 310207, upload-time = "2026-06-29T13:05:02.123Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/ca/c366b1012da1d640de975d9683acd44e4d150d9068845d0ca2610435253f/jiter-0.16.0-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b7dc85ea77d4abbae8bad0d3538678aedee75bceec4e2f6c8dfb1c74772e5aa5", size = 342771, upload-time = "2026-06-29T13:05:03.55Z" },
+    { url = "https://files.pythonhosted.org/packages/16/52/50cc4056fc1ae02e7154704e7ecc89df0afb8300222cfe8a52d3f67e4730/jiter-0.16.0-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:17ca7fae79f6d99cd9a042b75f917eaada7b895cfc7dd2ee3a16089dcaec7a85", size = 346468, upload-time = "2026-06-29T13:05:05.452Z" },
+    { url = "https://files.pythonhosted.org/packages/98/ab/664fd8c4be028b2bedd3d2ff08769c4ede23d0dbc87a77c62384a0515b5d/jiter-0.16.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:f17d61a28b4b3e0e3e2ba98490c70501403b4d196f78732439160e7fd3678127", size = 303106, upload-time = "2026-06-29T13:05:07.118Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/07/421f1d5b65493a76e16027b848aba6a7d28073ae75944fa4289cc914d39f/jiter-0.16.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:96e38eea538c8ddf853a35727c7be0741c76c13f04148ac5c116222f50ece3b3", size = 304658, upload-time = "2026-06-29T13:05:08.708Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/db/bba1155f01a01c3c37a89425d571da751bbedf5c54247b831a04cb971798/jiter-0.16.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d284fb8d94d5855d60c44fefcab4bf966f1da6fada73992b01f6f0c9bc0c6702", size = 339719, upload-time = "2026-06-29T13:05:10.41Z" },
+    { url = "https://files.pythonhosted.org/packages/78/f7/18a1afcd64f35314b68c1f23afcd9994d0bc13e65cc77517afff4e83986d/jiter-0.16.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64d613743df53199b1aa256a7d328340da6d7078aac7705a7db9d7a791e9cfd2", size = 343885, upload-time = "2026-06-29T13:05:12.087Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1023,7 +1163,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/68/6e292c0853e204c44d2f03ea5f090be3317a0e2d9417ecb62c9eb27687df/mmh3-5.2.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:8f767ba0911602ddef289404e33835a61168314ebd3c729833db2ed685824211", size = 106437, upload-time = "2026-03-05T15:54:35.177Z" },
     { url = "https://files.pythonhosted.org/packages/dd/c6/fedd7284c459cfb58721d461fcf5607a4c1f5d9ab195d113d51d10164d16/mmh3-5.2.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:67e41a497bac88cc1de96eeba56eeb933c39d54bc227352f8455aa87c4ca4000", size = 110002, upload-time = "2026-03-05T15:54:36.673Z" },
     { url = "https://files.pythonhosted.org/packages/3b/ac/ca8e0c19a34f5b71390171d2ff0b9f7f187550d66801a731bb68925126a4/mmh3-5.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3d74a03fb57757ece25aa4b3c1c60157a1cece37a020542785f942e2f827eed5", size = 97507, upload-time = "2026-03-05T15:54:37.804Z" },
+    { url = "https://files.pythonhosted.org/packages/25/a5/9daa0508a1569a54130f6198d5462a92deda870043624aa3ea72721aa765/mmh3-5.2.1-cp313-cp313-android_21_arm64_v8a.whl", hash = "sha256:723b2681ed4cc07d3401bbea9c201ad4f2a4ca6ba8cddaff6789f715dd2b391e", size = 40832, upload-time = "2026-03-05T15:54:43.212Z" },
     { url = "https://files.pythonhosted.org/packages/0a/6b/3230c6d80c1f4b766dedf280a92c2241e99f87c1504ff74205ec8cebe451/mmh3-5.2.1-cp313-cp313-android_21_x86_64.whl", hash = "sha256:3619473a0e0d329fd4aec8075628f8f616be2da41605300696206d6f36920c3d", size = 41964, upload-time = "2026-03-05T15:54:44.204Z" },
+    { url = "https://files.pythonhosted.org/packages/62/fb/648bfddb74a872004b6ee751551bfdda783fe6d70d2e9723bad84dbe5311/mmh3-5.2.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:e48d4dbe0f88e53081da605ae68644e5182752803bbc2beb228cca7f1c4454d6", size = 39114, upload-time = "2026-03-05T15:54:45.205Z" },
+    { url = "https://files.pythonhosted.org/packages/95/c2/ab7901f87af438468b496728d11264cb397b3574d41506e71b92128e0373/mmh3-5.2.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:a482ac121de6973897c92c2f31defc6bafb11c83825109275cffce54bb64933f", size = 39819, upload-time = "2026-03-05T15:54:46.509Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/ed/6f88dda0df67de1612f2e130ffea34cf84aaee5bff5b0aff4dbff2babe34/mmh3-5.2.1-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:17fbb47f0885ace8327ce1235d0416dc86a211dcd8cc1e703f41523be32cfec8", size = 40330, upload-time = "2026-03-05T15:54:47.864Z" },
     { url = "https://files.pythonhosted.org/packages/3d/66/7516d23f53cdf90f43fce24ab80c28f45e6851d78b46bef8c02084edf583/mmh3-5.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d51fde50a77f81330523562e3c2734ffdca9c4c9e9d355478117905e1cfe16c6", size = 56078, upload-time = "2026-03-05T15:54:48.9Z" },
     { url = "https://files.pythonhosted.org/packages/bc/34/4d152fdf4a91a132cb226b671f11c6b796eada9ab78080fb5ce1e95adaab/mmh3-5.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:19bbd3b841174ae6ed588536ab5e1b1fe83d046e668602c20266547298d939a9", size = 40498, upload-time = "2026-03-05T15:54:49.942Z" },
     { url = "https://files.pythonhosted.org/packages/d4/4c/8e3af1b6d85a299767ec97bd923f12b06267089c1472c27c1696870d1175/mmh3-5.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:be77c402d5e882b6fbacfd90823f13da8e0a69658405a39a569c6b58fdb17b03", size = 40033, upload-time = "2026-03-05T15:54:50.994Z" },
@@ -1037,7 +1181,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e8/88/a601e9f32ad1410f438a6d0544298ea621f989bd34a0731a7190f7dec799/mmh3-5.2.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:2bd9f19f7f1fcebd74e830f4af0f28adad4975d40d80620be19ffb2b2af56c9f", size = 106479, upload-time = "2026-03-05T15:55:01.532Z" },
     { url = "https://files.pythonhosted.org/packages/d6/5c/ce29ae3dfc4feec4007a437a1b7435fb9507532a25147602cd5b52be86db/mmh3-5.2.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:c88653877aeb514c089d1b3d473451677b8b9a6d1497dbddf1ae7934518b06d2", size = 110030, upload-time = "2026-03-05T15:55:02.934Z" },
     { url = "https://files.pythonhosted.org/packages/13/30/ae444ef2ff87c805d525da4fa63d27cda4fe8a48e77003a036b8461cfd5c/mmh3-5.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:fceef7fe67c81e1585198215e42ad3fdba3a25644beda8fbdaf85f4d7b93175a", size = 97536, upload-time = "2026-03-05T15:55:04.135Z" },
+    { url = "https://files.pythonhosted.org/packages/63/b4/65bc1fb2bb7f83e91c30865023b1847cf89a5f237165575e8c83aa536584/mmh3-5.2.1-cp314-cp314-android_24_arm64_v8a.whl", hash = "sha256:d771f085fcdf4035786adfb1d8db026df1eb4b41dac1c3d070d1e49512843227", size = 40794, upload-time = "2026-03-05T15:55:09.773Z" },
     { url = "https://files.pythonhosted.org/packages/c4/86/7168b3d83be8eb553897b1fac9da8bbb06568e5cfe555ffc329ebb46f59d/mmh3-5.2.1-cp314-cp314-android_24_x86_64.whl", hash = "sha256:7f196cd7910d71e9d9860da0ff7a77f64d22c1ad931f1dd18559a06e03109fc0", size = 41923, upload-time = "2026-03-05T15:55:10.924Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/9b/b653ab611c9060ce8ff0ba25c0226757755725e789292f3ca138a58082cd/mmh3-5.2.1-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:b1f12bd684887a0a5d55e6363ca87056f361e45451105012d329b86ec19dbe0b", size = 39131, upload-time = "2026-03-05T15:55:11.961Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/b4/5a2e0d34ab4d33543f01121e832395ea510132ea8e52cdf63926d9d81754/mmh3-5.2.1-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:d106493a60dcb4aef35a0fac85105e150a11cf8bc2b0d388f5a33272d756c966", size = 39825, upload-time = "2026-03-05T15:55:13.013Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/69/81699a8f39a3f8d368bec6443435c0c392df0d200ad915bf0d222b588e03/mmh3-5.2.1-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:44983e45310ee5b9f73397350251cdf6e63a466406a105f1d16cb5baa659270b", size = 40344, upload-time = "2026-03-05T15:55:14.026Z" },
     { url = "https://files.pythonhosted.org/packages/0c/b3/71c8c775807606e8fd8acc5c69016e1caf3200d50b50b6dd4b40ce10b76c/mmh3-5.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:368625fb01666655985391dbad3860dc0ba7c0d6b9125819f3121ee7292b4ac8", size = 56291, upload-time = "2026-03-05T15:55:15.137Z" },
     { url = "https://files.pythonhosted.org/packages/6f/75/2c24517d4b2ce9e4917362d24f274d3d541346af764430249ddcc4cb3a08/mmh3-5.2.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:72d1cc63bcc91e14933f77d51b3df899d6a07d184ec515ea7f56bff659e124d7", size = 40575, upload-time = "2026-03-05T15:55:16.518Z" },
     { url = "https://files.pythonhosted.org/packages/bf/b9/e4a360164365ac9f07a25f0f7928e3a66eb9ecc989384060747aa170e6aa/mmh3-5.2.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e8b4b5580280b9265af3e0409974fb79c64cf7523632d03fbf11df18f8b0181e", size = 40052, upload-time = "2026-03-05T15:55:17.735Z" },
@@ -1502,6 +1650,25 @@ wheels = [
 ]
 
 [[package]]
+name = "openai"
+version = "2.54.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/9a/8c75e8c8a5b407a0586faeb2afac91674ff955c191ecc1d6d3b6669f6788/openai-2.54.0.tar.gz", hash = "sha256:e3e6f8bc1ba30ddf381ace1a14340eed381cb984a1a59bd0f34b5be3b5d49cfa", size = 1100285, upload-time = "2026-08-11T18:46:59.035Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/a8/bb76c7356de8ad57f59d5ff993d434df0607f07f08bcc9c9a5c275e399c0/openai-2.54.0-py3-none-any.whl", hash = "sha256:89089789197ccdb87f173a03145ed1598d00795220c93e96cf712b1cbf5e5f2b", size = 1660351, upload-time = "2026-08-11T18:46:56.684Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1719,6 +1886,8 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/72/04/2beacf7e1607e93eefe4aed1b4709f079b905fb77530179d4f7c71745f22/pydantic_core-2.46.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:daa27d92c36f24388fe3ad306b174781c747627f134452e4f128ea00ce1fe8c4", size = 2184769, upload-time = "2026-05-06T13:38:13.901Z" },
     { url = "https://files.pythonhosted.org/packages/9e/29/d2b9fd9f539133548eaf622c06a4ce176cb46ac59f32d0359c4abc0de047/pydantic_core-2.46.4-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:19e51f073cd3df251856a8a4189fbdf1de4012c3ebacfb1884f94f1eb406079f", size = 2319312, upload-time = "2026-05-06T13:39:08.24Z" },
     { url = "https://files.pythonhosted.org/packages/7c/af/0f7a5b85fec6075bea96e3ef9187de38fccced0de92c1e7feda8d5cc7bb9/pydantic_core-2.46.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:c1747f85cee84c26985853c6f3d9bd3e75da5212912443fa111c113b9c246f39", size = 2361817, upload-time = "2026-05-06T13:38:43.2Z" },
+    { url = "https://files.pythonhosted.org/packages/25/a4/73363fec545fd3ec025490bdda2743c56d0dd5b6266b1a53bbe9e4265375/pydantic_core-2.46.4-cp310-cp310-win32.whl", hash = "sha256:2f84c03c8607173d16b5a854ec68a2f9079ae03237a54fb506d13af47e1d018d", size = 1987085, upload-time = "2026-05-06T13:39:25.497Z" },
+    { url = "https://files.pythonhosted.org/packages/01/aa/62f082da2c91fac1c234bc9ee0066257ce83f0604abd72e4c9d5991f2d84/pydantic_core-2.46.4-cp310-cp310-win_amd64.whl", hash = "sha256:8358a950c8909158e3df31538a7e4edc2d7265a7c54b47f0864d9e5bae9dcebf", size = 2074311, upload-time = "2026-05-06T13:39:59.922Z" },
     { url = "https://files.pythonhosted.org/packages/5c/fa/6d7708d2cfc1a832acb6aeb0cd16e801902df8a0f583bb3b4b527fde022e/pydantic_core-2.46.4-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:0e96592440881c74a213e5ad528e2b24d3d4f940de2766bed9010ab1d9e51594", size = 2111872, upload-time = "2026-05-06T13:40:27.596Z" },
     { url = "https://files.pythonhosted.org/packages/ae/6f/aa064a3e74b5745afbdf250594f38e7ead05e2d651bcb35994b9417a0d4d/pydantic_core-2.46.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e0d65b8c354be7fb5f720c3caa8bc940bc2d20ce749c8e06135f07f8ed95dd7c", size = 1948255, upload-time = "2026-05-06T13:39:12.574Z" },
     { url = "https://files.pythonhosted.org/packages/43/3a/41114a9f7569b84b4d84e7a018c57c56347dac30c0d4a872946ec4e36c46/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7bfb192b3f4b9e8a89b6277b6ce787564f62cfd272055f6e685726b111dc7826", size = 1972827, upload-time = "2026-05-06T13:38:19.841Z" },
@@ -1731,6 +1900,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/52/7c529d7bdb2d1068bd52f51fe32572c8301f9a4febf1948f10639f1436f5/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:aaa2a54443eff1950ba5ddc6b6ccda0d9c84a364276a62f969bdf2a390650848", size = 2182573, upload-time = "2026-05-06T13:38:45.04Z" },
     { url = "https://files.pythonhosted.org/packages/37/b3/7c40325848ba78247f2812dcf9c7274e38cd801820ca6dd9fe63bcfb0eb4/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:18e5ceec2ab67e6d5f1a9085e5a24c9c4e2ac4545730bfe668680bca05e555f3", size = 2317139, upload-time = "2026-05-06T13:37:15.539Z" },
     { url = "https://files.pythonhosted.org/packages/d9/37/f913f81a657c865b75da6c0dbed79876073c2a43b5bd9edbe8da785e4d49/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:a0f62d0a58f4e7da165457e995725421e0064f2255d8eccebc49f41bbc23b109", size = 2360433, upload-time = "2026-05-06T13:37:30.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/67/6acaa1be2567f9256b056d8477158cac7240813956ce86e49deae8e173b4/pydantic_core-2.46.4-cp311-cp311-win32.whl", hash = "sha256:041bde0a48fd37cf71cab1c9d56d3e8625a3793fef1f7dd232b3ff37e978ecda", size = 1985513, upload-time = "2026-05-06T13:38:15.669Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/e6/c505f83dfeda9a2e5c995cfd872949e4d05e12f7feb3dca72f633daefa94/pydantic_core-2.46.4-cp311-cp311-win_amd64.whl", hash = "sha256:6f2eeda33a839975441c86a4119e1383c50b47faf0cbb5176985565c6bb02c33", size = 2071114, upload-time = "2026-05-06T13:40:35.416Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/da/7a263a96d965d9d0df5e8de8a475f33495451117035b09acb110288c381f/pydantic_core-2.46.4-cp311-cp311-win_arm64.whl", hash = "sha256:14f4c5d6db102bd796a627bbb3a17b4cf4574b9ae861d8b7c9a9661c6dd3362d", size = 2044298, upload-time = "2026-05-06T13:38:29.754Z" },
     { url = "https://files.pythonhosted.org/packages/ce/8c/af022f0af448d7747c5154288d46b5f2bc5f17366eaa0e23e9aa04d59f3b/pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3245406455a5d98187ec35530fd772b1d799b26667980872c8d4614991e2c4a2", size = 2106158, upload-time = "2026-05-06T13:38:57.215Z" },
     { url = "https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f", size = 1951724, upload-time = "2026-05-06T13:37:02.697Z" },
     { url = "https://files.pythonhosted.org/packages/8e/bc/f47d1ff9cbb1620e1b5b697eef06010035735f07820180e74178226b27b3/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8233f2947cf85404441fd7e0085f53b10c93e0ee78611099b5c7237e36aacbf7", size = 1975742, upload-time = "2026-05-06T13:37:09.448Z" },
@@ -1743,6 +1915,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ae/6c/fc44000918855b42779d007ae63b0532794739027b2f417321cddbc44f6a/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b2f69dec1725e79a012d920df1707de5caf7ed5e08f3be4435e25803efc47458", size = 2190044, upload-time = "2026-05-06T13:40:43.231Z" },
     { url = "https://files.pythonhosted.org/packages/6b/65/d9cadc9f1920d7a127ad2edba16c1db7916e59719285cd6c94600b0080ba/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:8d0820e8192167f80d88d64038e609c31452eeca865b4e1d9950a27a4609b00b", size = 2329133, upload-time = "2026-05-06T13:39:57.365Z" },
     { url = "https://files.pythonhosted.org/packages/d0/cf/c873d91679f3a30bcf5e7ac280ce5573483e72295307685120d0d5ad3416/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fbdb89b3e1c94a30cc5edfce477c6e6a5dc4d8f84665b455c27582f211a1c72c", size = 2374464, upload-time = "2026-05-06T13:38:06.976Z" },
+    { url = "https://files.pythonhosted.org/packages/47/bd/6f2fc8188f31bf10590f1e98e7b306336161fac930a8c514cd7bd828c7dc/pydantic_core-2.46.4-cp312-cp312-win32.whl", hash = "sha256:9aa768456404a8bf48a4406685ac2bec8e72b62c69313734fa3b73cf33b3a894", size = 1974823, upload-time = "2026-05-06T13:40:47.985Z" },
+    { url = "https://files.pythonhosted.org/packages/40/8c/985c1d41ea1107c2534abd9870e4ed5c8e7669b5c308297835c001e7a1c4/pydantic_core-2.46.4-cp312-cp312-win_amd64.whl", hash = "sha256:e9c26f834c65f5752f3f06cb08cb86a913ceb7274d0db6e267808a708b46bc89", size = 2072919, upload-time = "2026-05-06T13:39:21.153Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ba/f463d006e0c47373ca7ec5e1a261c59dc01ef4d62b2657af925fb0deee3a/pydantic_core-2.46.4-cp312-cp312-win_arm64.whl", hash = "sha256:4fc73cb559bdb54b1134a706a2802a4cddd27a0633f5abb7e53056268751ac6a", size = 2027604, upload-time = "2026-05-06T13:39:03.753Z" },
     { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
     { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
     { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
@@ -1755,6 +1930,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
     { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
     { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
     { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
     { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
     { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
@@ -1767,6 +1945,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
     { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
     { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354, upload-time = "2026-05-06T13:38:03.499Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238, upload-time = "2026-05-06T13:39:40.807Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251, upload-time = "2026-05-06T13:37:26.72Z" },
     { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
     { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
     { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
@@ -1779,6 +1960,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
     { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
     { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
     { url = "https://files.pythonhosted.org/packages/ee/a4/73995fd4ebbb46ba0ee51e6fa049b8f02c40daebb762208feda8a6b7894d/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:14d4edf427bdcf950a8a02d7cb44a08614388dd6e1bdcbf4f67504fa7887da9c", size = 2111589, upload-time = "2026-05-06T13:37:10.817Z" },
     { url = "https://files.pythonhosted.org/packages/fb/7f/f37d3a5e8bfcc2e403f5c57a730f2d815693fb42119e8ea48b3789335af1/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:0ce40cd7b21210e99342afafbd4d0f76d784eb5b1d60f3bdc566be4983c6c73b", size = 1944552, upload-time = "2026-05-06T13:36:56.717Z" },
     { url = "https://files.pythonhosted.org/packages/15/3c/d7eb777b3ff43e8433a4efb39a17aa8fd98a4ee8561a24a67ef5db07b2d6/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:90884113d8b48f760e9587002789ddd741e76ab9f89518cd1e43b1f1a52ec44b", size = 1982984, upload-time = "2026-05-06T13:39:06.207Z" },
@@ -1794,6 +1978,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/81/44/6e112a4253e56f5705467cbab7ab5e91ee7398ba3d56d358635958893d3e/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:c7a7bd4e39e8e4c12c39cd480356842b6a8a06e41b23a55a5e3e191718838ddf", size = 2183828, upload-time = "2026-05-06T13:37:43.053Z" },
     { url = "https://files.pythonhosted.org/packages/ac/ad/5565071e937d8e752842ac241463944c9eb14c87e2d269f2658a5bd05e98/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:d396ec2b979760aaf3218e76c24e65bd0aca24983298653b3a9d7a45f9e47b30", size = 2310000, upload-time = "2026-05-06T13:37:56.694Z" },
     { url = "https://files.pythonhosted.org/packages/4f/c3/66883a5cec183e7fba4d024b4cbbe61851a63750ef606b0afecc46d1f2bf/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:86e1a4418c6cd97d60c95c71164158eaf7324fae7b0923264016baa993eba6fc", size = 2361286, upload-time = "2026-05-06T13:40:05.667Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/2d/69abac8f838090bbecd5df894befb2c2619e7996a98ddb949db9f3b93225/pydantic_core-2.46.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:d51026d73fcfd93610abc7b27789c26b313920fcfb20e27462d74a7f8b06e983", size = 2193071, upload-time = "2026-05-06T13:38:08.682Z" },
 ]
 
 [[package]]
@@ -2311,6 +2496,15 @@ wheels = [
 ]
 
 [[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
 name = "sortedcontainers"
 version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2326,6 +2520,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/85/d2/32c8a30768b788d319f94cde3a77e0ccc1812dca464ad8062d3c4d703e06/speedtest-cli-2.1.3.tar.gz", hash = "sha256:5e2773233cedb5fa3d8120eb7f97bcc4974b5221b254d33ff16e2f1d413d90f0", size = 24721, upload-time = "2021-04-08T13:51:33.627Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9f/39/65259b7054368b370d3183762484fa2c779ddc41633894d895f9d1720f45/speedtest_cli-2.1.3-py2.py3-none-any.whl", hash = "sha256:75ff32c91af9ac1ce2b905476d6e92bd9eb2c0783f9e7d1939d74605c7d0b9ea", size = 23973, upload-time = "2021-04-08T13:51:32.028Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/b4/205b0d5241d934e8add0c38aa924c4f9fb7330834ff11e5444db964ec3f9/starlette-1.6.0.tar.gz", hash = "sha256:d4e3ac5e546444960c710297a3c9fc3f7ebae1b7e963f3d36173b49da535be9b", size = 2716969, upload-time = "2026-08-08T18:27:57.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/cb/6a6a47d5b464bd08695d254f3da6e7986cc70c9fa5d778eda57538edfe56/starlette-1.6.0-py3-none-any.whl", hash = "sha256:a86dd39d14bb45f85a3d18525215a9ef0cfd1f192ac793220e72598c90335f0c", size = 75969, upload-time = "2026-08-08T18:27:56.196Z" },
 ]
 
 [[package]]
@@ -2568,6 +2775,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.52.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f2/0f/3f86e61397dd33bf2ccf28188c40db6a740658aeebbbf6e7dbc101a1f487/uvicorn-0.52.4.tar.gz", hash = "sha256:73acfee47a0b133c5de13d219492d62d8a31e935f4fe6e41a232451a15379f86", size = 100627, upload-time = "2026-08-19T06:27:41.821Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/79/4a20b54ab0491485ccd8c077db2d39187c7f12b3e15485d38a7be37c81b4/uvicorn-0.52.4-py3-none-any.whl", hash = "sha256:f86e41a149d7d05a9969337e3946a9c171c06a5d42680896daaba624aeac8da1", size = 79871, upload-time = "2026-08-19T06:27:40.36Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- complete the unified multi-model local-node milestone
- add decision-grade PySide6 and pywebview desktop shell spikes
- select PySide 6 for product implementation from cross-platform evidence
- separate privileged control credentials from OpenAI-compatible inference keys
- add Windows, Linux, and macOS desktop build and test workflow
- update the revival roadmap, ADRs, configuration guide, and validation evidence

## Validation

- broad offline matrix: 204 passed, 7 skipped
- credential and node authorization suite: 20 passed
- desktop spike contract suite: 9 passed
- Black and isort checks pass
- all six clean Windows, Linux, and macOS packaged runtime and UI-smoke jobs pass
- PySide bundle sizes: 128,862,316 bytes Windows; 324,323,392 Linux; 210,278,876 macOS
- pywebview bundle sizes: 29,234,555 bytes Windows; 948,268,266 Linux; 43,560,981 macOS
