### PR TITLE
Supervise the desktop node with native credentials

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -66,6 +66,7 @@ jobs:
             tests/test_loading_diagnostics.py \
             tests/test_model_manager.py \
             tests/test_model_manifest.py \
+            tests/test_native_credentials.py \
             tests/test_node_config.py \
             tests/test_node.py \
             tests/test_openai_api.py \

--- a/deploy/gcp/README.md
+++ b/deploy/gcp/README.md
@@ -22,7 +22,7 @@ journal. The private identity file must never leave the VM.
 - VM: `communityai-bootstrap-1` in `us-central1-a`
 - Public IPv4: `35.209.21.129`
 - Peer address: `/ip4/35.209.21.129/tcp/31337/p2p/QmZhGcSVR6qPLZTq3TJPZEi734GbMkouv3kPxQLdDY2qUo`
-- Proposed DNS: `bootstrap.communityai.flujo.com.co` (`A` record to `35.209.21.129`)
+- Published DNS: `bootstrap.communityai.flujo.com.co` (`A` record to `35.209.21.129`)
 
 The VM has no service account. SSH is allowed only through Google IAP; TCP
 31337 is the only application port exposed publicly.

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -13,14 +13,22 @@ The desktop currently provides the promoted milestone-5 vertical slice:
 - a persistent GPU-memory target slider ready for node-side budget enforcement;
 - create, relabel, and revoke controls for OpenAI client keys;
 - one-time display and clipboard copy for newly created client-key secrets; and
-- native credential-store access with automatic import of an existing headless-node key; and
+- native credential ownership with verified generation or automatic import of an existing headless-node key;
+- source-level startup, readiness, crash-backoff, reconnect, and owned-process shutdown for the standalone node; and
 - friendly automatic reconnect when the credential or node is unavailable.
 
-Full first-run node configuration, node lifecycle supervision, contribution budgets,
-login startup, accessibility validation, signed installers, and update/rollback behavior
-remain later milestone-5 slices. The private-file bridge remains available only to the
-headless `drift node`; this product package never accepts a control secret or secret-file
-path on its command line.
+The desktop starts `drift node` with an explicit native credential source and never puts
+the secret in its command, environment, logs, or ordinary configuration. A migrated
+private file is removed only after a desktop-owned native-key node authenticates. File
+mode remains the default for explicitly headless `drift node` use.
+
+The current PyInstaller artifact still contains only the GUI client: the real model/DHT
+node sidecar and initial signed catalog have not been added to that bundle. Until those
+arrive, source runs can supervise an installed node when
+`~/.drift/node/node-config.json` exists, while a fresh packaged install renders a
+model-catalog or missing-sidecar state in the window. Contribution budgets, login
+startup, accessibility validation, signed installers, and update/rollback behavior
+remain later milestone-5 slices.
 
 ## Development
 
@@ -37,8 +45,16 @@ python -m unittest discover -s tests -v
 communityai-desktop --self-test
 ```
 
+Exercise the real installed node process, native OS credential backend, published DNS
+seed, authenticated readiness, and owned shutdown:
+
+```shell
+python ../scripts/smoke_desktop_managed_node.py
+```
+
 On an existing headless-node installation, the desktop imports `control-api.key` into
-the native credential store automatically. There is no setup button or secret prompt in
+the native credential store automatically. On a fresh installation it creates the
+control credential in that store directly. There is no setup button or secret prompt in
 the normal app. Developers can still replace the stored key interactively without
 putting it in the process list:
 
@@ -46,8 +62,10 @@ putting it in the process list:
 communityai-desktop --store-control-key
 ```
 
-Then start the already-running node and launch `communityai-desktop`. The default node
-URL is `http://127.0.0.1:8080`.
+The desktop starts and owns the source node automatically when the default
+`~/.drift/node/node-config.json` exists. The default node URL is
+`http://127.0.0.1:8080`. Pass the hidden development flag `--no-manage-node` to attach
+to an already-running headless node without taking lifecycle ownership.
 
 Build and smoke-test the unsigned PyInstaller bundle:
 

--- a/desktop/src/communityai_desktop/app.py
+++ b/desktop/src/communityai_desktop/app.py
@@ -19,6 +19,12 @@ from communityai_desktop.credentials import (
     CredentialError,
     NativeCredentialStore,
 )
+from communityai_desktop.lifecycle import (
+    DEFAULT_NODE_CONFIG_PATH,
+    DEFAULT_NODE_DATA_DIR,
+    NodeLifecycleError,
+    NodeLifecycleSupervisor,
+)
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -28,6 +34,9 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--timeout", type=float, default=5.0)
     parser.add_argument("--credential-service", default=DEFAULT_CREDENTIAL_SERVICE, help=argparse.SUPPRESS)
     parser.add_argument("--credential-account", default=DEFAULT_CREDENTIAL_ACCOUNT, help=argparse.SUPPRESS)
+    parser.add_argument("--node-config", type=Path, default=DEFAULT_NODE_CONFIG_PATH, help=argparse.SUPPRESS)
+    parser.add_argument("--node-data-dir", type=Path, default=DEFAULT_NODE_DATA_DIR, help=argparse.SUPPRESS)
+    parser.add_argument("--no-manage-node", action="store_true", help=argparse.SUPPRESS)
     parser.add_argument("--capture-page", type=int, default=0, help=argparse.SUPPRESS)
     action = parser.add_mutually_exclusive_group()
     action.add_argument("--store-control-key", action="store_true")
@@ -107,21 +116,42 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         # Validate the destination before opening the credential store.
         node_url = normalize_loopback_url(args.node_url)
         credential_store = _credential_store(args)
+        lifecycle = (
+            None
+            if args.no_manage_node
+            else NodeLifecycleSupervisor(
+                node_url,
+                credential_store,
+                config_path=args.node_config,
+                data_dir=args.node_data_dir,
+                client_timeout=args.timeout,
+            )
+        )
 
         def connect() -> DesktopController:
+            if lifecycle is not None:
+                return DesktopController(lifecycle.ensure_client())
             token = credential_store.get_or_migrate()
             return DesktopController(NodeClient(node_url, token, timeout=args.timeout))
 
         if args.probe_only:
-            _write_json(connect().snapshot())
-            return 0
+            try:
+                _write_json(connect().snapshot())
+                return 0
+            finally:
+                if lifecycle is not None:
+                    lifecycle.close()
 
         from communityai_desktop.pyside_shell import run
 
         # Credential and connection errors belong in the window for normal desktop
         # startup. Existing headless installations migrate automatically.
-        return int(run(connect=connect) or 0)
-    except (CredentialError, NodeClientError, ValueError) as exc:
+        try:
+            return int(run(connect=connect) or 0)
+        finally:
+            if lifecycle is not None:
+                lifecycle.close()
+    except (CredentialError, NodeClientError, NodeLifecycleError, ValueError) as exc:
         parser.exit(2, f"communityai-desktop: {exc}\n")
 
 

--- a/desktop/src/communityai_desktop/credentials.py
+++ b/desktop/src/communityai_desktop/credentials.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import os
 import re
+import secrets
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
@@ -15,6 +17,17 @@ _CONTROL_KEY_RE = re.compile(r"^drift_control_[A-Za-z0-9_-]{43,}$")
 
 class CredentialError(RuntimeError):
     """A control credential could not be loaded or stored safely."""
+
+
+class CredentialMissingError(CredentialError):
+    """The native credential store is usable but has no product control key."""
+
+
+@dataclass(frozen=True)
+class CredentialProvision:
+    secret: str
+    source: str
+    legacy_path: Optional[Path] = None
 
 
 def _validate_secret(value: Optional[str]) -> str:
@@ -58,27 +71,44 @@ class NativeCredentialStore:
         except keyring_error as exc:
             raise CredentialError(f"native credential store failed: {exc}") from exc
         if secret is None:
-            raise CredentialError(f"no local-node control credential is stored for account {self.account!r}")
+            raise CredentialMissingError(f"no local-node control credential is stored for account {self.account!r}")
         return _validate_secret(secret)
 
     def get_or_migrate(self, path: Path | str = DEFAULT_HEADLESS_CONTROL_KEY_PATH) -> str:
         """Use the native store, importing the legacy node file once when necessary."""
+        return self.provision(path, allow_create=False).secret
+
+    def provision(
+        self,
+        path: Path | str = DEFAULT_HEADLESS_CONTROL_KEY_PATH,
+        *,
+        allow_create: bool = True,
+    ) -> CredentialProvision:
+        """Return the native key, migrating or creating it when explicitly allowed."""
         try:
-            return self.get()
-        except CredentialError as missing:
+            return CredentialProvision(self.get(), "native")
+        except CredentialMissingError as missing:
             path = Path(path)
-            if not path.exists():
+            if path.exists() or path.is_symlink():
+                secret = load_private_control_key(path)
+                self.set(secret)
+                return CredentialProvision(secret, "migrated", path)
+            if not allow_create:
                 raise CredentialError("CommunityAI is not ready on this computer yet") from missing
-            secret = load_private_control_key(path)
+            secret = f"drift_control_{secrets.token_urlsafe(32)}"
             self.set(secret)
-            return secret
+            return CredentialProvision(secret, "generated")
 
     def set(self, secret: str) -> None:
         keyring, keyring_error = self._keyring()
+        secret = _validate_secret(secret)
         try:
-            keyring.set_password(self.service, self.account, _validate_secret(secret))
+            keyring.set_password(self.service, self.account, secret)
+            stored = keyring.get_password(self.service, self.account)
         except keyring_error as exc:
             raise CredentialError(f"native credential store failed: {exc}") from exc
+        if stored is None or not secrets.compare_digest(_validate_secret(stored), secret):
+            raise CredentialError("native credential store did not retain the control credential")
 
     def delete(self) -> bool:
         keyring, keyring_error = self._keyring()
@@ -88,6 +118,20 @@ class NativeCredentialStore:
             keyring.delete_password(self.service, self.account)
         except keyring_error as exc:
             raise CredentialError(f"native credential store failed: {exc}") from exc
+        return True
+
+    @staticmethod
+    def retire_legacy_file(provision: CredentialProvision) -> bool:
+        """Remove a migrated file only after a native-key node authenticated successfully."""
+        path = provision.legacy_path
+        if provision.source != "migrated" or path is None:
+            return False
+        if load_private_control_key(path) != provision.secret:
+            raise CredentialError("legacy control credential changed during migration")
+        try:
+            path.unlink()
+        except OSError as exc:
+            raise CredentialError("CommunityAI could not retire its migrated local credential") from exc
         return True
 
 

--- a/desktop/src/communityai_desktop/lifecycle.py
+++ b/desktop/src/communityai_desktop/lifecycle.py
@@ -1,0 +1,251 @@
+"""Desktop ownership and supervision of the standalone CommunityAI node process."""
+
+from __future__ import annotations
+
+import os
+import socket
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import Any, Callable, Optional, Sequence
+from urllib.parse import urlsplit
+
+from communityai_desktop.client import NodeApiError, NodeClient, NodeClientError, normalize_loopback_url
+from communityai_desktop.credentials import NativeCredentialStore
+
+DEFAULT_NODE_DATA_DIR = Path.home() / ".drift" / "node"
+DEFAULT_NODE_CONFIG_PATH = DEFAULT_NODE_DATA_DIR / "node-config.json"
+
+
+class NodeLifecycleError(RuntimeError):
+    """The desktop could not safely connect to or supervise its local node."""
+
+
+def _default_node_command() -> tuple[str, ...]:
+    if getattr(sys, "frozen", False):
+        suffix = ".exe" if os.name == "nt" else ""
+        return (str(Path(sys.executable).resolve().with_name(f"CommunityAI-Node{suffix}")),)
+    return (sys.executable, "-m", "drift.cli", "node")
+
+
+def _port_is_open(node_url: str, timeout: float) -> bool:
+    parsed = urlsplit(node_url)
+    host = parsed.hostname or "127.0.0.1"
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+class NodeLifecycleSupervisor:
+    """Start one native-key node sidecar and stop only the process it owns."""
+
+    def __init__(
+        self,
+        node_url: str,
+        credential_store: NativeCredentialStore,
+        *,
+        config_path: Path | str = DEFAULT_NODE_CONFIG_PATH,
+        data_dir: Path | str = DEFAULT_NODE_DATA_DIR,
+        node_command: Optional[Sequence[str]] = None,
+        startup_timeout: float = 45.0,
+        poll_interval: float = 0.2,
+        client_timeout: float = 2.0,
+        process_factory: Callable[..., Any] = subprocess.Popen,
+        client_factory: Callable[..., NodeClient] = NodeClient,
+        port_probe: Callable[[str, float], bool] = _port_is_open,
+        clock: Callable[[], float] = time.monotonic,
+        sleeper: Callable[[float], None] = time.sleep,
+    ) -> None:
+        self.node_url = normalize_loopback_url(node_url)
+        self.credential_store = credential_store
+        self.config_path = Path(config_path).expanduser().resolve()
+        self.data_dir = Path(data_dir).expanduser().resolve()
+        self.node_command = tuple(node_command or _default_node_command())
+        if not self.node_command or any(not isinstance(part, str) or not part for part in self.node_command):
+            raise ValueError("node command must contain non-empty strings")
+        if startup_timeout <= 0 or poll_interval <= 0 or client_timeout <= 0:
+            raise ValueError("node lifecycle timeouts must be positive")
+        self.startup_timeout = float(startup_timeout)
+        self.poll_interval = float(poll_interval)
+        self.client_timeout = float(client_timeout)
+        self._process_factory = process_factory
+        self._client_factory = client_factory
+        self._port_probe = port_probe
+        self._clock = clock
+        self._sleeper = sleeper
+        self._process = None
+        self._closed = False
+        self._closing = threading.Event()
+        self._failures = 0
+        self._next_start = 0.0
+        self._lock = threading.RLock()
+
+    @property
+    def owned_pid(self) -> Optional[int]:
+        with self._lock:
+            process = self._process
+            return process.pid if process is not None and process.poll() is None else None
+
+    def _make_client(self, secret: str) -> NodeClient:
+        return self._client_factory(self.node_url, secret, timeout=self.client_timeout)
+
+    def _command(self) -> tuple[str, ...]:
+        parsed = urlsplit(self.node_url)
+        host = parsed.hostname or "127.0.0.1"
+        port = parsed.port or 80
+        return (
+            *self.node_command,
+            "--config",
+            str(self.config_path),
+            "--data_dir",
+            str(self.data_dir),
+            "--host",
+            host,
+            "--port",
+            str(port),
+            "--control_key_source",
+            "native",
+            "--credential_service",
+            self.credential_store.service,
+            "--credential_account",
+            self.credential_store.account,
+        )
+
+    def _record_failure(self) -> None:
+        self._failures += 1
+        delay = min(30.0, float(2 ** min(self._failures - 1, 5)))
+        self._next_start = self._clock() + delay
+
+    def _start(self) -> None:
+        if urlsplit(self.node_url).scheme != "http":
+            raise NodeLifecycleError("Desktop-owned nodes require a loopback HTTP URL")
+        if not self.config_path.is_file() or self.config_path.is_symlink():
+            raise NodeLifecycleError(
+                f"CommunityAI's model catalog is not installed yet ({self.config_path.name} is missing)"
+            )
+        executable = Path(self.node_command[0])
+        if len(self.node_command) == 1 and not executable.is_file():
+            raise NodeLifecycleError("The bundled CommunityAI node is missing; reinstall the application")
+        if self._clock() < self._next_start:
+            raise NodeLifecycleError("The local node stopped unexpectedly; CommunityAI will retry shortly")
+
+        self.data_dir.mkdir(parents=True, exist_ok=True)
+        kwargs = {
+            "stdin": subprocess.DEVNULL,
+            "stdout": subprocess.DEVNULL,
+            "stderr": subprocess.DEVNULL,
+            "cwd": str(self.data_dir),
+            "close_fds": True,
+        }
+        if os.name == "nt":
+            kwargs["creationflags"] = getattr(subprocess, "CREATE_NO_WINDOW", 0)
+        else:
+            kwargs["start_new_session"] = True
+        try:
+            self._process = self._process_factory(self._command(), **kwargs)
+        except OSError as exc:
+            self._record_failure()
+            raise NodeLifecycleError(f"Could not start the bundled local node: {exc}") from exc
+
+    def _stop_owned_process(self) -> None:
+        process, self._process = self._process, None
+        if process is None or process.poll() is not None:
+            return
+        try:
+            process.terminate()
+            process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            try:
+                process.kill()
+                process.wait(timeout=5)
+            except OSError:
+                pass
+        except OSError:
+            pass
+
+    def _wait_until_ready(self, client: NodeClient) -> None:
+        deadline = self._clock() + self.startup_timeout
+        last_error: Optional[Exception] = None
+        while self._clock() < deadline:
+            if self._closing.is_set():
+                self._stop_owned_process()
+                raise NodeLifecycleError("The local node supervisor is closing")
+            process = self._process
+            if process is None:
+                raise NodeLifecycleError("The local node process was not started")
+            exit_code = process.poll()
+            if exit_code is not None:
+                self._process = None
+                self._record_failure()
+                raise NodeLifecycleError(f"The local node stopped during startup (exit code {exit_code})")
+            if self._port_probe(self.node_url, min(self.client_timeout, 0.25)):
+                try:
+                    client.status()
+                    self._failures = 0
+                    self._next_start = 0.0
+                    return
+                except NodeApiError as exc:
+                    if exc.status_code in (401, 403):
+                        self._stop_owned_process()
+                        self._record_failure()
+                        raise NodeLifecycleError("The local node rejected its native control credential") from exc
+                    last_error = exc
+                except NodeClientError as exc:
+                    last_error = exc
+            self._sleeper(self.poll_interval)
+
+        self._stop_owned_process()
+        self._record_failure()
+        detail = f": {last_error}" if last_error is not None else ""
+        raise NodeLifecycleError(f"The local node did not become ready in time{detail}")
+
+    def ensure_client(self) -> NodeClient:
+        """Return an authenticated client, starting or restarting the sidecar as needed."""
+        with self._lock:
+            if self._closed or self._closing.is_set():
+                raise NodeLifecycleError("The local node supervisor is closed")
+            provision = self.credential_store.provision(self.data_dir / "control-api.key")
+            client = self._make_client(provision.secret)
+
+            port_open = self._port_probe(self.node_url, min(self.client_timeout, 0.25))
+            if port_open:
+                try:
+                    client.status()
+                except NodeClientError as exc:
+                    if self._process is None:
+                        raise NodeLifecycleError(
+                            "Another local service is using the CommunityAI port but did not accept its credential"
+                        ) from exc
+                    self._wait_until_ready(client)
+                return client
+
+            if self._process is not None:
+                exit_code = self._process.poll()
+                if exit_code is None:
+                    self._wait_until_ready(client)
+                    return client
+                self._process = None
+                self._record_failure()
+
+            self._start()
+            self._wait_until_ready(client)
+            if provision.source == "migrated":
+                self.credential_store.retire_legacy_file(provision)
+            return client
+
+    def close(self) -> None:
+        self._closing.set()
+        with self._lock:
+            self._closed = True
+            self._stop_owned_process()
+
+    def __enter__(self) -> "NodeLifecycleSupervisor":
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> None:  # noqa: ANN001
+        self.close()

--- a/desktop/src/communityai_desktop/pyside_shell.py
+++ b/desktop/src/communityai_desktop/pyside_shell.py
@@ -601,7 +601,7 @@ def run(
                 self.sidebar_status.setText("Connecting")
                 self._submit(connect, self._connected)
                 return
-            self._submit(self._controller.snapshot, self._render)
+            self._submit(self._controller.snapshot, self._render, self._snapshot_failed)
 
         def _connected(self, connected_controller) -> None:  # noqa: ANN001
             self._controller = connected_controller
@@ -609,8 +609,13 @@ def run(
 
         def _connection_failed(self, message: str) -> None:
             self._set_connection_state(False)
+            self.connection_detail.setText(str(message)[:300])
             self.hero_title.setText("Your AI will appear here")
             self.hero_subtitle.setText("CommunityAI connects automatically as soon as it is ready.")
+
+        def _snapshot_failed(self, message: str) -> None:
+            self._controller = None
+            self._connection_failed(message)
 
         def _reset_connection(self) -> None:
             self._controller = None

--- a/desktop/tests/test_credentials.py
+++ b/desktop/tests/test_credentials.py
@@ -39,6 +39,22 @@ class NativeCredentialStoreTests(unittest.TestCase):
             self.assertTrue(store.delete())
             self.assertFalse(store.delete())
 
+    def test_provisions_a_new_native_key_without_an_ordinary_file(self):
+        backend = FakeKeyring()
+        store = NativeCredentialStore()
+        with TemporaryDirectory() as directory, patch.object(
+            store, "_keyring", return_value=(backend, FakeKeyringError)
+        ):
+            legacy_path = Path(directory) / "missing-control-api.key"
+            provision = store.provision(legacy_path)
+            stored = store.get()
+
+        self.assertEqual(provision.source, "generated")
+        self.assertIsNone(provision.legacy_path)
+        self.assertTrue(provision.secret.startswith("drift_control_"))
+        self.assertFalse(legacy_path.exists())
+        self.assertEqual(stored, provision.secret)
+
     def test_rejects_an_inference_key_or_empty_value(self):
         backend = FakeKeyring()
         store = NativeCredentialStore()
@@ -60,16 +76,16 @@ class NativeCredentialStoreTests(unittest.TestCase):
         get.assert_not_called()
 
     def test_normal_startup_opens_the_window_before_loading_a_credential(self):
-        with patch("communityai_desktop.app.NativeCredentialStore.get_or_migrate") as get, patch(
+        with patch("communityai_desktop.app.NodeLifecycleSupervisor.ensure_client") as ensure, patch(
             "communityai_desktop.pyside_shell.run", return_value=0
         ) as run:
             self.assertEqual(main([]), 0)
 
-        get.assert_not_called()
+        ensure.assert_not_called()
         run.assert_called_once()
         connector = run.call_args.kwargs["connect"]
         with patch(
-            "communityai_desktop.app.NativeCredentialStore.get_or_migrate",
+            "communityai_desktop.lifecycle.NodeLifecycleSupervisor.ensure_client",
             side_effect=CredentialError("missing"),
         ):
             with self.assertRaisesRegex(CredentialError, "missing"):
@@ -84,6 +100,23 @@ class NativeCredentialStoreTests(unittest.TestCase):
             key_path.chmod(0o600)
             with patch.object(store, "_keyring", return_value=(backend, FakeKeyringError)):
                 self.assertEqual(store.get_or_migrate(key_path), CONTROL_KEY)
+                self.assertEqual(store.get(), CONTROL_KEY)
+
+                provision = store.provision(key_path)
+                self.assertEqual(provision.source, "native")
+
+    def test_retires_only_the_legacy_file_bound_to_a_successful_migration(self):
+        backend = FakeKeyring()
+        store = NativeCredentialStore()
+        with TemporaryDirectory() as directory:
+            key_path = Path(directory) / "control-api.key"
+            key_path.write_text(CONTROL_KEY + "\n", encoding="utf-8")
+            key_path.chmod(0o600)
+            with patch.object(store, "_keyring", return_value=(backend, FakeKeyringError)):
+                provision = store.provision(key_path)
+                self.assertEqual(provision.source, "migrated")
+                self.assertTrue(store.retire_legacy_file(provision))
+                self.assertFalse(key_path.exists())
                 self.assertEqual(store.get(), CONTROL_KEY)
 
 

--- a/desktop/tests/test_lifecycle.py
+++ b/desktop/tests/test_lifecycle.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from communityai_desktop.client import NodeApiError
+from communityai_desktop.credentials import CredentialProvision
+from communityai_desktop.lifecycle import NodeLifecycleError, NodeLifecycleSupervisor
+
+CONTROL_KEY = "drift_control_" + "L" * 43
+
+
+class FakeStore:
+    service = "test-service"
+    account = "test-account"
+
+    def __init__(self, source="generated", legacy_path=None):
+        self.provisioned = CredentialProvision(CONTROL_KEY, source, legacy_path)
+        self.retired = []
+
+    def provision(self, path):
+        return self.provisioned
+
+    def retire_legacy_file(self, provision):
+        self.retired.append(provision)
+        return True
+
+
+class FakeClient:
+    def __init__(self, node_url, secret, *, timeout, error=None):
+        self.node_url = node_url
+        self.secret = secret
+        self.timeout = timeout
+        self.error = error
+        self.status_calls = 0
+
+    def status(self):
+        self.status_calls += 1
+        if self.error is not None:
+            raise self.error
+        return {"api_version": 1}
+
+
+class FakeProcess:
+    next_pid = 100
+
+    def __init__(self, command, **kwargs):
+        self.command = tuple(command)
+        self.kwargs = kwargs
+        self.returncode = None
+        self.terminated = False
+        self.killed = False
+        self.pid = FakeProcess.next_pid
+        FakeProcess.next_pid += 1
+
+    def poll(self):
+        return self.returncode
+
+    def terminate(self):
+        self.terminated = True
+        self.returncode = 0
+
+    def wait(self, timeout):
+        return self.returncode
+
+    def kill(self):
+        self.killed = True
+        self.returncode = -9
+
+
+class FakeClock:
+    def __init__(self):
+        self.value = 0.0
+
+    def __call__(self):
+        return self.value
+
+    def sleep(self, duration):
+        self.value += duration
+
+
+class PortSequence:
+    def __init__(self, *values):
+        self.values = list(values)
+
+    def __call__(self, node_url, timeout):
+        if len(self.values) > 1:
+            return self.values.pop(0)
+        return self.values[0]
+
+
+class NodeLifecycleTests(unittest.TestCase):
+    def _supervisor(self, directory, store, **kwargs):
+        root = Path(directory)
+        config = root / "node-config.json"
+        config.write_text("{}\n", encoding="utf-8")
+        return NodeLifecycleSupervisor(
+            "http://127.0.0.1:8080",
+            store,
+            config_path=config,
+            data_dir=root / "data",
+            node_command=("python", "fake-node.py"),
+            startup_timeout=2,
+            poll_interval=0.1,
+            **kwargs,
+        )
+
+    def test_reuses_an_authenticated_external_node_without_owning_it(self):
+        processes = []
+        clients = []
+
+        def client_factory(*args, **kwargs):
+            client = FakeClient(*args, **kwargs)
+            clients.append(client)
+            return client
+
+        with TemporaryDirectory() as directory:
+            supervisor = self._supervisor(
+                directory,
+                FakeStore(),
+                process_factory=lambda *args, **kwargs: processes.append((args, kwargs)),
+                client_factory=client_factory,
+                port_probe=PortSequence(True),
+            )
+            returned = supervisor.ensure_client()
+            supervisor.close()
+
+        self.assertIs(returned, clients[0])
+        self.assertEqual(returned.secret, CONTROL_KEY)
+        self.assertEqual(processes, [])
+        self.assertIsNone(supervisor.owned_pid)
+
+    def test_starts_native_node_without_exposing_the_secret_and_retires_migration(self):
+        processes = []
+        clients = []
+        clock = FakeClock()
+
+        def process_factory(command, **kwargs):
+            process = FakeProcess(command, **kwargs)
+            processes.append(process)
+            return process
+
+        def client_factory(*args, **kwargs):
+            client = FakeClient(*args, **kwargs)
+            clients.append(client)
+            return client
+
+        with TemporaryDirectory() as directory:
+            legacy_path = Path(directory) / "control-api.key"
+            store = FakeStore("migrated", legacy_path)
+            supervisor = self._supervisor(
+                directory,
+                store,
+                process_factory=process_factory,
+                client_factory=client_factory,
+                port_probe=PortSequence(False, True),
+                clock=clock,
+                sleeper=clock.sleep,
+            )
+            returned = supervisor.ensure_client()
+            owned_pid = supervisor.owned_pid
+            supervisor.close()
+
+        self.assertIs(returned, clients[0])
+        self.assertIsNotNone(owned_pid)
+        self.assertEqual(len(processes), 1)
+        command = processes[0].command
+        self.assertIn("--control_key_source", command)
+        self.assertIn("native", command)
+        self.assertEqual(command[command.index("--port") + 1], "8080")
+        self.assertNotIn(CONTROL_KEY, command)
+        self.assertNotIn(CONTROL_KEY, str(processes[0].kwargs))
+        self.assertEqual(store.retired, [store.provisioned])
+        self.assertTrue(processes[0].terminated)
+
+    def test_does_not_replace_an_untrusted_service_on_the_configured_port(self):
+        processes = []
+
+        def client_factory(*args, **kwargs):
+            return FakeClient(*args, **kwargs, error=NodeApiError(401, "no"))
+
+        with TemporaryDirectory() as directory:
+            supervisor = self._supervisor(
+                directory,
+                FakeStore(),
+                process_factory=lambda *args, **kwargs: processes.append((args, kwargs)),
+                client_factory=client_factory,
+                port_probe=PortSequence(True),
+            )
+            with self.assertRaisesRegex(NodeLifecycleError, "Another local service"):
+                supervisor.ensure_client()
+            supervisor.close()
+
+        self.assertEqual(processes, [])
+
+    def test_crash_restarts_only_after_bounded_backoff(self):
+        processes = []
+        clock = FakeClock()
+
+        def process_factory(command, **kwargs):
+            process = FakeProcess(command, **kwargs)
+            processes.append(process)
+            return process
+
+        with TemporaryDirectory() as directory:
+            supervisor = self._supervisor(
+                directory,
+                FakeStore(),
+                process_factory=process_factory,
+                client_factory=FakeClient,
+                port_probe=PortSequence(False, True, False, False, True),
+                clock=clock,
+                sleeper=clock.sleep,
+            )
+            supervisor.ensure_client()
+            processes[0].returncode = 7
+            with self.assertRaisesRegex(NodeLifecycleError, "retry shortly"):
+                supervisor.ensure_client()
+            clock.value += 1.1
+            supervisor.ensure_client()
+            supervisor.close()
+
+        self.assertEqual(len(processes), 2)
+        self.assertTrue(processes[1].terminated)
+
+    def test_missing_catalog_does_not_spawn_a_process(self):
+        processes = []
+        with TemporaryDirectory() as directory:
+            supervisor = NodeLifecycleSupervisor(
+                "http://127.0.0.1:8080",
+                FakeStore(),
+                config_path=Path(directory) / "missing.json",
+                data_dir=Path(directory) / "data",
+                node_command=("python", "fake-node.py"),
+                process_factory=lambda *args, **kwargs: processes.append((args, kwargs)),
+                client_factory=FakeClient,
+                port_probe=PortSequence(False),
+            )
+            with self.assertRaisesRegex(NodeLifecycleError, "model catalog is not installed"):
+                supervisor.ensure_client()
+            supervisor.close()
+
+        self.assertEqual(processes, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/NODE_CONFIG_V1.md
+++ b/docs/NODE_CONFIG_V1.md
@@ -66,8 +66,11 @@ are deliberately absent from this format. A Hugging Face token may currently be
 supplied with the process secret mechanism or the existing `--token` compatibility
 option. The generated OpenAI bootstrap key remains in `local-api.key`; the privileged
 control credential is separately generated in `control-api.key` or read from
-`--control_key_path`. Labeled OpenAI key records are stored beneath the node data
-directory as metadata and domain-separated hashes only.
+`--control_key_path` for headless use. A desktop-owned node instead uses
+`--control_key_source native`, which requires an existing `drift_control_` key in
+the configured native credential service/account and never falls back to an
+ordinary file. Labeled OpenAI key records are stored beneath the node data directory
+as metadata and domain-separated hashes only.
 
 An existing explicit control file must contain the `drift_control_` key class with
 at least 256 bits of URL-safe random material. A client key file cannot be reused as

--- a/docs/REVIVAL.md
+++ b/docs/REVIVAL.md
@@ -36,10 +36,13 @@ Milestone 5 is active. Its architectural foundation is now fixed:
 The shared client and acceptance contract now live in a standalone production PySide
 package. Its source and packaged smokes enforce the GUI/node boundary, strict loopback
 control traffic, key lifecycle, and worker controls without importing model runtimes.
-The immediate objective is now end-to-end native credential ownership, followed by
-onboarding and process lifecycle, contribution policies and budgets, accessibility and
-resource measurements, and signed installer/update/rollback validation. Milestones 6
-through 8 remain planned after this desktop foundation.
+The node and desktop now share the native credential store directly, and the desktop
+has source-level ownership for node startup, authenticated readiness, bounded crash
+backoff, reconnect, and shutdown. The immediate objective is to bundle that standalone
+node sidecar plus the first signed catalog and automatic public seed configuration.
+Contribution policies and budgets, accessibility and resource measurements, and signed
+installer/update/rollback validation follow. Milestones 6 through 8 remain planned
+after this desktop foundation.
 
 The first always-on public discovery peer is now deployed as milestone 6 pilot
 infrastructure. A separate Windows client reached its public IPv4 address, completed a
@@ -185,7 +188,7 @@ receives no prompts, selects no routes, and has no Google Cloud API identity.
 | Network | Dedicated VPC, Standard Tier, static IPv4 `35.209.21.129` |
 | Public ingress | TCP 31337 only; SSH is restricted to Google IAP |
 | Peer address | `/ip4/35.209.21.129/tcp/31337/p2p/QmZhGcSVR6qPLZTq3TJPZEi734GbMkouv3kPxQLdDY2qUo` |
-| Planned DNS | `bootstrap.communityai.flujo.com.co` A record to `35.209.21.129` |
+| Published DNS | `bootstrap.communityai.flujo.com.co` A record to `35.209.21.129` |
 
 The static IPv4 makes dynamic DNS unnecessary and keeps the peer reachable by
 IPv4-only contributors. The VM and disk fit the Google Cloud Free Tier when that
@@ -201,9 +204,9 @@ boot, runs as an unprivileged user, preserves its private identity with owner-on
 permissions, and retained the PeerID above across restarts. Reproducible deployment
 sources and the live inventory are in [`deploy/gcp/`](../deploy/gcp/README.md).
 
-This node is a bootstrap dependency, not a centralized inference service. The next
-deployment gate is the DNS record and automatic desktop seed configuration. Before a
-public release, at least one independently operated seed must be added and the fresh-
+This node is a bootstrap dependency, not a centralized inference service. Its DNS A
+record is published; the next deployment gate is automatic desktop seed configuration.
+Before a public release, at least one independently operated seed must be added and the fresh-
 install, cached-peer, seed-loss, partition, and recovery paths must pass without this
 Google VM being a single point of failure.
 
@@ -545,18 +548,28 @@ implementation.
    Existing headless credentials migrate into the native store automatically, missing
    credentials and node failures render inside the application instead of terminating
    before Qt starts, and the Windows build uses the GUI subsystem without a console
-   window. An unsigned Windows bundle passed the
-   packaged runtime, authenticated contract, connected UI, and onboarding UI smokes; the
-   three-platform production workflow is now checked in but must pass remotely before
-   cross-platform promotion is claimed.
+   window. The production workflow passed its unsigned runtime, authenticated-contract,
+   connected-UI, and onboarding-UI smokes on clean Windows, Linux, and macOS runners.
 
-   **Next implementation sequence.** Publish the pending
-   `bootstrap.communityai.flujo.com.co` DNS record and ship that peer as an automatic,
-   replaceable seed; make the packaged desktop start, supervise, and stop its bundled
-   local node without a setup button; and make the node and desktop share native
-   credential ownership directly so the one-time private-file migration can be retired.
-   Then ship the initial signed model catalog and verified worker manifests so model
-   selection represents real usable swarms. After that, add single-instance and login
+   The second product slice is implemented at the source boundary. A desktop-owned node
+   reads the same native credential entry directly, while explicitly headless nodes keep
+   private-file mode. Fresh installs generate the key only in the native store; existing
+   private files migrate and are removed only after an owned native-key node authenticates.
+   The shell-neutral supervisor detects occupied ports without replacing their process,
+   starts the node with no secret in arguments or environment, waits for authenticated
+   readiness, applies bounded crash backoff, reconnects after a failed status refresh, and
+   stops only its owned process. The GUI bundle does not yet contain the actual model/DHT
+   sidecar or a signed catalog, so packaged end-to-end lifecycle promotion remains open.
+   A real source-level Windows smoke nevertheless provisioned Credential Manager, launched
+   `drift node` on an isolated loopback port, joined through the published DNS seed,
+   authenticated the control API without creating `control-api.key`, and shut down the
+   owned node cleanly.
+
+   **Next implementation sequence.** Bundle the standalone node sidecar, ship the
+   published DNS peer as an automatic replaceable seed, and add the initial signed model
+   catalog plus verified worker manifests so model selection represents real usable
+   swarms. Prove the native credential and owned-process path against real packaged
+   Windows, Linux, and macOS credential backends. After that, add single-instance and login
    startup behavior, feed privacy-safe peer-region observations into the region view,
    enforce contribution budgets and model policy in the node rather than only in the
    GUI, and complete resource, accessibility, signed installer, upgrade, rollback,
@@ -571,8 +584,8 @@ implementation.
 
    **Pilot evidence.** The first GCP `e2-micro` bootstrap is live on a stable public
    IPv4 address, preserves its identity, and has passed an off-host DHT connection.
-   This is the first seed, not milestone completion: DNS publication, desktop wiring,
-   independent operators, additional seeds and relays, cached-peer recovery, signed
+   This is the first seed, not milestone completion: desktop wiring, independent
+   operators, additional seeds and relays, cached-peer recovery, signed
    catalog distribution, observability, and failure drills remain open.
 7. **Safe public pilot and shadow credits.** Add admission and rate limits, abuse
    controls, health and coverage monitoring without a single required dashboard,

--- a/docs/REVIVAL_TEST_RESULTS.md
+++ b/docs/REVIVAL_TEST_RESULTS.md
@@ -15,7 +15,7 @@ test harnesses are `scripts/smoke_tinyllama_local_swarm.py` and
 | 2. Real multi-machine swarm | Complete | A private Fly swarm reached explicit `0:8` coverage with two replicas per block; a selected `4:8` Machine was killed during generation, the client rerouted and replayed its prefix, and both the recovered request and a cache-cleanup request passed exact parity | None for this milestone; broader-model recovery remains follow-up work |
 | 3. Public protocol identity and content integrity | Complete | Content-derived manifests, signed expiring worker announcements, PeerID/TLS binding, replay/range/profile checks, signed intent leases, dual-signed rotation, revocation, deterministic interruption tests, real Hub HTTP 206 resume on Windows and macOS, signed Windows parity/failover, signed Fly cross-Machine parity, hosted macOS signed parity, and prior Fly poison rejection are proven | None |
 | 4. Unified local node and multi-model OpenAI API | Complete | Exact multi-manifest selection, artifact-free unloaded discovery, cancellation-safe lazy loading and LRU residency, isolated supervised workers, labeled hash-only key CRUD, authenticated controls, reproducible edge measurements, official OpenAI Python client compatibility, clean restart/key reuse, and real external two-model Fly parity are proven | None for this milestone; every additional selectable model still needs its own published edge envelope |
-| 5. Desktop application and contribution controls | In progress | ADR 0002 selects PySide 6 after all six clean Windows/Linux/macOS spike jobs passed; the standalone production package enforces the GUI/node import boundary and an unsigned Windows product bundle passed runtime, authenticated-contract, and UI smokes; OpenAI inference keys and the privileged control credential are separate authorities | End-to-end native credential ownership, production cross-platform CI, contribution policies and budgets, lifecycle integration, startup/RSS and crash-isolation measurements, signing, updates, rollback, accessibility, and installer gates remain |
+| 5. Desktop application and contribution controls | In progress | ADR 0002 selects PySide 6; clean production package/UI smokes pass on Windows, Linux, and macOS; OpenAI and control authorities are separate; the node can read the desktop's native credential directly; and source-level lifecycle tests cover startup, authenticated readiness, collisions, backoff, reconnect, migration retirement, and owned shutdown | The real node sidecar and signed catalog are not bundled; real native-store integration, contribution policies and budgets, startup/RSS and crash-isolation measurements, signing, updates, rollback, accessibility, and installer gates remain |
 
 ## Desktop milestone: control authority separation
 
@@ -29,10 +29,11 @@ cannot use those controls.
 The headless migration preserves `~/.drift/node/local-api.key` as an OpenAI client
 key and creates `~/.drift/node/control-api.key` on first upgraded startup. An explicit
 private path can be supplied with `--control_key_path`; putting the privileged secret
-itself on the command line is not supported. The production desktop reads its copy from
-the native OS store and automatically imports an existing node private file once when
-needed. The next slice makes that store the shared source of truth so the migration file
-can be retired.
+itself on the command line is not supported. Desktop-owned nodes instead use
+`--control_key_source native` and read the same service/account entry as the GUI. A fresh
+desktop provisions that entry directly. An existing private file is imported and removed
+only after the owned node authenticates with the native copy. Explicitly headless nodes
+retain private-file mode as their default.
 
 ## Desktop milestone: first production slice
 
@@ -55,12 +56,39 @@ same store directly; the headless node continues to own the private-file mode. N
 desktop startup opens Qt before reading the credential, renders missing-credential and
 connection errors in the window, and retries without a setup or secret-entry screen.
 
-Fourteen focused source tests pass. A clean local Windows x64 PyInstaller build using
+The initial fourteen focused source tests pass. A clean local Windows x64 PyInstaller build using
 Python 3.12.9 and PySide 6.11.2 produced an unsigned 120,936,481-byte, 232-file bundle.
 It uses the Windows GUI subsystem and opens no console. The packaged framework check,
 full authenticated control contract, connected offscreen UI smoke, and missing-credential
-onboarding smoke all passed. A production Windows/Linux/macOS workflow is checked in; its
-clean-runner results are still required before claiming cross-platform product packaging.
+onboarding smoke all passed. The production Windows/Linux/macOS workflow subsequently
+passed all three clean-runner package and UI-smoke jobs.
+
+## Desktop milestone: native credential and lifecycle source contract
+
+The local node has an explicit native credential source that lazily loads `keyring`,
+requires a usable backend and an existing `drift_control_` credential, and never falls
+back to a file if native access fails. The desktop provisions a new 256-bit control key
+directly in that store or verifies and imports a legacy private file. It verifies the
+round trip after writing. The legacy file is retired only after a node started by this
+desktop authenticates successfully; attaching to an external headless node never causes
+the desktop to remove its file.
+
+The source supervisor checks the configured loopback port before spawning, refuses to
+replace an unknown service, launches the standalone node with native-store identifiers
+but no secret, waits for authenticated readiness, applies exponential backoff capped at
+30 seconds, and terminates only its owned process. A failed periodic status refresh now
+drops the stale client so the next refresh re-enters lifecycle recovery. Twenty-one
+desktop tests and twenty-five focused node/key tests pass. The package still excludes
+model, DHT, and worker runtimes and does not yet stage a node sidecar, so this is not a
+claim that a clean packaged installation can run inference.
+
+The real Windows source smoke used a disposable Credential Manager service/account and
+an isolated loopback port. The desktop launched the installed `drift node`, the node
+loaded the same native key, joined via
+`/dns4/bootstrap.communityai.flujo.com.co/tcp/31337/p2p/QmZhGcSVR6qPLZTq3TJPZEi734GbMkouv3kPxQLdDY2qUo`,
+and returned authenticated API version 1 status for one manifest. No
+`control-api.key` appeared in the temporary data directory. The supervisor then stopped
+its owned process and deleted the disposable native credential.
 
 ## Desktop milestone: shell decision
 
@@ -77,7 +105,7 @@ against an isolated fake node. All six package jobs passed.
 ADR 0002 therefore selects PySide 6 for product implementation. Pywebview's Windows and
 macOS size advantage does not offset its 948 MB Linux Qt bundle, larger backend variance,
 and additional JavaScript bridge. The unsigned CI artifacts prove clean packaging and UI
-startup only; native credential stores, accessibility, lifecycle, crash isolation,
+startup only; real native credential backends, accessibility, packaged lifecycle, crash isolation,
 startup/RSS, signed installers, upgrades, rollback, and uninstall remain open release gates.
 
 ## Unified local node: first vertical slice

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,8 @@ api = [
     # plain clients don't drag in a web stack.
     "fastapi>=0.115",
     "uvicorn>=0.30",
+    # Desktop-owned nodes read their privileged control credential from the native OS store.
+    "keyring>=25,<27",
 ]
 benchmark = [
     # Process-tree peak RSS sampling for `drift edge-benchmark`.
@@ -90,6 +92,8 @@ dev = [
     "httpx>=0.27",
     # Representative compatibility gate for the documented localhost OpenAI endpoint.
     "openai>=2,<3",
+    # Native credential source tests run in the broad offline matrix.
+    "keyring>=25,<27",
 ]
 
 [project.scripts]

--- a/scripts/smoke_desktop_managed_node.py
+++ b/scripts/smoke_desktop_managed_node.py
@@ -1,0 +1,88 @@
+"""Exercise desktop-to-node native credentials and lifecycle with a real local process."""
+
+from __future__ import annotations
+
+import json
+import socket
+import sys
+import tempfile
+import uuid
+from pathlib import Path
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPOSITORY_ROOT / "desktop" / "src"))
+
+from communityai_desktop.credentials import NativeCredentialStore  # noqa: E402
+from communityai_desktop.lifecycle import NodeLifecycleSupervisor  # noqa: E402
+
+PUBLIC_BOOTSTRAP = (
+    "/dns4/bootstrap.communityai.flujo.com.co/tcp/31337/" "p2p/QmZhGcSVR6qPLZTq3TJPZEi734GbMkouv3kPxQLdDY2qUo"
+)
+
+
+def _unused_loopback_port() -> int:
+    with socket.socket() as listener:
+        listener.bind(("127.0.0.1", 0))
+        return int(listener.getsockname()[1])
+
+
+def main() -> int:
+    service = f"org.communityai.desktop.smoke.{uuid.uuid4().hex}"
+    account = "local-node-control-v1"
+    store = NativeCredentialStore(service, account)
+    with tempfile.TemporaryDirectory(prefix="communityai-managed-node-") as directory:
+        root = Path(directory)
+        config_path = root / "node-config.json"
+        config_path.write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "max_loaded_models": 1,
+                    "discovery_update_period": 30,
+                    "discovery_startup_timeout": 2,
+                    "models": [
+                        {
+                            "manifest": str(
+                                (REPOSITORY_ROOT / "tests" / "data" / "model_manifest_v1_vector.json").resolve()
+                            ),
+                            "initial_peers": [PUBLIC_BOOTSTRAP],
+                        }
+                    ],
+                    "workers": [],
+                },
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        port = _unused_loopback_port()
+        supervisor = NodeLifecycleSupervisor(
+            f"http://127.0.0.1:{port}",
+            store,
+            config_path=config_path,
+            data_dir=root / "data",
+            startup_timeout=45,
+        )
+        try:
+            client = supervisor.ensure_client()
+            status = client.status()
+            result = {
+                "api_version": status["api_version"],
+                "credential_file_created": (root / "data" / "control-api.key").exists(),
+                "model_count": len(status["models"]),
+                "owned_pid": supervisor.owned_pid,
+                "public_bootstrap": PUBLIC_BOOTSTRAP,
+            }
+            if result["credential_file_created"]:
+                raise RuntimeError("desktop-owned node wrote its privileged native credential to a file")
+            if result["owned_pid"] is None:
+                raise RuntimeError("desktop did not retain ownership of the local node")
+            print(json.dumps(result, sort_keys=True))
+        finally:
+            supervisor.close()
+            store.delete()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/drift/cli/run_node.py
+++ b/src/drift/cli/run_node.py
@@ -16,6 +16,12 @@ from drift.node.discovery import CoverageTarget, ModelCoverageDiscovery
 from drift.node.keys import ApiKeyStore, ApiKeyStoreError, load_or_create_api_key, load_or_create_control_key
 from drift.node.loading import make_manifest_loader
 from drift.node.model_manager import ModelDescriptor, ModelManager, ModelNotFoundError
+from drift.node.native_credentials import (
+    DEFAULT_CREDENTIAL_ACCOUNT,
+    DEFAULT_CREDENTIAL_SERVICE,
+    NativeCredentialLocation,
+    load_native_control_key,
+)
 from drift.node.worker_supervisor import WorkerLaunch, WorkerSupervisor
 from drift.utils.process_lifetime import tie_child_processes_to_this_process
 
@@ -64,6 +70,14 @@ def build_parser() -> argparse.ArgumentParser:
         help="Private drift_control_ key file for the privileged control API (generated if missing)",
     )
     parser.add_argument(
+        "--control_key_source",
+        choices=("file", "native"),
+        default="file",
+        help="Read the privileged control key from a private file or the native OS credential store",
+    )
+    parser.add_argument("--credential_service", default=DEFAULT_CREDENTIAL_SERVICE, help=argparse.SUPPRESS)
+    parser.add_argument("--credential_account", default=DEFAULT_CREDENTIAL_ACCOUNT, help=argparse.SUPPRESS)
+    parser.add_argument(
         "--max_loaded_models",
         type=int,
         default=None,
@@ -110,6 +124,10 @@ def _validate_args(parser: argparse.ArgumentParser, args: argparse.Namespace) ->
         parser.error("--default_max_tokens must be at least 1")
     if any(not key for key in args.api_key):
         parser.error("--api_key values must not be empty")
+    if args.control_key_source == "native" and args.control_key_path is not None:
+        parser.error("--control_key_path cannot be combined with --control_key_source native")
+    if not args.credential_service.strip() or not args.credential_account.strip():
+        parser.error("native credential service and account must not be empty")
 
 
 def _load_node_config(args: argparse.Namespace) -> NodeConfig:
@@ -287,8 +305,22 @@ def _prepare_api_key_store(data_dir: Path, supplied_keys: list[str]) -> tuple[Ap
     return key_store, key_path, created
 
 
-def _prepare_control_key(data_dir: Path, supplied_path: Path | None) -> tuple[str, Path, bool]:
+def _prepare_control_key(
+    data_dir: Path,
+    supplied_path: Path | None,
+    *,
+    source: str = "file",
+    credential_service: str = DEFAULT_CREDENTIAL_SERVICE,
+    credential_account: str = DEFAULT_CREDENTIAL_ACCOUNT,
+) -> tuple[str, Path | None, bool]:
     """Load or atomically create the credential used only by `/control/v1/*`."""
+    if source == "native":
+        if supplied_path is not None:
+            raise ValueError("a control key path cannot be used with the native credential store")
+        key = load_native_control_key(NativeCredentialLocation(credential_service, credential_account))
+        return key, None, False
+    if source != "file":
+        raise ValueError(f"unsupported control key source {source!r}")
     key_path = supplied_path if supplied_path is not None else data_dir / "control-api.key"
     key, created = load_or_create_control_key(key_path)
     return key, key_path, created
@@ -315,7 +347,13 @@ def main() -> None:
 
     try:
         key_store, key_path, created = _prepare_api_key_store(args.data_dir, args.api_key)
-        control_key, control_key_path, control_key_created = _prepare_control_key(args.data_dir, args.control_key_path)
+        control_key, control_key_path, control_key_created = _prepare_control_key(
+            args.data_dir,
+            args.control_key_path,
+            source=args.control_key_source,
+            credential_service=args.credential_service,
+            credential_account=args.credential_account,
+        )
         if key_path is not None:
             if created:
                 logger.info(f"Created the local API key in {key_path}; its value is not written to logs")
@@ -323,7 +361,12 @@ def main() -> None:
                 logger.info(f"Using the local API key from {key_path}")
         elif not args.api_key:
             logger.info(f"Using the active managed API keys in {key_store.path}")
-        if control_key_created:
+        if control_key_path is None:
+            logger.info(
+                f"Using the privileged local control key from native account {args.credential_account!r}; "
+                "its value is not written to logs"
+            )
+        elif control_key_created:
             logger.info(
                 f"Created the privileged local control key in {control_key_path}; its value is not written to logs"
             )

--- a/src/drift/node/keys.py
+++ b/src/drift/node/keys.py
@@ -307,9 +307,17 @@ def load_or_create_api_key(path: Path) -> Tuple[str, bool]:
     return _load_or_create_secret(path, prefix="drift_")
 
 
+def validate_control_key(value: str) -> str:
+    """Validate and normalize a privileged local-node control credential."""
+    if not isinstance(value, str):
+        raise ValueError("control key must be a string")
+    key = value.strip()
+    if _CONTROL_KEY_RE.fullmatch(key) is None:
+        raise ValueError("control key must use the drift_control_ key class with at least 256 bits of entropy")
+    return key
+
+
 def load_or_create_control_key(path: Path) -> Tuple[str, bool]:
     """Load or create the privileged local control credential."""
     key, created = _load_or_create_secret(path, prefix="drift_control_")
-    if _CONTROL_KEY_RE.fullmatch(key) is None:
-        raise ValueError("control key must use the drift_control_ key class with at least 256 bits of entropy")
-    return key, created
+    return validate_control_key(key), created

--- a/src/drift/node/native_credentials.py
+++ b/src/drift/node/native_credentials.py
@@ -1,0 +1,60 @@
+"""Native credential-store access for desktop-owned local nodes.
+
+This module is deliberately small and imports ``keyring`` lazily. Headless nodes keep
+their private-file default; the desktop product opts into this backend explicitly so
+the privileged control secret never crosses a command line, environment variable, or
+ordinary configuration file.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from drift.node.keys import validate_control_key
+
+DEFAULT_CREDENTIAL_SERVICE = "org.communityai.desktop"
+DEFAULT_CREDENTIAL_ACCOUNT = "local-node-control-v1"
+
+
+class NativeCredentialError(ValueError):
+    """The operating-system credential store could not supply a safe key."""
+
+
+@dataclass(frozen=True)
+class NativeCredentialLocation:
+    service: str = DEFAULT_CREDENTIAL_SERVICE
+    account: str = DEFAULT_CREDENTIAL_ACCOUNT
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.service, str) or not isinstance(self.account, str):
+            raise NativeCredentialError("native credential service and account must be strings")
+        service, account = self.service.strip(), self.account.strip()
+        if not service or not account:
+            raise NativeCredentialError("native credential service and account must not be empty")
+        object.__setattr__(self, "service", service)
+        object.__setattr__(self, "account", account)
+
+
+def load_native_control_key(location: NativeCredentialLocation = NativeCredentialLocation()) -> str:
+    """Load an existing control credential without creating or migrating one."""
+    try:
+        import keyring
+        from keyring.errors import KeyringError
+    except ImportError as exc:
+        raise NativeCredentialError("native credential support is not installed; install drift[api]") from exc
+
+    backend = keyring.get_keyring()
+    if getattr(backend, "priority", 0) <= 0:
+        raise NativeCredentialError("no usable native credential store is available")
+    try:
+        secret = keyring.get_password(location.service, location.account)
+    except KeyringError as exc:
+        raise NativeCredentialError(f"native credential store failed: {exc}") from exc
+    if secret is None:
+        raise NativeCredentialError(
+            f"no local-node control credential is stored for native account {location.account!r}"
+        )
+    try:
+        return validate_control_key(secret)
+    except ValueError as exc:
+        raise NativeCredentialError("native control credential has an invalid key class") from exc

--- a/tests/test_api_keys.py
+++ b/tests/test_api_keys.py
@@ -70,6 +70,24 @@ def test_control_key_is_stable_separate_and_supports_an_explicit_path(tmp_path):
     assert custom_path.read_text(encoding="utf-8").strip() == custom
 
 
+def test_control_key_can_come_from_the_native_store_without_a_file(monkeypatch, tmp_path):
+    native_key = "drift_control_" + "K" * 43
+    monkeypatch.setattr("drift.cli.run_node.load_native_control_key", lambda location: native_key)
+
+    loaded, selected_path, created = _prepare_control_key(
+        tmp_path,
+        None,
+        source="native",
+        credential_service="service",
+        credential_account="account",
+    )
+
+    assert loaded == native_key
+    assert selected_path is None
+    assert created is False
+    assert not (tmp_path / "control-api.key").exists()
+
+
 def test_key_store_rejects_duplicate_json_keys(tmp_path):
     path = tmp_path / "api-keys.json"
     path.write_text('{"schema_version":1,"schema_version":1,"keys":[]}', encoding="utf-8")

--- a/tests/test_native_credentials.py
+++ b/tests/test_native_credentials.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import pytest
+
+keyring = pytest.importorskip("keyring")
+
+from drift.node.native_credentials import NativeCredentialError, NativeCredentialLocation, load_native_control_key
+
+CONTROL_KEY = "drift_control_" + "N" * 43
+
+
+class FakeBackend:
+    priority = 1
+
+
+def test_native_node_loads_the_desktop_credential(monkeypatch):
+    calls = []
+    monkeypatch.setattr(keyring, "get_keyring", lambda: FakeBackend())
+    monkeypatch.setattr(
+        keyring,
+        "get_password",
+        lambda service, account: calls.append((service, account)) or CONTROL_KEY,
+    )
+
+    assert load_native_control_key(NativeCredentialLocation(" service ", " account ")) == CONTROL_KEY
+    assert calls == [("service", "account")]
+
+
+@pytest.mark.parametrize("secret", [None, "drift_client", "drift_control_short"])
+def test_native_node_fails_closed_on_missing_or_wrong_key_class(monkeypatch, secret):
+    monkeypatch.setattr(keyring, "get_keyring", lambda: FakeBackend())
+    monkeypatch.setattr(keyring, "get_password", lambda service, account: secret)
+
+    with pytest.raises(NativeCredentialError):
+        load_native_control_key()

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -271,6 +271,21 @@ def test_node_parser_accepts_config_mode_and_rejects_ambiguous_model_options():
     _validate_args(parser, config_args)
     assert config_args.control_key_path.as_posix() == "private/control.key"
 
+    native_args = parser.parse_args(["--config", "node.json", "--control_key_source", "native"])
+    _validate_args(parser, native_args)
+    conflicting_native_args = parser.parse_args(
+        [
+            "--config",
+            "node.json",
+            "--control_key_source",
+            "native",
+            "--control_key_path",
+            "private/control.key",
+        ]
+    )
+    with pytest.raises(SystemExit):
+        _validate_args(parser, conflicting_native_args)
+
     both = parser.parse_args(
         [
             "manifest.json",

--- a/uv.lock
+++ b/uv.lock
@@ -84,6 +84,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backports-tarfile"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/72/cd9b395f25e290e633655a100af28cb253e4393396264a98bd5f5951d50f/backports_tarfile-1.2.0.tar.gz", hash = "sha256:d75e02c268746e1b8144c278978b6e98e85de6ad16f8e4b0844a154557eca991", size = 86406, upload-time = "2024-05-28T17:01:54.731Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/fa/123043af240e49752f1c4bd24da5053b6bd00cad78c2be53c0d1e8b975bc/backports.tarfile-1.2.0-py3-none-any.whl", hash = "sha256:77e284d754527b01fb1e6fa8a1afe577858ebe4e9dad8919e34c862cb399bc34", size = 30181, upload-time = "2024-05-28T17:01:53.112Z" },
+]
+
+[[package]]
 name = "base58"
 version = "2.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -533,6 +542,7 @@ dependencies = [
 [package.optional-dependencies]
 api = [
     { name = "fastapi" },
+    { name = "keyring" },
     { name = "uvicorn" },
 ]
 benchmark = [
@@ -543,6 +553,7 @@ dev = [
     { name = "fastapi" },
     { name = "httpx" },
     { name = "isort" },
+    { name = "keyring" },
     { name = "openai" },
     { name = "psutil" },
     { name = "pytest" },
@@ -565,6 +576,8 @@ requires-dist = [
     { name = "huggingface-hub", specifier = ">=0.30" },
     { name = "humanfriendly" },
     { name = "isort", marker = "extra == 'dev'", specifier = "==5.10.1" },
+    { name = "keyring", marker = "extra == 'api'", specifier = ">=25,<27" },
+    { name = "keyring", marker = "extra == 'dev'", specifier = ">=25,<27" },
     { name = "numpy", specifier = ">=1.26" },
     { name = "openai", marker = "extra == 'dev'", specifier = ">=2,<3" },
     { name = "packaging", specifier = ">=20.9" },
@@ -884,6 +897,18 @@ wheels = [
 ]
 
 [[package]]
+name = "importlib-metadata"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp", marker = "python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl", hash = "sha256:2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7", size = 27789, upload-time = "2026-03-20T06:42:55.665Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -899,6 +924,51 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ab/e9/964cb0b2eedd80c92f5172f1f8ae0443781a9d461c1372a3ce5762489593/isort-5.10.1.tar.gz", hash = "sha256:e8443a5e7a020e9d7f97f1d7d9cd17c88bcb3bc7e218bf9cf5095fe550be2951", size = 174062, upload-time = "2021-11-09T05:42:46.759Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b8/5b/f18e227df38b94b4ee30d2502fd531bebac23946a2497e5595067a561274/isort-5.10.1-py3-none-any.whl", hash = "sha256:6f62d78e2f89b4500b080fe3a81690850cd254227f27f75c3a0c491a1f351ba7", size = 103430, upload-time = "2021-11-09T05:42:44.651Z" },
+]
+
+[[package]]
+name = "jaraco-classes"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd", size = 11780, upload-time = "2024-03-31T07:27:36.643Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl", hash = "sha256:f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790", size = 6777, upload-time = "2024-03-31T07:27:34.792Z" },
+]
+
+[[package]]
+name = "jaraco-context"
+version = "6.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backports-tarfile", marker = "python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/af/50/4763cd07e722bb6285316d390a164bc7e479db9d90daa769f22578f698b4/jaraco_context-6.1.2.tar.gz", hash = "sha256:f1a6c9d391e661cc5b8d39861ff077a7dc24dc23833ccee564b234b81c82dfe3", size = 16801, upload-time = "2026-03-20T22:13:33.922Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/58/bc8954bda5fcda97bd7c19be11b85f91973d67a706ed4a3aec33e7de22db/jaraco_context-6.1.2-py3-none-any.whl", hash = "sha256:bf8150b79a2d5d91ae48629d8b427a8f7ba0e1097dd6202a9059f29a36379535", size = 7871, upload-time = "2026-03-20T22:13:32.808Z" },
+]
+
+[[package]]
+name = "jaraco-functools"
+version = "4.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6c/1f/c23395957d41ccf27c4e535c3d334c4051e5395b3752057ba4cbaec35c56/jaraco_functools-4.6.0.tar.gz", hash = "sha256:880c577ec9720b3a052d5bc611fb9f2269b3d87902ef42440df443b88e443280", size = 20837, upload-time = "2026-07-14T01:28:02.544Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/36/ecc85bc96c273dc8a11273ed4782272975e6338d4a3e9228621175edf0e3/jaraco_functools-4.6.0-py3-none-any.whl", hash = "sha256:99e3dc0060c5cbe8fcd1cdb36258e2a65ca40f1566b2033b12abb1bb44dd3c30", size = 11677, upload-time = "2026-07-14T01:28:01.59Z" },
+]
+
+[[package]]
+name = "jeepney"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
 ]
 
 [[package]]
@@ -1010,6 +1080,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1a/07/421f1d5b65493a76e16027b848aba6a7d28073ae75944fa4289cc914d39f/jiter-0.16.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:96e38eea538c8ddf853a35727c7be0741c76c13f04148ac5c116222f50ece3b3", size = 304658, upload-time = "2026-06-29T13:05:08.708Z" },
     { url = "https://files.pythonhosted.org/packages/0a/db/bba1155f01a01c3c37a89425d571da751bbedf5c54247b831a04cb971798/jiter-0.16.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d284fb8d94d5855d60c44fefcab4bf966f1da6fada73992b01f6f0c9bc0c6702", size = 339719, upload-time = "2026-06-29T13:05:10.41Z" },
     { url = "https://files.pythonhosted.org/packages/78/f7/18a1afcd64f35314b68c1f23afcd9994d0bc13e65cc77517afff4e83986d/jiter-0.16.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64d613743df53199b1aa256a7d328340da6d7078aac7705a7db9d7a791e9cfd2", size = 343885, upload-time = "2026-06-29T13:05:12.087Z" },
+]
+
+[[package]]
+name = "keyring"
+version = "25.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata", marker = "python_full_version < '3.12'" },
+    { name = "jaraco-classes" },
+    { name = "jaraco-context" },
+    { name = "jaraco-functools" },
+    { name = "jeepney", marker = "sys_platform == 'linux'" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "secretstorage", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/4b/674af6ef2f97d56f0ab5153bf0bfa28ccb6c3ed4d1babf4305449668807b/keyring-25.7.0.tar.gz", hash = "sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b", size = 63516, upload-time = "2025-11-16T16:26:09.482Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl", hash = "sha256:be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f", size = 39160, upload-time = "2025-11-16T16:26:08.402Z" },
 ]
 
 [[package]]
@@ -1212,6 +1300,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/81/a6/ca51c864bdb30524beb055a6d8826db3906af0834ec8c41d097a6e8573d5/mmh3-5.2.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:6290289fa5fb4c70fd7f72016e03633d60388185483ff3b162912c81205ae2cf", size = 116890, upload-time = "2026-03-05T15:55:49.405Z" },
     { url = "https://files.pythonhosted.org/packages/cc/04/5a1fe2e2ad843d03e89af25238cbc4f6840a8bb6c4329a98ab694c71deda/mmh3-5.2.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:4fc6cd65dc4d2fdb2625e288939a3566e36127a84811a4913f02f3d5931da52d", size = 123121, upload-time = "2026-03-05T15:55:50.61Z" },
     { url = "https://files.pythonhosted.org/packages/af/4d/3c820c6f4897afd25905270a9f2330a23f77a207ea7356f7aadace7273c0/mmh3-5.2.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:623f938f6a039536cc02b7582a07a080f13fdfd48f87e63201d92d7e34d09a18", size = 110187, upload-time = "2026-03-05T15:55:52.143Z" },
+]
+
+[[package]]
+name = "more-itertools"
+version = "11.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/1d/f4da6f02cdffe04d6362210b807146a26044c88d839208aec273bb0d9184/more_itertools-11.1.0.tar.gz", hash = "sha256:48e8f4d9e7e5878571ecf6f2b4e57634f93cd474cc8cfbd2376f2d11b396e30d", size = 145772, upload-time = "2026-05-22T14:14:29.909Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/3d/1087453384dbde46a8c7f9356eead2c58be8a7bf156bca40243377c85715/more_itertools-11.1.0-py3-none-any.whl", hash = "sha256:4b65538ae22f6fed0ce4874efd317463a7489796a0939fa66824dd542125a192", size = 72226, upload-time = "2026-05-22T14:14:28.824Z" },
 ]
 
 [[package]]
@@ -2050,6 +2147,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/33/d0/9297d7d8dd74767b4d5560d834b30b2fff17d39987c23ed8656f476e0d9b/python-baseconv-1.2.2.tar.gz", hash = "sha256:0539f8bd0464013b05ad62e0a1673f0ac9086c76b43ebf9f833053527cd9931b", size = 4929, upload-time = "2019-04-04T19:28:57.17Z" }
 
 [[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2402,6 +2508,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/41/68/8f21e8a65a5a03f25a79165ec9d2b28c00e66dc80546cf5eb803aeeff35b/scipy-1.17.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a9956e4d4f4a301ebf6cde39850333a6b6110799d470dbbb1e25326ac447f52a", size = 35281163, upload-time = "2026-02-23T00:22:07.024Z" },
     { url = "https://files.pythonhosted.org/packages/84/8d/c8a5e19479554007a5632ed7529e665c315ae7492b4f946b0deb39870e39/scipy-1.17.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:a4328d245944d09fd639771de275701ccadf5f781ba0ff092ad141e017eccda4", size = 35116291, upload-time = "2026-02-23T00:22:12.585Z" },
     { url = "https://files.pythonhosted.org/packages/52/52/e57eceff0e342a1f50e274264ed47497b59e6a4e3118808ee58ddda7b74a/scipy-1.17.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a77cbd07b940d326d39a1d1b37817e2ee4d79cb30e7338f3d0cddffae70fcaa2", size = 37682317, upload-time = "2026-02-23T00:22:18.513Z" },
+]
+
+[[package]]
+name = "secretstorage"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "jeepney" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl", hash = "sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137", size = 15554, upload-time = "2025-11-23T19:02:51.545Z" },
 ]
 
 [[package]]
@@ -2840,3 +2959,12 @@ name = "varint"
 version = "1.0.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a8/fe/1ea0ba0896dfa47186692655b86db3214c4b7c9e0e76c7b1dc257d101ab1/varint-1.0.2.tar.gz", hash = "sha256:a6ecc02377ac5ee9d65a6a8ad45c9ff1dac8ccee19400a5950fb51d594214ca5", size = 1886, upload-time = "2016-02-24T20:42:38.5Z" }
+
+[[package]]
+name = "zipp"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/d8/eab98a517c14134c0b2eb4e2387bc5f457334293ec5d2dd3857ec2966802/zipp-4.1.0.tar.gz", hash = "sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602", size = 26214, upload-time = "2026-05-18T20:08:57.967Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl", hash = "sha256:25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f", size = 10238, upload-time = "2026-05-18T20:08:57.045Z" },
+]


### PR DESCRIPTION
## Summary
- make the OS credential store the direct source of truth for desktop-owned nodes while preserving explicit headless file mode
- add shell-neutral startup, authenticated readiness, occupied-port safety, bounded crash backoff, reconnect, migration retirement, and owned shutdown
- record the published bootstrap DNS and add a real Windows native-key/node lifecycle smoke

## Validation
- 209 passed, 7 skipped in the broad offline matrix
- 21 desktop source tests passed
- real Windows Credential Manager + drift node + public DNS seed smoke passed
- unsigned Windows PyInstaller runtime, authenticated contract, connected UI, and onboarding UI smokes passed
- black, isort, lock, and diff checks passed