### PR TITLE
Bundle node sidecar and add catalog bootstrap qualification

### DIFF
--- a/.github/workflows/desktop.yaml
+++ b/.github/workflows/desktop.yaml
@@ -5,6 +5,10 @@ on:
     paths:
       - ".github/workflows/desktop.yaml"
       - "desktop/**"
+      - "pyproject.toml"
+      - "src/**"
+      - "scripts/build_hivemind_windows.py"
+      - "scripts/hivemind-win32.patch"
       - "docs/REVIVAL.md"
       - "docs/REVIVAL_TEST_RESULTS.md"
   workflow_dispatch:
@@ -16,7 +20,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    timeout-minutes: 75
     defaults:
       run:
         working-directory: desktop
@@ -26,20 +30,41 @@ jobs:
         with:
           python-version: "3.12"
           cache: pip
-          cache-dependency-path: desktop/pyproject.toml
+          cache-dependency-path: |
+            pyproject.toml
+            desktop/pyproject.toml
+      - uses: actions/setup-go@v6
+        if: runner.os == 'Windows'
+        with:
+          go-version: stable
       - name: Install Linux Qt runtime libraries
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install --no-install-recommends --yes libdbus-1-3 libegl1 libgl1 libxkbcommon0
-      - name: Install production desktop
-        run: python -m pip install -e ".[dev]"
+      - name: Build patched Windows Hivemind runtime
+        if: runner.os == 'Windows'
+        run: |
+          python -m pip install patch
+          python ../scripts/build_hivemind_windows.py --out-dir ../dist
+          $wheel = Get-ChildItem ../dist/hivemind-1.1.12-*-win_amd64.whl | Select-Object -Last 1
+          if (-not $wheel) { throw "Hivemind wheel build produced no artifact" }
+          python -m pip install $wheel.FullName
+      - name: Install production desktop and node runtime
+        run: |
+          python -m pip install -e "..[api]"
+          python -m pip install -e ".[dev]"
       - name: Run protocol and runtime-boundary tests
         run: |
           python -m unittest discover -s tests -v
           communityai-desktop --self-test
       - name: Build and smoke unsigned production bundle
         run: python build_desktop.py
+      - name: Exercise packaged node, native credentials, and public seed
+        if: runner.os == 'Windows'
+        run: >-
+          python ../scripts/smoke_desktop_managed_node.py
+          --node-command dist/desktop/CommunityAI/node/CommunityAI-Node.exe
       - name: Upload unsigned bundle and metrics
         uses: actions/upload-artifact@v6
         with:

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -49,7 +49,7 @@ jobs:
           # attention wiring, join tokens, device portability). The swarm/network tests
           # (test_full_model, test_remote_sequential, ...) require MODEL_NAME/INITIAL_PEERS and a
           # running swarm; the maintainer exercises those on real hardware.
-          pytest -v --durations=0 --durations-min=1.0 \
+          python -m pytest -v --durations=0 --durations-min=1.0 \
             tests/test_attn_implementation.py \
             tests/test_api_keys.py \
             tests/test_cache.py \

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -53,6 +53,7 @@ jobs:
             tests/test_attn_implementation.py \
             tests/test_api_keys.py \
             tests/test_cache.py \
+            tests/test_catalog_bootstrap.py \
             tests/test_deepseek_v3.py \
             tests/test_discovery.py \
             tests/test_edge_benchmark.py \
@@ -76,6 +77,7 @@ jobs:
             tests/test_priority_pool.py \
             tests/test_process_lifetime.py \
             tests/test_protocol_identity.py \
+            tests/test_qualification_harness.py \
             tests/test_route_health.py \
             tests/test_server_registry.py \
             tests/test_startup_guard.py \
@@ -103,7 +105,7 @@ jobs:
         if: matrix.os == 'macos'
         run: |
           source .venv/bin/activate
-          python scripts/smoke_tinyllama_local_swarm.py \
+          python scripts/smoke_manifest_local_swarm.py \
             --device cpu \
             --torch-dtype float32 \
             --model-manifest "$RUNNER_TEMP/tinyllama-manifest.json" \

--- a/README.md
+++ b/README.md
@@ -268,6 +268,28 @@ activation prefix on the survivor, and verify exact parity:
     --test-failover --failover-tokens 8
 ```
 
+To qualify any exact `ModelManifest v1` instead of the legacy TinyLlama default,
+use the model-agnostic runner. It derives the repository, immutable revision, block
+count, DHT namespace, dtype, and attention profile from the manifest, serves every
+declared transformer block, compares generated token IDs with the stock model, and
+writes bounded machine-readable evidence:
+
+```powershell
+.\.venv\Scripts\python.exe scripts\qualify_model_manifest.py `
+    manifests\candidates\qwen3-1.7b-bfloat16-eager.json `
+    --device cpu --with-failover `
+    --output qualification-qwen3-1.7b-windows-cpu.json
+```
+
+Pass `--artifact-root` with a complete publisher snapshot to re-hash every declared
+artifact before inference. A standard immutable Hugging Face snapshot also lets the
+runner infer and reuse its Hub cache root; pass `--cache-dir` for other cache layouts.
+`--manifest-only` performs the schema/runtime/artifact gate without loading the model.
+The report always marks
+`complete_release_qualification` false because multi-machine interruption recovery,
+the cross-platform device matrix, the cold-client resource envelope, and redundant
+public-worker soak require separate evidence.
+
 ## Supported models
 
 Dense GQA models:

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -30,12 +30,18 @@ entry points. A packaged Windows lifecycle smoke has also launched that sidecar 
 native Credential Manager key, joined the published DNS seed, authenticated readiness,
 and shut down the owned process without writing a control-key file.
 
-The initial signed catalog, verified model manifests, and first-install node
-configuration have not been added yet. Until those arrive, source or packaged runs can
-supervise the node when `~/.drift/node/node-config.json` exists, while a fresh install
-renders the missing-catalog state in the window. Cross-platform packaged native-store
-promotion, contribution budgets, login startup, accessibility validation, signed
-installers, and update/rollback behavior remain later milestone-5 slices.
+The sidecar now implements the first-install catalog consumer, and the desktop invokes
+it automatically when `~/.drift/node/node-config.json` is absent. It authenticates a
+bounded HTTPS catalog against a bundled root, enforces expiry and persistent rollback
+state, installs only exact digest-matched manifests, generates the seed-backed node
+configuration, and retains an unexpired last-known-good catalog for offline recovery.
+The release bootstrap file and first qualified public manifests are not published or
+bundled yet, so current unsigned builds still render the missing-catalog state on a
+truly clean install. See [`CATALOG_BOOTSTRAP_V1.md`](../docs/CATALOG_BOOTSTRAP_V1.md).
+
+Cross-platform packaged native-store promotion, contribution budgets, login startup,
+accessibility validation, signed installers, and update/rollback behavior remain later
+milestone-5 slices.
 
 ## Development
 
@@ -84,6 +90,13 @@ Build and smoke-test the unsigned PyInstaller bundle:
 ```shell
 python generate_assets.py  # only needed after changing the product icon
 python build_desktop.py
+```
+
+Once release catalog inputs are qualified, stage the validated public bootstrap file
+into the product bundle with:
+
+```shell
+python build_desktop.py --bootstrap-config ../path/to/catalog-bootstrap.json
 ```
 
 On Windows the GUI build uses the GUI subsystem, so double-clicking the application does

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -22,21 +22,33 @@ the secret in its command, environment, logs, or ordinary configuration. A migra
 private file is removed only after a desktop-owned native-key node authenticates. File
 mode remains the default for explicitly headless `drift node` use.
 
-The current PyInstaller artifact still contains only the GUI client: the real model/DHT
-node sidecar and initial signed catalog have not been added to that bundle. Until those
-arrive, source runs can supervise an installed node when
-`~/.drift/node/node-config.json` exists, while a fresh packaged install renders a
-model-catalog or missing-sidecar state in the window. Contribution budgets, login
-startup, accessibility validation, signed installers, and update/rollback behavior
-remain later milestone-5 slices.
+The PyInstaller product bundle now contains the GUI plus a separately built
+`node/CommunityAI-Node` runtime. The node bundle retains Torch, Transformers,
+Hivemind, the platform keyring backend, and `p2pd`, while the GUI executable continues
+to exclude those packages. The build smokes both the node and contribution-worker
+entry points. A packaged Windows lifecycle smoke has also launched that sidecar with a
+native Credential Manager key, joined the published DNS seed, authenticated readiness,
+and shut down the owned process without writing a control-key file.
+
+The initial signed catalog, verified model manifests, and first-install node
+configuration have not been added yet. Until those arrive, source or packaged runs can
+supervise the node when `~/.drift/node/node-config.json` exists, while a fresh install
+renders the missing-catalog state in the window. Cross-platform packaged native-store
+promotion, contribution budgets, login startup, accessibility validation, signed
+installers, and update/rollback behavior remain later milestone-5 slices.
 
 ## Development
 
 Create a disposable environment and install the package:
 
 ```shell
+python -m pip install -e "..[api]"
 python -m pip install -e ".[dev]"
 ```
+
+On Windows, install the repository's patched Hivemind wheel first as described in the
+root README. The desktop source tests need only the desktop package; producing the node
+sidecar requires the full root runtime.
 
 Run the headless protocol and source-boundary tests:
 
@@ -74,8 +86,8 @@ python generate_assets.py  # only needed after changing the product icon
 python build_desktop.py
 ```
 
-On Windows the build uses the GUI subsystem, so double-clicking the executable does not
-open a terminal. The build runs the packaged runtime check, headless control-API contract,
-connected UI smoke, and automatic-reconnect smoke. It also writes a size and
-runtime manifest to `dist/desktop`. These bundles are CI evidence, not signed installers
-or release candidates.
+On Windows the GUI build uses the GUI subsystem, so double-clicking the application does
+not open a terminal. The build runs the packaged GUI runtime check, headless control-API
+contract, connected UI smoke, automatic-reconnect smoke, and the frozen node/worker
+runtime checks. It also writes GUI and sidecar size/runtime evidence to `dist/desktop`.
+These bundles are CI evidence, not signed installers or release candidates.

--- a/desktop/build_desktop.py
+++ b/desktop/build_desktop.py
@@ -55,6 +55,7 @@ def _run_pyinstaller(arguments: list[str]) -> None:
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--output-root", type=Path)
+    parser.add_argument("--bootstrap-config", type=Path)
     args = parser.parse_args()
 
     try:
@@ -70,6 +71,14 @@ def main() -> int:
     icon_path = project / "src" / "communityai_desktop" / "assets" / "communityai.ico"
     if not icon_path.is_file():
         raise RuntimeError(f"desktop icon is missing: {icon_path}; run generate_assets.py")
+    bootstrap_config = args.bootstrap_config or project / "release" / "catalog-bootstrap.json"
+    bootstrap_config = bootstrap_config.expanduser().resolve()
+    if args.bootstrap_config is not None and not bootstrap_config.is_file():
+        raise RuntimeError(f"release bootstrap config is missing: {bootstrap_config}")
+    if bootstrap_config.is_file():
+        from drift.node.catalog_bootstrap import CatalogBootstrapConfig
+
+        CatalogBootstrapConfig.load(bootstrap_config)
 
     pyinstaller_args = [
         str(project / "launch_desktop.py"),
@@ -91,6 +100,8 @@ def main() -> int:
         "--add-data",
         f"{icon_path}{os.pathsep}communityai_desktop/assets",
     ]
+    if bootstrap_config.is_file():
+        pyinstaller_args.extend(("--add-data", f"{bootstrap_config}{os.pathsep}bootstrap"))
     if platform.system() == "Windows":
         # The product executable is a GUI application. Diagnostic actions still
         # return meaningful exit codes but do not open a console window.
@@ -166,6 +177,7 @@ def main() -> int:
     _run_bundle(executable, "--onboarding-ui-self-test", environment)
     node_contract = json.loads(_run_bundle(node_executable, "--self-test", environment, timeout=180).stdout)
     _run_bundle(node_executable, "--help", environment, timeout=180)
+    _run_bundle(node_executable, ("bootstrap", "--help"), environment, timeout=180)
     _run_bundle(node_executable, ("server", "--help"), environment, timeout=180)
     bundle_bytes, file_count = _directory_metrics(bundle_root)
     node_bytes, node_file_count = _directory_metrics(node_root)
@@ -192,6 +204,7 @@ def main() -> int:
         },
         "console_window": platform.system() != "Windows",
         "signed": False,
+        "catalog_bootstrap_bundled": bootstrap_config.is_file(),
     }
     metrics_path = output_root / "desktop-metrics.json"
     metrics_path.parent.mkdir(parents=True, exist_ok=True)

--- a/desktop/build_desktop.py
+++ b/desktop/build_desktop.py
@@ -6,13 +6,18 @@ import argparse
 import json
 import os
 import platform
+import shutil
 import subprocess
+import sys
 from pathlib import Path
+from typing import Sequence
 
 from communityai_desktop.acceptance import run_self_test
 from communityai_desktop.pyside_shell import check_runtime
 
 APP_NAME = "CommunityAI"
+NODE_NAME = "CommunityAI-Node"
+NODE_DIRECTORY = "node"
 FORBIDDEN_RUNTIME_PACKAGES = ("drift", "torch", "transformers", "hivemind", "accelerate")
 
 
@@ -21,22 +26,30 @@ def _directory_metrics(path: Path) -> tuple[int, int]:
     return sum(item.stat().st_size for item in files), len(files)
 
 
-def _run_bundle(executable: Path, action: str, environment: dict[str, str]) -> subprocess.CompletedProcess[str]:
+def _run_bundle(
+    executable: Path, arguments: str | Sequence[str], environment: dict[str, str], *, timeout: float = 60
+) -> subprocess.CompletedProcess[str]:
+    if isinstance(arguments, str):
+        arguments = (arguments,)
     result = subprocess.run(
-        [str(executable), action],
+        [str(executable), *arguments],
         check=False,
         capture_output=True,
         text=True,
-        timeout=60,
+        timeout=timeout,
         env=environment,
     )
     if result.returncode:
         raise RuntimeError(
-            f"packaged executable failed {action} with exit code {result.returncode}\n"
+            f"packaged executable failed {' '.join(arguments)} with exit code {result.returncode}\n"
             f"stdout:\n{result.stdout.strip()}\n"
             f"stderr:\n{result.stderr.strip()}"
         )
     return result
+
+
+def _run_pyinstaller(arguments: list[str]) -> None:
+    subprocess.run([sys.executable, "-m", "PyInstaller", *arguments], check=True)
 
 
 def main() -> int:
@@ -50,6 +63,7 @@ def main() -> int:
         parser.error(f"PyInstaller is not installed: {exc}")
 
     project = Path(__file__).resolve().parent
+    repository = project.parent
     output_root = (args.output_root or project / "dist" / "desktop").resolve()
     build_root = project / "build" / "desktop"
     bundle_root = output_root / APP_NAME
@@ -92,11 +106,56 @@ def main() -> int:
     if credential_backend:
         pyinstaller_args.extend(("--hidden-import", credential_backend))
 
-    PyInstaller.__main__.run(pyinstaller_args)
+    _run_pyinstaller(pyinstaller_args)
 
     executable = bundle_root / f"{APP_NAME}{'.exe' if os.name == 'nt' else ''}"
     if not executable.is_file():
         raise RuntimeError(f"packaged executable was not created: {executable}")
+
+    sidecar_dist = build_root / "sidecar-dist"
+    node_args = [
+        str(project / "launch_node.py"),
+        "--name",
+        NODE_NAME,
+        "--onedir",
+        "--noconfirm",
+        "--clean",
+        "--paths",
+        str(repository / "src"),
+        "--distpath",
+        str(sidecar_dist),
+        "--workpath",
+        str(build_root / "sidecar-work"),
+        "--specpath",
+        str(build_root / "sidecar-spec"),
+        "--collect-all",
+        "hivemind",
+        "--collect-submodules",
+        "drift",
+        "--exclude-module",
+        "PySide6",
+    ]
+    credential_backend = {
+        "Windows": "keyring.backends.Windows",
+        "Darwin": "keyring.backends.macOS",
+        "Linux": "keyring.backends.SecretService",
+    }.get(platform.system())
+    if credential_backend:
+        node_args.extend(("--hidden-import", credential_backend))
+    _run_pyinstaller(node_args)
+
+    built_sidecar = sidecar_dist / NODE_NAME
+    node_root = bundle_root / NODE_DIRECTORY
+    if not built_sidecar.is_dir():
+        raise RuntimeError(f"packaged node directory was not created: {built_sidecar}")
+    if node_root.exists():
+        shutil.rmtree(node_root)
+    # Move rather than duplicate the multi-gigabyte runtime inside the CI workspace.
+    shutil.move(str(built_sidecar), str(node_root))
+    node_executable = node_root / f"{NODE_NAME}{'.exe' if os.name == 'nt' else ''}"
+    if not node_executable.is_file():
+        raise RuntimeError(f"packaged node executable was not staged: {node_executable}")
+
     environment = os.environ.copy()
     environment.setdefault("QT_QPA_PLATFORM", "offscreen")
     runtime = check_runtime()
@@ -105,7 +164,11 @@ def main() -> int:
     _run_bundle(executable, "--self-test", environment)
     _run_bundle(executable, "--ui-self-test", environment)
     _run_bundle(executable, "--onboarding-ui-self-test", environment)
+    node_contract = json.loads(_run_bundle(node_executable, "--self-test", environment, timeout=180).stdout)
+    _run_bundle(node_executable, "--help", environment, timeout=180)
+    _run_bundle(node_executable, ("server", "--help"), environment, timeout=180)
     bundle_bytes, file_count = _directory_metrics(bundle_root)
+    node_bytes, node_file_count = _directory_metrics(node_root)
     metrics = {
         "schema_version": 1,
         "application": APP_NAME,
@@ -118,6 +181,15 @@ def main() -> int:
         "acceptance": contract,
         "ui_smoke_passed": True,
         "onboarding_ui_smoke_passed": True,
+        "node_sidecar": {
+            "relative_executable": str(node_executable.relative_to(bundle_root)),
+            "bundle_bytes": node_bytes,
+            "file_count": node_file_count,
+            "runtime": node_contract,
+            "self_test_passed": True,
+            "node_entrypoint_smoke_passed": True,
+            "worker_entrypoint_smoke_passed": True,
+        },
         "console_window": platform.system() != "Windows",
         "signed": False,
     }

--- a/desktop/launch_node.py
+++ b/desktop/launch_node.py
@@ -1,0 +1,66 @@
+"""Frozen entry point for the standalone CommunityAI node sidecar.
+
+The sidecar normally runs ``drift node``. A frozen node also reuses this
+executable for supervised contribution workers, so the explicit ``server`` mode
+below replaces ``python -m drift.cli server`` inside a packaged installation.
+"""
+
+from __future__ import annotations
+
+import json
+import multiprocessing
+import os
+import sys
+from importlib.metadata import version
+from importlib.resources import files
+
+
+def _runtime_contract() -> dict[str, object]:
+    """Import every critical packaged runtime and locate Hivemind's daemon."""
+    import drift
+    import fastapi
+    import hivemind
+    import keyring
+    import torch
+    import transformers
+    import uvicorn
+
+    daemon_name = "p2pd.exe" if os.name == "nt" else "p2pd"
+    daemon = files("hivemind.hivemind_cli").joinpath(daemon_name)
+    if not daemon.is_file():
+        raise RuntimeError(f"packaged Hivemind daemon is missing: {daemon_name}")
+    return {
+        "schema_version": 1,
+        "application": "CommunityAI-Node",
+        "drift": drift.__version__,
+        "torch": torch.__version__,
+        "transformers": transformers.__version__,
+        "hivemind": hivemind.__version__,
+        "fastapi": fastapi.__version__,
+        "uvicorn": uvicorn.__version__,
+        "keyring": version("keyring"),
+        "p2pd": daemon_name,
+        "frozen": bool(getattr(sys, "frozen", False)),
+    }
+
+
+def main() -> int:
+    # PyInstaller's multiprocessing children must be intercepted before importing
+    # Torch, Hivemind, or any application modules.
+    multiprocessing.freeze_support()
+    argv = sys.argv[1:]
+    if argv == ["--self-test"]:
+        print(json.dumps(_runtime_contract(), sort_keys=True))
+        return 0
+    if argv[:1] == ["server"]:
+        sys.argv = ["CommunityAI-Node server", *argv[1:]]
+        from drift.cli.run_server import main as run
+    else:
+        from drift.cli.run_node import main as run
+
+    run()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/desktop/launch_node.py
+++ b/desktop/launch_node.py
@@ -1,8 +1,9 @@
 """Frozen entry point for the standalone CommunityAI node sidecar.
 
 The sidecar normally runs ``drift node``. A frozen node also reuses this
-executable for supervised contribution workers, so the explicit ``server`` mode
-below replaces ``python -m drift.cli server`` inside a packaged installation.
+executable for supervised contribution workers and first-install catalog
+bootstrap, so the explicit modes below replace their ``python -m drift.cli``
+forms inside a packaged installation.
 """
 
 from __future__ import annotations
@@ -17,13 +18,15 @@ from importlib.resources import files
 
 def _runtime_contract() -> dict[str, object]:
     """Import every critical packaged runtime and locate Hivemind's daemon."""
-    import drift
     import fastapi
     import hivemind
     import keyring
     import torch
     import transformers
     import uvicorn
+
+    import drift
+    from drift.node.catalog_bootstrap import CATALOG_BOOTSTRAP_SCHEMA_VERSION
 
     daemon_name = "p2pd.exe" if os.name == "nt" else "p2pd"
     daemon = files("hivemind.hivemind_cli").joinpath(daemon_name)
@@ -40,6 +43,7 @@ def _runtime_contract() -> dict[str, object]:
         "uvicorn": uvicorn.__version__,
         "keyring": version("keyring"),
         "p2pd": daemon_name,
+        "catalog_bootstrap_schema": CATALOG_BOOTSTRAP_SCHEMA_VERSION,
         "frozen": bool(getattr(sys, "frozen", False)),
     }
 
@@ -55,6 +59,9 @@ def main() -> int:
     if argv[:1] == ["server"]:
         sys.argv = ["CommunityAI-Node server", *argv[1:]]
         from drift.cli.run_server import main as run
+    elif argv[:1] == ["bootstrap"]:
+        sys.argv = ["CommunityAI-Node bootstrap", *argv[1:]]
+        from drift.cli.run_bootstrap import main as run
     else:
         from drift.cli.run_node import main as run
 

--- a/desktop/src/communityai_desktop/app.py
+++ b/desktop/src/communityai_desktop/app.py
@@ -24,6 +24,7 @@ from communityai_desktop.lifecycle import (
     DEFAULT_NODE_DATA_DIR,
     NodeLifecycleError,
     NodeLifecycleSupervisor,
+    default_bootstrap_config_path,
 )
 
 
@@ -36,6 +37,9 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--credential-account", default=DEFAULT_CREDENTIAL_ACCOUNT, help=argparse.SUPPRESS)
     parser.add_argument("--node-config", type=Path, default=DEFAULT_NODE_CONFIG_PATH, help=argparse.SUPPRESS)
     parser.add_argument("--node-data-dir", type=Path, default=DEFAULT_NODE_DATA_DIR, help=argparse.SUPPRESS)
+    parser.add_argument(
+        "--bootstrap-config", type=Path, default=default_bootstrap_config_path(), help=argparse.SUPPRESS
+    )
     parser.add_argument("--no-manage-node", action="store_true", help=argparse.SUPPRESS)
     parser.add_argument("--capture-page", type=int, default=0, help=argparse.SUPPRESS)
     action = parser.add_mutually_exclusive_group()
@@ -124,6 +128,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                 credential_store,
                 config_path=args.node_config,
                 data_dir=args.node_data_dir,
+                bootstrap_config_path=args.bootstrap_config,
                 client_timeout=args.timeout,
             )
         )

--- a/desktop/src/communityai_desktop/lifecycle.py
+++ b/desktop/src/communityai_desktop/lifecycle.py
@@ -19,10 +19,17 @@ DEFAULT_NODE_DATA_DIR = Path.home() / ".drift" / "node"
 DEFAULT_NODE_CONFIG_PATH = DEFAULT_NODE_DATA_DIR / "node-config.json"
 PACKAGED_NODE_DIRECTORY = "node"
 PACKAGED_NODE_NAME = "CommunityAI-Node"
+PACKAGED_BOOTSTRAP_DIRECTORY = "bootstrap"
+PACKAGED_BOOTSTRAP_NAME = "catalog-bootstrap.json"
 
 
 class NodeLifecycleError(RuntimeError):
     """The desktop could not safely connect to or supervise its local node."""
+
+
+def _absolute_path(path: Path | str) -> Path:
+    """Make a path absolute without following its final symbolic link."""
+    return Path(os.path.abspath(os.fspath(Path(path).expanduser())))
 
 
 def _default_node_command() -> tuple[str, ...]:
@@ -31,6 +38,22 @@ def _default_node_command() -> tuple[str, ...]:
         executable = Path(sys.executable).resolve().parent / PACKAGED_NODE_DIRECTORY / f"{PACKAGED_NODE_NAME}{suffix}"
         return (str(executable),)
     return (sys.executable, "-m", "drift.cli", "node")
+
+
+def _default_bootstrap_command() -> tuple[str, ...]:
+    if getattr(sys, "frozen", False):
+        return (*_default_node_command(), "bootstrap")
+    return (sys.executable, "-m", "drift.cli", "bootstrap")
+
+
+def default_bootstrap_config_path() -> Optional[Path]:
+    """Locate a release bootstrap staged by the packager, if one is available."""
+    if getattr(sys, "frozen", False):
+        bundle_data = Path(getattr(sys, "_MEIPASS", Path(sys.executable).resolve().parent))
+        candidate = bundle_data / PACKAGED_BOOTSTRAP_DIRECTORY / PACKAGED_BOOTSTRAP_NAME
+    else:
+        candidate = Path(__file__).resolve().parents[2] / "release" / PACKAGED_BOOTSTRAP_NAME
+    return candidate.resolve() if candidate.is_file() and not candidate.is_symlink() else None
 
 
 def _port_is_open(node_url: str, timeout: float) -> bool:
@@ -55,10 +78,14 @@ class NodeLifecycleSupervisor:
         config_path: Path | str = DEFAULT_NODE_CONFIG_PATH,
         data_dir: Path | str = DEFAULT_NODE_DATA_DIR,
         node_command: Optional[Sequence[str]] = None,
+        bootstrap_config_path: Optional[Path | str] = None,
+        bootstrap_command: Optional[Sequence[str]] = None,
+        bootstrap_timeout: float = 60.0,
         startup_timeout: float = 45.0,
         poll_interval: float = 0.2,
         client_timeout: float = 2.0,
         process_factory: Callable[..., Any] = subprocess.Popen,
+        bootstrap_runner: Callable[..., Any] = subprocess.run,
         client_factory: Callable[..., NodeClient] = NodeClient,
         port_probe: Callable[[str, float], bool] = _port_is_open,
         clock: Callable[[], float] = time.monotonic,
@@ -66,17 +93,31 @@ class NodeLifecycleSupervisor:
     ) -> None:
         self.node_url = normalize_loopback_url(node_url)
         self.credential_store = credential_store
-        self.config_path = Path(config_path).expanduser().resolve()
+        self.config_path = _absolute_path(config_path)
         self.data_dir = Path(data_dir).expanduser().resolve()
+        default_node_command = node_command is None
         self.node_command = tuple(node_command or _default_node_command())
         if not self.node_command or any(not isinstance(part, str) or not part for part in self.node_command):
             raise ValueError("node command must contain non-empty strings")
-        if startup_timeout <= 0 or poll_interval <= 0 or client_timeout <= 0:
+        if bootstrap_command is not None:
+            self.bootstrap_command = tuple(bootstrap_command)
+        elif default_node_command:
+            self.bootstrap_command = _default_bootstrap_command()
+        elif len(self.node_command) == 1:
+            self.bootstrap_command = (*self.node_command, "bootstrap")
+        else:
+            self.bootstrap_command = ()
+        if any(not isinstance(part, str) or not part for part in self.bootstrap_command):
+            raise ValueError("bootstrap command must contain non-empty strings")
+        self.bootstrap_config_path = None if bootstrap_config_path is None else _absolute_path(bootstrap_config_path)
+        if bootstrap_timeout <= 0 or startup_timeout <= 0 or poll_interval <= 0 or client_timeout <= 0:
             raise ValueError("node lifecycle timeouts must be positive")
+        self.bootstrap_timeout = float(bootstrap_timeout)
         self.startup_timeout = float(startup_timeout)
         self.poll_interval = float(poll_interval)
         self.client_timeout = float(client_timeout)
         self._process_factory = process_factory
+        self._bootstrap_runner = bootstrap_runner
         self._client_factory = client_factory
         self._port_probe = port_probe
         self._clock = clock
@@ -124,13 +165,59 @@ class NodeLifecycleSupervisor:
         delay = min(30.0, float(2 ** min(self._failures - 1, 5)))
         self._next_start = self._clock() + delay
 
+    def _ensure_config(self) -> None:
+        if self.config_path.is_symlink():
+            raise NodeLifecycleError(f"CommunityAI refuses the unsafe configuration link {self.config_path.name}")
+        if self.config_path.is_file():
+            return
+        if self.bootstrap_config_path is None:
+            raise NodeLifecycleError(
+                f"CommunityAI's signed model catalog is not bundled yet ({self.config_path.name} is missing)"
+            )
+        if not self.bootstrap_config_path.is_file() or self.bootstrap_config_path.is_symlink():
+            raise NodeLifecycleError("CommunityAI's bundled catalog trust configuration is missing or unsafe")
+        if not self.bootstrap_command:
+            raise NodeLifecycleError("The configured local node cannot provision a first-install catalog")
+
+        executable = Path(self.bootstrap_command[0])
+        if len(self.node_command) == 1 and not executable.is_file():
+            raise NodeLifecycleError("The bundled CommunityAI node is missing; reinstall the application")
+        self.data_dir.mkdir(parents=True, exist_ok=True)
+        command = (
+            *self.bootstrap_command,
+            str(self.bootstrap_config_path),
+            "--data_dir",
+            str(self.data_dir),
+            "--node_config",
+            str(self.config_path),
+        )
+        kwargs = {
+            "stdin": subprocess.DEVNULL,
+            "capture_output": True,
+            "text": True,
+            "timeout": self.bootstrap_timeout,
+            "cwd": str(self.data_dir),
+            "close_fds": True,
+        }
+        if os.name == "nt":
+            kwargs["creationflags"] = getattr(subprocess, "CREATE_NO_WINDOW", 0)
+        try:
+            result = self._bootstrap_runner(command, **kwargs)
+        except subprocess.TimeoutExpired as exc:
+            raise NodeLifecycleError("The signed model catalog installation timed out") from exc
+        except OSError as exc:
+            raise NodeLifecycleError(f"Could not run the bundled catalog installer: {exc}") from exc
+        if result.returncode:
+            output = (result.stderr or result.stdout or "").strip().splitlines()
+            detail = output[-1][:600] if output else f"exit code {result.returncode}"
+            raise NodeLifecycleError(f"The signed model catalog could not be installed: {detail}")
+        if not self.config_path.is_file() or self.config_path.is_symlink():
+            raise NodeLifecycleError("The signed model catalog installer did not create a safe node configuration")
+
     def _start(self) -> None:
         if urlsplit(self.node_url).scheme != "http":
             raise NodeLifecycleError("Desktop-owned nodes require a loopback HTTP URL")
-        if not self.config_path.is_file() or self.config_path.is_symlink():
-            raise NodeLifecycleError(
-                f"CommunityAI's model catalog is not installed yet ({self.config_path.name} is missing)"
-            )
+        self._ensure_config()
         executable = Path(self.node_command[0])
         if len(self.node_command) == 1 and not executable.is_file():
             raise NodeLifecycleError("The bundled CommunityAI node is missing; reinstall the application")

--- a/desktop/src/communityai_desktop/lifecycle.py
+++ b/desktop/src/communityai_desktop/lifecycle.py
@@ -17,6 +17,8 @@ from communityai_desktop.credentials import NativeCredentialStore
 
 DEFAULT_NODE_DATA_DIR = Path.home() / ".drift" / "node"
 DEFAULT_NODE_CONFIG_PATH = DEFAULT_NODE_DATA_DIR / "node-config.json"
+PACKAGED_NODE_DIRECTORY = "node"
+PACKAGED_NODE_NAME = "CommunityAI-Node"
 
 
 class NodeLifecycleError(RuntimeError):
@@ -26,7 +28,8 @@ class NodeLifecycleError(RuntimeError):
 def _default_node_command() -> tuple[str, ...]:
     if getattr(sys, "frozen", False):
         suffix = ".exe" if os.name == "nt" else ""
-        return (str(Path(sys.executable).resolve().with_name(f"CommunityAI-Node{suffix}")),)
+        executable = Path(sys.executable).resolve().parent / PACKAGED_NODE_DIRECTORY / f"{PACKAGED_NODE_NAME}{suffix}"
+        return (str(executable),)
     return (sys.executable, "-m", "drift.cli", "node")
 
 

--- a/desktop/tests/test_lifecycle.py
+++ b/desktop/tests/test_lifecycle.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest import mock
 
+import communityai_desktop.lifecycle as lifecycle
 from communityai_desktop.client import NodeApiError
 from communityai_desktop.credentials import CredentialProvision
 from communityai_desktop.lifecycle import NodeLifecycleError, NodeLifecycleSupervisor
@@ -91,6 +93,19 @@ class PortSequence:
 
 
 class NodeLifecycleTests(unittest.TestCase):
+    def test_frozen_desktop_resolves_nested_node_sidecar(self):
+        executable = Path.cwd() / "product" / ("CommunityAI.exe" if lifecycle.os.name == "nt" else "CommunityAI")
+        suffix = ".exe" if lifecycle.os.name == "nt" else ""
+        with mock.patch.object(lifecycle.sys, "frozen", True, create=True), mock.patch.object(
+            lifecycle.sys, "executable", str(executable)
+        ):
+            command = lifecycle._default_node_command()
+
+        self.assertEqual(
+            command,
+            (str(executable.resolve().parent / "node" / f"CommunityAI-Node{suffix}"),),
+        )
+
     def _supervisor(self, directory, store, **kwargs):
         root = Path(directory)
         config = root / "node-config.json"

--- a/desktop/tests/test_lifecycle.py
+++ b/desktop/tests/test_lifecycle.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -307,8 +308,8 @@ class NodeLifecycleTests(unittest.TestCase):
         self.assertEqual(len(bootstrap_calls), 1)
         bootstrap_command = bootstrap_calls[0][0]
         self.assertEqual(bootstrap_command[:2], ("python", "fake-bootstrap.py"))
-        self.assertEqual(bootstrap_command[2], str(bootstrap_path.resolve()))
-        self.assertEqual(bootstrap_command[bootstrap_command.index("--node_config") + 1], str(config_path.resolve()))
+        self.assertEqual(bootstrap_command[2], os.path.abspath(bootstrap_path))
+        self.assertEqual(bootstrap_command[bootstrap_command.index("--node_config") + 1], os.path.abspath(config_path))
         self.assertNotIn(CONTROL_KEY, bootstrap_command)
         self.assertEqual(len(processes), 1)
         self.assertTrue(processes[0].terminated)

--- a/desktop/tests/test_lifecycle.py
+++ b/desktop/tests/test_lifecycle.py
@@ -106,6 +106,12 @@ class NodeLifecycleTests(unittest.TestCase):
             (str(executable.resolve().parent / "node" / f"CommunityAI-Node{suffix}"),),
         )
 
+        with mock.patch.object(lifecycle.sys, "frozen", True, create=True), mock.patch.object(
+            lifecycle.sys, "executable", str(executable)
+        ):
+            bootstrap_command = lifecycle._default_bootstrap_command()
+        self.assertEqual(bootstrap_command, (*command, "bootstrap"))
+
     def _supervisor(self, directory, store, **kwargs):
         root = Path(directory)
         config = root / "node-config.json"
@@ -252,7 +258,83 @@ class NodeLifecycleTests(unittest.TestCase):
                 client_factory=FakeClient,
                 port_probe=PortSequence(False),
             )
-            with self.assertRaisesRegex(NodeLifecycleError, "model catalog is not installed"):
+            with self.assertRaisesRegex(NodeLifecycleError, "signed model catalog is not bundled"):
+                supervisor.ensure_client()
+            supervisor.close()
+
+        self.assertEqual(processes, [])
+
+    def test_missing_config_is_bootstrapped_before_the_node_starts(self):
+        bootstrap_calls = []
+        processes = []
+        clock = FakeClock()
+
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            config_path = root / "node-config.json"
+            bootstrap_path = root / "catalog-bootstrap.json"
+            bootstrap_path.write_text("{}\n", encoding="utf-8")
+
+            def bootstrap_runner(command, **kwargs):
+                bootstrap_calls.append((tuple(command), kwargs))
+                output_path = Path(command[command.index("--node_config") + 1])
+                output_path.write_text("{}\n", encoding="utf-8")
+                return mock.Mock(returncode=0, stdout="{}", stderr="")
+
+            def process_factory(command, **kwargs):
+                process = FakeProcess(command, **kwargs)
+                processes.append(process)
+                return process
+
+            supervisor = NodeLifecycleSupervisor(
+                "http://127.0.0.1:8080",
+                FakeStore(),
+                config_path=config_path,
+                data_dir=root / "data",
+                node_command=("python", "fake-node.py"),
+                bootstrap_command=("python", "fake-bootstrap.py"),
+                bootstrap_config_path=bootstrap_path,
+                bootstrap_runner=bootstrap_runner,
+                process_factory=process_factory,
+                client_factory=FakeClient,
+                port_probe=PortSequence(False, True),
+                clock=clock,
+                sleeper=clock.sleep,
+            )
+            supervisor.ensure_client()
+            supervisor.close()
+
+        self.assertEqual(len(bootstrap_calls), 1)
+        bootstrap_command = bootstrap_calls[0][0]
+        self.assertEqual(bootstrap_command[:2], ("python", "fake-bootstrap.py"))
+        self.assertEqual(bootstrap_command[2], str(bootstrap_path.resolve()))
+        self.assertEqual(bootstrap_command[bootstrap_command.index("--node_config") + 1], str(config_path.resolve()))
+        self.assertNotIn(CONTROL_KEY, bootstrap_command)
+        self.assertEqual(len(processes), 1)
+        self.assertTrue(processes[0].terminated)
+
+    def test_failed_catalog_bootstrap_does_not_start_the_node(self):
+        processes = []
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            bootstrap_path = root / "catalog-bootstrap.json"
+            bootstrap_path.write_text("{}\n", encoding="utf-8")
+            supervisor = NodeLifecycleSupervisor(
+                "http://127.0.0.1:8080",
+                FakeStore(),
+                config_path=root / "node-config.json",
+                data_dir=root / "data",
+                node_command=("python", "fake-node.py"),
+                bootstrap_command=("python", "fake-bootstrap.py"),
+                bootstrap_config_path=bootstrap_path,
+                bootstrap_runner=lambda *args, **kwargs: mock.Mock(
+                    returncode=2, stdout="", stderr="bootstrap: signature threshold was not met\n"
+                ),
+                process_factory=lambda *args, **kwargs: processes.append((args, kwargs)),
+                client_factory=FakeClient,
+                port_probe=PortSequence(False),
+            )
+            with self.assertRaisesRegex(NodeLifecycleError, "signature threshold was not met"):
                 supervisor.ensure_client()
             supervisor.close()
 

--- a/docs/CATALOG_BOOTSTRAP_V1.md
+++ b/docs/CATALOG_BOOTSTRAP_V1.md
@@ -1,0 +1,77 @@
+# Catalog bootstrap v1
+
+Status: the strict sidecar consumer, desktop lifecycle integration, last-known-good
+cache, and packaging hook are implemented. A production bootstrap file is deliberately
+not checked in until the first model manifests have completed qualification and the
+corresponding catalog has been signed and published.
+
+`CatalogBootstrap v1` is the small, trusted release input that lets a clean desktop
+installation find a model catalog and the public discovery network. It is application
+configuration, not remotely supplied catalog metadata. The desktop passes its path to
+the standalone node sidecar and never parses catalog signatures or model manifests
+itself.
+
+## Format
+
+The document contains only:
+
+- `schema_version`, currently `1`;
+- the independent catalog `trust_root` defined by
+  [`MODEL_CATALOG_V1.md`](MODEL_CATALOG_V1.md);
+- one or more absolute HTTPS `catalog_mirrors` without credentials, queries, or
+  fragments;
+- one or more libp2p `initial_peers`; and
+- the optional positive `max_loaded_models`, defaulting to one.
+
+Unknown fields, duplicate JSON keys, unsafe catalog URLs, malformed seed addresses,
+invalid trust roots, and symbolic-link inputs fail closed. Catalog URLs and public seed
+addresses are intentionally outside ordinary `NodeConfig v1` until they have been
+verified and expanded into exact model entries.
+
+Create the release input after the offline root and catalog are ready:
+
+```text
+drift catalog bootstrap-config \
+  --root catalog-root.json \
+  --catalog-mirror https://mirror-one.example/communityai/catalog.signed.json \
+  --catalog-mirror https://mirror-two.example/communityai/catalog.signed.json \
+  --initial-peer /dns4/bootstrap.communityai.flujo.com.co/tcp/31337/p2p/QmZhGcSVR6qPLZTq3TJPZEi734GbMkouv3kPxQLdDY2qUo \
+  --output catalog-bootstrap.json
+```
+
+The release builder accepts that file explicitly:
+
+```text
+python desktop/build_desktop.py --bootstrap-config catalog-bootstrap.json
+```
+
+It is staged into the GUI bundle as public read-only configuration. On a missing
+`node-config.json`, the GUI invokes the separately frozen node as:
+
+```text
+CommunityAI-Node bootstrap catalog-bootstrap.json \
+  --data_dir <native node data directory> \
+  --node_config <node-config.json>
+```
+
+The bootstrap process disables environment proxies, refuses redirects, bounds catalog
+and manifest response bodies, requires HTTPS certificate validation, verifies catalog
+threshold signatures, expiry, and rollback state, and accepts a manifest only when its
+canonical digest exactly matches the signed catalog entry. Accepted manifests are
+stored by digest. The rollback state is persisted before the generated configuration is
+activated, and all files use same-directory temporary writes plus atomic replacement.
+
+An existing `node-config.json` is validated and preserved without network access. If
+remote mirrors are unavailable, a still-valid previously accepted catalog and its
+content-addressed manifests can recreate a missing configuration. An expired cached
+catalog cannot do so.
+
+## Release gate
+
+Do not bundle a placeholder root, an unsigned catalog, test-vector manifests, or a
+private signing key. The first production bootstrap becomes eligible only after both
+options in its first rung have exact qualified manifests, the signed envelope is
+available through HTTPS mirrors, and real workers provide the catalog's claimed usable
+routes. Catalog mirrors and seeds can be replaced in a later signed application build;
+user-supplied seeds and independently updateable discovery configuration remain
+milestone-6 work.

--- a/docs/MODEL_CATALOG_V1.md
+++ b/docs/MODEL_CATALOG_V1.md
@@ -1,9 +1,14 @@
 # Signed model catalog and elastic capacity ladder v1
 
 Status: strict schema, independent Ed25519 signing keys, threshold verification,
-expiry, persistent rollback protection, and local rung selection are implemented.
-Remote catalog fetching, trust-root rotation, node/desktop consumption, automatic
-worker migration, and the first qualified public manifests remain open.
+expiry, persistent rollback protection, local rung selection, bounded HTTPS fetching,
+exact manifest installation, first-install node configuration, and desktop-sidecar
+consumption are implemented. The model-agnostic qualification runner and exact first
+primary source/profile pin are also implemented; the pinned Qwen3 1.7B candidate passed
+full-artifact audit, local Windows CPU parity, and selected-worker recovery. Trust-root
+rotation, periodic catalog refresh, automatic worker migration, publication of the
+release bootstrap, the standby manifest, and the remaining primary/standby
+qualification gates remain open.
 
 `ModelManifest v1` identifies one exact checkpoint and execution profile. A model
 catalog answers a separate question: which immutable manifests does one community
@@ -149,11 +154,15 @@ the required number of distinct signatures is present.
 
 ## Remaining integration work
 
-1. Generate and qualify exact manifests for both options in the first rung.
-2. Publish the signed catalog through interchangeable HTTPS mirrors and bundle its
-   independent trust root with the desktop.
-3. Fetch manifests, verify their digest against the catalog, and register them with
-   the persistent node without trusting catalog display metadata.
+1. Complete multi-machine, cross-platform, edge-envelope, and public-route
+   qualification for the pinned Qwen3 1.7B primary candidate. Generate and qualify the
+   exact Gemma 3 1B standby manifest. The evidence contract and completed local primary
+   evidence are defined in [`MODEL_QUALIFICATION_V1.md`](MODEL_QUALIFICATION_V1.md).
+2. Publish the signed catalog through interchangeable HTTPS mirrors and build the
+   release bootstrap containing its independent trust root and public seeds.
+3. Bundle that bootstrap and pass the clean-install packaged inference gate. The
+   implemented sidecar consumer fetches manifests, verifies their digest against the
+   catalog, and registers them without trusting catalog display metadata.
 4. Reconstruct capacity observations from authenticated DHT records and completed
    route probes rather than accepting a central capacity total.
 5. Add the staged promotion controller, worker intent leases, download hysteresis,

--- a/docs/MODEL_MANIFEST_V1.md
+++ b/docs/MODEL_MANIFEST_V1.md
@@ -207,9 +207,12 @@ The implementation now includes worker signatures, authenticated encrypted
 transport binding, signed intent-lease primitives, dual-signed rotation, successor
 revocation, replay/expiry enforcement, deterministic interrupted-download tests, and
 a successful real Hub HTTP 206 resume followed by SHA-256 promotion. Native Windows
-has passed signed manifested exact parity and in-generation failover locally. The
-macOS workflow runs canonical vectors, adversarial identity tests, a real Hub resume,
-and manifested exact parity, but its first hosted run still has to complete. A signed
-two-worker Fly swarm has passed cross-Machine routing and exact parity under the same
-manifest. Converted and pre-quantized formats still require model-specific release
-qualification even though the v1 verifier treats them as declared content.
+has passed signed manifested exact parity and in-generation failover locally. Hosted
+Apple Silicon macOS passed canonical vectors, adversarial identity tests, a real Hub
+resume, and manifested exact parity. A signed two-worker Fly swarm passed
+cross-Machine routing and exact parity under the same manifest.
+
+The model-agnostic local runner and the remaining per-model approval matrix are
+specified in [`MODEL_QUALIFICATION_V1.md`](MODEL_QUALIFICATION_V1.md). Converted and
+pre-quantized formats still require model-specific release qualification even though
+the v1 verifier treats them as declared content.

--- a/docs/MODEL_QUALIFICATION_V1.md
+++ b/docs/MODEL_QUALIFICATION_V1.md
@@ -1,0 +1,94 @@
+# Model qualification v1
+
+Status: the model-agnostic single-machine harness is implemented. The first-rung
+primary candidate is pinned in
+[`manifests/candidates/qwen3-1.7b-bfloat16-eager.json`](../manifests/candidates/qwen3-1.7b-bfloat16-eager.json),
+and has passed full-artifact audit, local Windows CPU parity, and selected-worker
+interruption recovery. A candidate manifest is not catalog approval. The remaining
+evidence below must be attached before its digest enters a signed production catalog.
+
+## Candidate identity
+
+The first primary candidate uses the official
+[`Qwen/Qwen3-1.7B`](https://huggingface.co/Qwen/Qwen3-1.7B) repository at immutable
+revision `70d244cc86ccca08cf5af4e1e306ecf908b1ad5e`. The selected execution profile is
+unquantized bfloat16 with eager attention on DRIFT `>=2.3.0.dev0,<2.4.0`. The manifest
+records the exact configuration, tokenizer, weight index, and both publisher weight
+shards by size and SHA-256. It declares the upstream Apache-2.0 license and ungated
+artifact access. Its canonical identity is
+`sha256:aef22f8678f9c5dcc5315913cf1cf584fa9e6c2fba8d064f715d78d823c9f056`, covering
+eight artifacts and 4,079,422,995 declared bytes.
+
+The eager profile is a distinct swarm identity. A future SDPA or quantized release
+must receive its own manifest and repeat the applicable qualification gates rather
+than reuse this digest.
+
+## Reproducible local gate
+
+Run strict manifest validation, a complete local distributed route, stock token
+parity, and selected-worker interruption recovery with:
+
+```text
+python scripts/qualify_model_manifest.py \
+  manifests/candidates/qwen3-1.7b-bfloat16-eager.json \
+  --artifact-root /path/to/complete/publisher/snapshot \
+  --device cpu --with-failover \
+  --output qualification-qwen3-1.7b.json
+```
+
+When `--artifact-root` is present, the runner hashes every declared byte before
+starting a DHT. Without it, the incremental runtime verifier still checks every file
+it loads, but the report correctly records that a complete pre-run artifact audit was
+not requested. A standard Hugging Face
+`<hub>/models--org--repo/snapshots/<commit>` artifact root also lets the runner infer
+the matching Hub cache directory so workers reuse the audited immutable bytes instead
+of downloading them into the separate DRIFT cache. Other layouts require an explicit
+`--cache-dir`. `--manifest-only` performs only schema, runtime, and optional artifact
+validation.
+
+## First primary local result
+
+On 2026-08-23, Windows CPU with DRIFT 2.3.0.dev2 and Torch 2.6.0 loaded and served all
+28 Qwen3 blocks through the manifest-derived namespace. Both client input embeddings
+and the tied language-model head were bfloat16 on CPU. Greedy generation for `Hello`
+produced `[[9707,25,358,2776]]`, exactly matching the stock eager-attention model.
+
+The two-replica stage then stopped the worker selected by the active inference
+session, replayed the prefix through the surviving signed route, recovered in 4.484
+seconds, and produced the same exact stock IDs. Before inference, the runner hashed all
+4,079,422,995 declared bytes. It inferred the Hub cache root from the audited immutable
+snapshot and recorded that provenance in the report.
+
+The first full-model attempt exposed that same-dtype block tensors returned by
+`safetensors.safe_open` retained a mapping of the complete 3.44 GB shard for every
+loaded block. Windows exhausted commit/virtual memory and the native process failed
+while loading block 25. Block deserialization now clones only the selected block
+tensors into owned CPU storage while the mapping is open, allowing the complete shard
+mapping to close before the next block. A regression test proves the returned tensor
+does not share the mapped source storage; focused loader/model tests and manifested
+TinyLlama parity passed before the Qwen rerun.
+
+The report is bounded JSON with schema version 1. A subprocess exit code is not enough
+to pass parity: the runner also requires the distributed and stock token comparison
+marker plus successful manifested-route completion. The failover stage additionally
+requires proof that the selected worker was interrupted and a recovery duration was
+observed. Reports always set `complete_release_qualification` to false because one
+machine cannot prove the public release gates.
+
+## Approval evidence
+
+| Gate | Required evidence | Harness coverage |
+| --- | --- | --- |
+| Exact identity | Immutable revision, canonical manifest digest, full artifact sizes and hashes | Implemented |
+| Local distributed parity | All declared blocks, manifested signed route, exact stock token IDs | Implemented |
+| Local interruption recovery | Two complete signed replicas, selected-worker stop, activation replay, exact stock parity | Implemented as `--with-failover` |
+| Multi-machine parity and recovery | Split route and redundant route on separate machines; selected process killed during generation | External run required |
+| Cross-platform execution | Claimed CPU/CUDA/MPS profiles tested without silently changing dtype or attention | External matrix required |
+| Edge envelope | Cold cache growth, local embedding/head bytes, RSS/accelerator peaks, load/first-token/decode timing | `drift edge-benchmark` run required |
+| Public availability | Target bottleneck replicas, independent complete routes, largest-peer-loss survival, fresh measurements and soak | Public workers required |
+| Catalog approval | Primary and standby qualified, threshold signatures, mirrors and release bootstrap published | Release process required |
+
+Qualification evidence should identify the manifest digest, source commit, DRIFT and
+Transformers versions, operating system, device, worker identities, route spans,
+output token IDs, and cleanup result. Logs and reports must not contain provider
+tokens, API keys, prompts from real users, or private identity material.

--- a/docs/PUBLIC_SWARM_SECURITY_V1.md
+++ b/docs/PUBLIC_SWARM_SECURITY_V1.md
@@ -1,7 +1,8 @@
 # Public swarm security v1
 
-Status: implemented; public deployment remains gated on the macOS CI run and the
-broader public-safety release gates in `REVIVAL.md`.
+Status: implemented; the hosted Apple Silicon macOS identity, resume, and parity run
+passed. Public deployment remains gated on the broader public-safety release gates in
+`REVIVAL.md`.
 
 This protocol completes the identity and transport portion of revival milestone 3.
 It makes the DHT an untrusted carrier: clients validate a worker record locally and

--- a/docs/REVIVAL.md
+++ b/docs/REVIVAL.md
@@ -5,6 +5,17 @@ of Petals found during the August 2026 fork audit. It preserves the parts that a
 most valuable for a revival: transformer-block sharding, Hivemind DHT discovery,
 fault-aware routing, heterogeneous devices, and a standard OpenAI-compatible API.
 
+DRIFT-LLM is the implementation starting point, not the product or network
+destination. CommunityAI is not intended to stop at operator-created private
+clusters. Its primary goal is a shared public inference network in the spirit of
+the original Petals public swarm, where independently operated machines contribute
+model blocks and ordinary users can run supported models without assembling a
+cluster, exchanging join addresses, or coordinating block placement. The revival
+adds the product and security work needed to make that public model practical:
+one-install onboarding, automatic discovery and routing, exact model identity,
+artifact verification, authenticated peers, bounded contribution controls, and
+recovery from untrusted or disappearing workers.
+
 The original Petals 2.2.0 source snapshot remains separate and unchanged. The
 following remotes are configured in the local revival checkout:
 
@@ -15,7 +26,7 @@ following remotes are configured in the local revival checkout:
 - `nakshatra`: an active, independent llama.cpp/GGUF distributed-inference effort
   that we will track for discovery, transport, and reliability ideas.
 
-## Current status (2026-08-22)
+## Current status (2026-08-23)
 
 Milestones 1 through 4 are complete. The revival has exact cross-platform inference
 parity, real multi-machine failure recovery, signed manifest and artifact integrity,
@@ -41,11 +52,19 @@ has source-level ownership for node startup, authenticated readiness, bounded cr
 backoff, reconnect, and shutdown. The production builder now also stages a separately
 frozen node runtime and smokes its node and contribution-worker entry points; a packaged
 Windows run joined the published DNS seed with a native credential and completed owned
-shutdown. The first signed-catalog foundation now provides
-independent Ed25519 keys, threshold verification, expiry, rollback protection, and an
-elastic capacity-ladder selector; the signed catalog distribution and first qualified
-manifest set are not yet published. The immediate objective is to generate first-install
-configuration, consume that catalog safely, and ship automatic public seed configuration.
+shutdown. The signed-catalog path now provides independent Ed25519 keys, threshold
+verification, expiry, rollback protection, an elastic capacity-ladder selector, bounded
+node-side HTTPS fetching, exact manifest installation, last-known-good recovery, and
+automatic seed-backed first-install configuration. The desktop invokes that work in the
+separately frozen sidecar before starting a node, and the builder can stage the strict
+public release input without moving trust code into the GUI. The model-agnostic
+qualification path now pins the official Qwen3 1.7B primary candidate as exact digest
+`sha256:aef22f8678f9c5dcc5315913cf1cf584fa9e6c2fba8d064f715d78d823c9f056`; all 28
+blocks passed full-artifact Windows CPU parity and two-replica selected-worker recovery.
+That local evidence does not yet make the candidate catalog-approved. The remaining
+primary matrix, standby manifest, signed catalog distribution, release bootstrap, and
+actual model workers are not yet published. Those qualification, publication, and real
+packaged clean-install inference gates are the immediate objective.
 Contribution policies and budgets, accessibility and resource measurements, and signed
 installer/update/rollback validation follow. Milestones 6 through 8 remain planned
 after this desktop foundation.
@@ -55,22 +74,25 @@ infrastructure. A separate Windows client reached its public IPv4 address, compl
 real Hivemind join and DHT query, and observed the same peer identity after service
 restarts. This removes the immediate need for users to operate the first node, but it
 does not complete decentralized discovery and does not by itself make the desktop
-usable: the application still needs to start and own its local node automatically,
-ship the trusted seed and model catalog, and find actual model workers.
+usable: the application can start and own its local node and now has the safe bootstrap
+consumer, but a release still needs to ship the trusted root/seed input, publish the
+signed model catalog, and find actual model workers.
 
 ## Scope and product destination
 
-Inference is the product. Distributed training and fine-tuning are compatibility
-features, not roadmap priorities. Near-term work must make it easy for ordinary
-computers to contribute model blocks and for clients to receive correct, streamed
-responses.
+Public community inference is the primary product. Distributed training and
+fine-tuning are compatibility features, not roadmap priorities. Near-term work
+must make it easy for ordinary computers to contribute model blocks and for clients
+to receive correct, streamed responses from a shared public network.
 
 The long-term product is one installable desktop application. A user starts the
 application, points an AI client at a stable localhost OpenAI endpoint, and chooses
-a community model. The application discovers the swarm, calculates and repairs its
-own route, and streams the response without depending on an operator-owned gateway.
-The same installation may contribute compute in the background when the user opts
-in.
+a model from a signed community catalog. By default, the application discovers the
+public community swarm, calculates and repairs its own route, and streams the
+response directly through independently operated workers without depending on an
+operator-owned inference gateway. The user does not need to create a swarm, run a
+bootstrap node, find peers, or assign model blocks. The same installation may
+contribute compute to that public network in the background when the user opts in.
 
 ```mermaid
 flowchart LR
@@ -104,13 +126,19 @@ The GUI must let a non-expert:
 - understand that public workers process request-derived data and must be assumed
   capable of observing or retaining it.
 
-Private and VPN swarms remain supported. The community network is an additional
-mode, not a replacement for environments where every participant is trusted.
+The public community network is the product destination and, once its release gates
+pass, the intended default experience. Private and VPN swarms remain supported as a
+secondary mode for organizations or groups where every participant is trusted; they
+are not the end goal inherited from DRIFT-LLM. Using private swarms as the current
+validation and rollout baseline is a safety measure while the public-network identity,
+discovery, abuse-resistance, redundancy, and usability gates are completed.
 
 ## Architectural baseline and gaps
 
-The current code is decentralized within a configured model swarm, but it is not
-yet an autonomous public community:
+The current DRIFT-derived code is decentralized within a configured model swarm,
+which makes private clusters a useful implementation baseline. The gap this roadmap
+must close is turning that baseline into the intended autonomous, easy-to-join public
+community network:
 
 - Workers publish expiring layer announcements into a Hivemind DHT. Each client
   reads those records and chooses its own latency- or throughput-aware route. The
@@ -140,11 +168,13 @@ rules are improvised.
 
 ## Decentralization model
 
-The goal is to minimize concentrated authority and eliminate central services from
-the inference hot path. It is not credible to promise that a fresh installation can
-discover a global network with no prior information or trust. Each installation
-needs at least a trusted application build or catalog root and one reachable way to
-learn about peers.
+The target is public community inference across independently operated, mutually
+untrusted nodes, while minimizing concentrated authority and eliminating central
+services from the inference hot path. Joining that network must feel like using a
+local application, not operating a distributed system. It is not credible to promise
+that a fresh installation can discover a global network with no prior information or
+trust, so each installation needs at least a trusted application build or catalog
+root and one reachable way to learn about peers.
 
 The target design is:
 
@@ -179,6 +209,69 @@ The target design is:
 No single bootstrap, catalog mirror, health dashboard, hosted API, or credit node
 may have unilateral control over inference. Catalog signing and credit settlement
 are separate trust domains and stay off the token-generation critical path.
+
+## Security and privacy objectives
+
+A public swarm must assume that its DHT, relays, artifact hosts, catalog mirrors,
+workers, clients, and future accounting participants can fail independently and that
+some of them may be malicious. CommunityAI must not obtain safety merely by replacing
+the old Petals services with one new trusted coordinator. Clients validate identities,
+records, manifests, and artifacts locally, and security-sensitive inputs fail closed
+when they are malformed, stale, unsigned, downgraded, or inconsistent.
+
+The major security outcomes are:
+
+| Threat or boundary | Intended protection | Current state and public-release work |
+| --- | --- | --- |
+| Network interception or an untrusted relay | Manifested client-to-worker RPC uses libp2p TLS 1.3 and connects to an authenticated PeerID. Relays may forward the encrypted connection but do not receive its plaintext. | Implemented for manifested swarms. Public qualification must continue to reject plaintext or unauthenticated transport profiles and test direct plus relayed paths. |
+| Forged, copied, or stale DHT records | The DHT is only an untrusted carrier. Worker announcements and intent leases bind the public key, PeerID, exact manifest, execution profile, block range, lifetime, and monotonic sequence in a signed envelope. Clients reject bad signatures, copied block records, expiry, replay, equivocation, and revoked identities before routing. | Worker announcements, rotation, successor revocation, replay guards, and RPC identity comparison are implemented in [`Public swarm security v1`](PUBLIC_SWARM_SECURITY_V1.md). Catalog-authority revocation and public key-compromise drills remain release work. |
+| Model substitution or poisoned artifacts | A content-derived `ModelManifest` pins the full upstream revision, tokenizer, chat template, execution profile, and complete weight inventory. Configuration and every required weight shard are checked by size and SHA-256 before parsing or deserialization; partial downloads remain unusable until atomically verified. | Implemented and validated against tampered metadata, poisoned weights, interrupted downloads, and exact stock-model parity. Public catalogs still need qualified production manifests and interchangeable artifact origins. |
+| Compromise of one catalog key or mirror | Model approval is separate from worker identity. Catalogs use independent Ed25519 keys, configurable signature thresholds, expiry, sequence-based rollback protection, exact manifest digests, and interchangeable HTTPS mirrors. Installations retain their own trust root and may select a different compatible catalog. | The format, verifier, selector, first-install consumer, and last-known-good recovery are implemented. Production roots and catalogs, key rotation/compromise exercises, and alternative-catalog interoperability remain release gates. |
+| Tampered application or unsafe update | Release artifacts must use platform-verifiable signing, authenticate update metadata, refuse unauthorized or older builds, and support tested rollback to the last known-good application without preserving stale secrets. | Current desktop bundles are unsigned engineering evidence, not release candidates. Signed installers, update-key governance, clean install, upgrade, rollback, uninstall, and compromised-update recovery must pass on Windows, Linux, and macOS before release. |
+| Local credential theft or privilege confusion | The node binds to loopback by default. Revocable OpenAI client keys authorize inference only; a separate privileged control credential manages workers and keys but cannot perform inference. Desktop-owned control credentials live in the native OS credential store and are not passed in commands, environment variables, logs, or ordinary configuration. | Authority separation, 256-bit client keys, immediate revocation, one-time secret display, native credential ownership, and authenticated node lifecycle are implemented. Signed installers and packaged credential-store validation on every supported OS remain open. |
+| Discovery, telemetry, or accounting leaking request content | DHT records contain routing and capacity data, not prompts. Demand signals must be coarse, short-lived aggregates, and future receipts must exclude prompts, generated text, hidden states, logits, API keys, and per-user request histories. | This is a protocol and data-minimization requirement. Signed demand aggregation, privacy review, retention limits, receipt implementation, and tests proving that content cannot enter observability or accounting records are still required. |
+| Worker loss, compromised infrastructure, or denial of service | Clients route directly, use finite timeouts, exclude failed identities, replay bounded activation history through redundant workers, and do not require an operator gateway. Multiple independent seeds, mirrors, and routes prevent one service from controlling availability. | In-generation worker-loss recovery is implemented and has passed real multi-machine parity tests. Independent public seeds, admission and rate limits, regional redundancy, partition drills, and malicious-load testing remain public-release gates. |
+| A public signal coercing or exhausting a contributor | Contribution is opt-in and local policy is authoritative. The network must not override model allow/deny rules, force an unapproved download, exceed storage/VRAM/bandwidth/power limits, or keep resources after the user pauses sharing. Worker processes remain supervised separately from the desktop and local API. | Worker supervision exists. Hard budget enforcement, download authorization, sandbox/containment review, pause-time guarantees, and adversarial resource-exhaustion tests remain milestone work. |
+
+Signatures, hashes, and TLS address different threats. Signatures authenticate who
+published a record; hashes prove which bytes were selected; TLS protects those bytes
+and request-derived tensors while they travel between authenticated endpoints. None
+of these alone proves that a remote worker runs honest code, reports honest capacity,
+or deletes data after processing it. Runtime attestation, measurement, admission,
+rate limits, Sybil resistance, and receipt validation are separate controls and must
+not be represented as consequences of transport encryption.
+
+### Privacy boundary
+
+CommunityAI preserves Petals' valuable decentralized data path and makes it the
+default product boundary: the OpenAI endpoint, routing decision, input embeddings,
+final language-model head, and sampling stay on the user's machine. Bootstrap nodes,
+catalog mirrors, relays, health services, and accounting services are not in the
+inference plaintext path. No single hosted gateway receives every prompt, and
+discovery and future accounting data are deliberately separated from prompt and
+generated content.
+
+This is not end-to-end confidential inference against the selected workers. A worker
+must decrypt and process the request-derived activations for the blocks it serves.
+Those activations can reveal information about the request, and a malicious worker
+may inspect, analyze, or retain them. TLS prevents passive network observers and
+relays from reading the connection; it does not make the serving worker blind. The
+network also does not currently provide sender anonymity: peers and relays may observe
+connection metadata such as addresses, timing, and traffic volume.
+
+The public application must therefore warn users before first use and provide a
+persistent explanation of this boundary. Sensitive workloads should use a private or
+VPN swarm of trusted workers unless a separately specified and validated confidential-
+execution design is available. Any future thin-edge mode that moves embeddings, the
+language-model head, or sampling to remote peers expands the privacy boundary and
+requires an explicit protocol decision, threat model, user disclosure, and parity and
+privacy tests. It must never be presented as equivalent to the current local-head path.
+
+The public-network privacy goal is consequently precise rather than absolute: encrypt
+request-derived traffic in transit, authenticate every endpoint used for computation,
+keep content out of discovery and accounting systems, minimize retained metadata, avoid
+a central prompt-processing gateway, and tell users honestly which selected workers
+can still observe request-derived data.
 
 ## Pilot discovery deployment
 
@@ -474,8 +567,9 @@ implementation.
    worker identity, announcements, intent leases, and execution profiles; reject
    manifest mismatches; authenticate and encrypt transport; define key rotation and
    revocation; and preserve an explicit legacy/private namespace during migration.
-   Private/VPN swarms remain the default until this milestone and the public safety
-   gates pass.
+   Private/VPN swarms remain the deployment default until this milestone and the
+   public safety gates pass. That is a rollout precaution, not the product destination;
+   the intended release experience is the shared public community network.
 
    The first identity slice is implemented: the strict
    [`ModelManifest v1`](MODEL_MANIFEST_V1.md) schema has deterministic SHA-256
@@ -589,9 +683,9 @@ implementation.
    readiness, applies bounded crash backoff, reconnects after a failed status refresh, and
    stops only its owned process. The production product bundle now contains a separately
    frozen model/DHT sidecar while the GUI executable continues to exclude those runtimes.
-   The builder smokes both the frozen node and contribution-worker entry points. A signed
-   catalog and first-install configuration are not yet bundled, so clean-install inference
-   remains open. A real source-level Windows smoke provisioned Credential Manager, launched
+   The builder smokes the frozen node, contribution-worker, and catalog-bootstrap entry
+   points. A production signed catalog and release bootstrap are not yet bundled, so
+   clean-install inference remains open. A real source-level Windows smoke provisioned Credential Manager, launched
    `drift node` on an isolated loopback port, joined through the published DNS seed,
    authenticated the control API without creating `control-api.key`, and shut down the
    owned node cleanly. The packaged Windows sidecar then passed that same native-credential,
@@ -602,12 +696,34 @@ implementation.
    sequence rollback/equivocation protection, exact manifest references, one primary
    plus standby options per capacity rung, and fail-closed promotion gates based on
    bottleneck coverage, independent routes, largest-peer-loss survival, soak, latency,
-   and throughput. It does not yet fetch catalogs or drive workers.
+   and throughput. The standalone sidecar now also fetches bounded HTTPS catalogs without
+   redirects or environment proxies, tries interchangeable mirrors, validates the
+   signature threshold, expiry, and persistent rollback state, fetches and digest-checks
+   every exact manifest, rejects alias collisions, and atomically installs a seed-backed
+   `NodeConfig v1`. Existing configurations are preserved, and an unexpired accepted
+   catalog plus its content-addressed manifests can recover offline. The desktop invokes
+   this only when its configuration is missing and passes no credential to the bootstrap
+   process. The format and release gate are specified in
+   [`CATALOG_BOOTSTRAP_V1.md`](CATALOG_BOOTSTRAP_V1.md). Catalog publication and worker
+   allocation remain open.
 
-   **Next implementation sequence.** Generate the first-install node configuration, ship
-   the published DNS peer as an automatic replaceable seed, publish and consume the initial
-   signed model catalog plus verified worker manifests so model selection represents
-   real usable swarms. Prove the native credential and owned-process path against real
+   The model-agnostic local qualification runner now derives repository, revision,
+   block count, DHT namespace, dtype, attention profile, and artifact verification from
+   an exact manifest and emits bounded evidence that cannot claim full release approval.
+   Its first pinned primary candidate is official Qwen3 1.7B bfloat16/eager. Windows CPU
+   audited all 4,079,422,995 declared bytes, served all 28 blocks, matched stock token IDs
+   exactly, and recovered through a surviving full replica in 4.484 seconds. The run also
+   fixed a safetensors loader defect that retained a complete large-shard mapping per
+   same-dtype block. Multi-machine, other-platform, edge-envelope, public-route, and
+   standby evidence remain open as specified in
+   [`MODEL_QUALIFICATION_V1.md`](MODEL_QUALIFICATION_V1.md).
+
+   **Next implementation sequence.** Complete the Qwen3 primary's external qualification
+   matrix and qualify the exact first-rung standby manifest, operate redundant model
+   workers, publish the initial signed catalog through interchangeable HTTPS mirrors,
+   and build the release bootstrap with the published DNS peer plus at least one
+   independent seed. Then pass real packaged
+   clean-install inference and prove the native credential and owned-process path against real
    packaged Windows, Linux, and macOS credential backends. After that, add single-instance
    and login startup behavior, feed privacy-safe peer-region observations into the region
    view, enforce contribution budgets and model policy in the node rather than only in

--- a/docs/REVIVAL.md
+++ b/docs/REVIVAL.md
@@ -38,11 +38,14 @@ package. Its source and packaged smokes enforce the GUI/node boundary, strict lo
 control traffic, key lifecycle, and worker controls without importing model runtimes.
 The node and desktop now share the native credential store directly, and the desktop
 has source-level ownership for node startup, authenticated readiness, bounded crash
-backoff, reconnect, and shutdown. The first signed-catalog foundation now provides
+backoff, reconnect, and shutdown. The production builder now also stages a separately
+frozen node runtime and smokes its node and contribution-worker entry points; a packaged
+Windows run joined the published DNS seed with a native credential and completed owned
+shutdown. The first signed-catalog foundation now provides
 independent Ed25519 keys, threshold verification, expiry, rollback protection, and an
 elastic capacity-ladder selector; the signed catalog distribution and first qualified
-manifest set are not yet published. The immediate objective is to bundle the standalone
-node sidecar, consume that catalog safely, and ship automatic public seed configuration.
+manifest set are not yet published. The immediate objective is to generate first-install
+configuration, consume that catalog safely, and ship automatic public seed configuration.
 Contribution policies and budgets, accessibility and resource measurements, and signed
 installer/update/rollback validation follow. Milestones 6 through 8 remain planned
 after this desktop foundation.
@@ -584,12 +587,15 @@ implementation.
    The shell-neutral supervisor detects occupied ports without replacing their process,
    starts the node with no secret in arguments or environment, waits for authenticated
    readiness, applies bounded crash backoff, reconnects after a failed status refresh, and
-   stops only its owned process. The GUI bundle does not yet contain the actual model/DHT
-   sidecar or a signed catalog, so packaged end-to-end lifecycle promotion remains open.
-   A real source-level Windows smoke nevertheless provisioned Credential Manager, launched
+   stops only its owned process. The production product bundle now contains a separately
+   frozen model/DHT sidecar while the GUI executable continues to exclude those runtimes.
+   The builder smokes both the frozen node and contribution-worker entry points. A signed
+   catalog and first-install configuration are not yet bundled, so clean-install inference
+   remains open. A real source-level Windows smoke provisioned Credential Manager, launched
    `drift node` on an isolated loopback port, joined through the published DNS seed,
    authenticated the control API without creating `control-api.key`, and shut down the
-   owned node cleanly.
+   owned node cleanly. The packaged Windows sidecar then passed that same native-credential,
+   public-seed, authenticated-readiness, and owned-shutdown path.
 
    The strict signed-catalog foundation is now implemented separately from worker
    identity: offline Ed25519 roots enforce configurable signature thresholds, expiry,
@@ -598,8 +604,8 @@ implementation.
    bottleneck coverage, independent routes, largest-peer-loss survival, soak, latency,
    and throughput. It does not yet fetch catalogs or drive workers.
 
-   **Next implementation sequence.** Bundle the standalone node sidecar, ship the
-   published DNS peer as an automatic replaceable seed, publish and consume the initial
+   **Next implementation sequence.** Generate the first-install node configuration, ship
+   the published DNS peer as an automatic replaceable seed, publish and consume the initial
    signed model catalog plus verified worker manifests so model selection represents
    real usable swarms. Prove the native credential and owned-process path against real
    packaged Windows, Linux, and macOS credential backends. After that, add single-instance

--- a/docs/REVIVAL_TEST_RESULTS.md
+++ b/docs/REVIVAL_TEST_RESULTS.md
@@ -1,6 +1,6 @@
 # Revival baseline results
 
-Test dates: 2026-08-21 through 2026-08-22
+Test dates: 2026-08-21 through 2026-08-23
 
 These tests exercise `Maykeye/TinyLLama-v0` as an eight-block model and compare
 greedy distributed generation with the stock Transformers implementation. The
@@ -15,7 +15,7 @@ test harnesses are `scripts/smoke_tinyllama_local_swarm.py` and
 | 2. Real multi-machine swarm | Complete | A private Fly swarm reached explicit `0:8` coverage with two replicas per block; a selected `4:8` Machine was killed during generation, the client rerouted and replayed its prefix, and both the recovered request and a cache-cleanup request passed exact parity | None for this milestone; broader-model recovery remains follow-up work |
 | 3. Public protocol identity and content integrity | Complete | Content-derived manifests, signed expiring worker announcements, PeerID/TLS binding, replay/range/profile checks, signed intent leases, dual-signed rotation, revocation, deterministic interruption tests, real Hub HTTP 206 resume on Windows and macOS, signed Windows parity/failover, signed Fly cross-Machine parity, hosted macOS signed parity, and prior Fly poison rejection are proven | None |
 | 4. Unified local node and multi-model OpenAI API | Complete | Exact multi-manifest selection, artifact-free unloaded discovery, cancellation-safe lazy loading and LRU residency, isolated supervised workers, labeled hash-only key CRUD, authenticated controls, reproducible edge measurements, official OpenAI Python client compatibility, clean restart/key reuse, and real external two-model Fly parity are proven | None for this milestone; every additional selectable model still needs its own published edge envelope |
-| 5. Desktop application and contribution controls | In progress | ADR 0002 selects PySide 6; clean production package/UI smokes pass on Windows, Linux, and macOS; OpenAI and control authorities are separate; the production build now stages an independently frozen node sidecar and smokes its node and worker entry points; a packaged Windows run used Credential Manager, joined the public DNS seed, authenticated readiness, and shut down cleanly; and the strict signed-catalog foundation covers independent signing keys, thresholds, expiry, rollback, exact manifests, and elastic-rung promotion gates | The initial catalog is not bundled or remotely fetched; first-install configuration, qualified public manifests, cross-platform native-store package promotion, contribution policies and budgets, startup/RSS and crash-isolation measurements, signing, updates, root rotation, accessibility, and installer gates remain |
+| 5. Desktop application and contribution controls | In progress | ADR 0002 selects PySide 6; clean production package/UI smokes pass on Windows, Linux, and macOS; OpenAI and control authorities are separate; the production build stages an independently frozen node sidecar; a packaged Windows run used Credential Manager, joined the public DNS seed, authenticated readiness, and shut down cleanly; and the signed-catalog path now covers independent signing keys, thresholds, expiry, rollback, exact manifests, elastic-rung gates, bounded mirror fetching, digest-checked installation, last-known-good recovery, and automatic first-install config generation | The release bootstrap and initial catalog are not published or bundled; qualified public manifests and workers, real packaged clean-install inference, cross-platform native-store package promotion, contribution policies and budgets, startup/RSS and crash-isolation measurements, signing, updates, root rotation, accessibility, and installer gates remain |
 
 ## Desktop milestone: control authority separation
 
@@ -77,12 +77,35 @@ The source supervisor checks the configured loopback port before spawning, refus
 replace an unknown service, launches the standalone node with native-store identifiers
 but no secret, waits for authenticated readiness, applies exponential backoff capped at
 30 seconds, and terminates only its owned process. A failed periodic status refresh now
-drops the stale client so the next refresh re-enters lifecycle recovery. Twenty-two
+drops the stale client so the next refresh re-enters lifecycle recovery. Twenty-four
 desktop tests and the focused node/key tests pass. The package still excludes model,
 DHT, and worker runtimes from the GUI executable itself. Its product bundle now stages
-those dependencies in a separate frozen node directory and verifies the node and worker
-entry points. The missing signed catalog and first-install configuration mean this is
-still not a claim that a clean packaged installation can run inference.
+those dependencies in a separate frozen node directory and verifies the node, worker,
+and catalog-bootstrap entry points. The sidecar and desktop now implement first-install
+catalog fetching, authentication, manifest installation, and node-config generation,
+but the missing production release bootstrap, qualified signed catalog, and public model
+workers mean this is still not a claim that a clean packaged installation can run inference.
+
+## Desktop milestone: first-install signed catalog consumer
+
+The strict `CatalogBootstrap v1` release input binds an offline catalog trust root,
+ordered HTTPS catalog mirrors, public libp2p seed addresses, and a local runtime-residency
+limit. The node-side consumer disables environment proxies and redirects, bounds response
+bodies, verifies the catalog signature threshold, time window, and persistent rollback
+state, and installs only manifests whose canonical digest matches an exact signed catalog
+entry. It rejects duplicate selectors across manifests and generates a validated,
+secret-free `NodeConfig v1` through an atomic activation path. Existing node configs are
+never replaced. An unexpired last-known-good envelope plus cached content-addressed
+manifests can recreate a missing config while offline.
+
+The desktop starts that mode only when `node-config.json` is absent, passes no credential,
+requires a safe generated file before spawning the node, and surfaces bounded installer
+errors in the existing reconnect UI. The builder validates and stages an explicitly
+supplied release bootstrap and smokes the frozen dispatch. Focused tests cover mirror
+fallback, threshold verification, digest mismatch rejection, existing-config preservation,
+offline recovery, lifecycle ordering, failure isolation, and the GUI/runtime import
+boundary. A production asset is intentionally withheld until its manifests and real
+worker routes pass qualification.
 
 The real Windows source smoke used a disposable Credential Manager service/account and
 an isolated loopback port. The desktop launched the installed `drift node`, the node
@@ -92,15 +115,58 @@ and returned authenticated API version 1 status for one manifest. No
 `control-api.key` appeared in the temporary data directory. The supervisor then stopped
 its owned process and deleted the disposable native credential.
 
-The subsequent Windows product build created a 1,841,600,397-byte, 4,810-file frozen
-node directory inside a 1,967,229,026-byte, 5,154-file unsigned product bundle. Its
+The subsequent Windows product build created a 1,841,616,549-byte, 4,810-file frozen
+node directory inside a 1,967,247,643-byte, 5,154-file unsigned product bundle. Its
 runtime contract imported DRIFT 2.3.0.dev2, Torch 2.6.0 CPU, Transformers 5.13.0,
 Hivemind 1.1.12, FastAPI, Uvicorn, the Windows keyring backend, and the packaged
-`p2pd.exe`; both `node` and frozen contribution-worker dispatch passed. The same
+`p2pd.exe`; `node`, frozen contribution-worker, and catalog-bootstrap dispatch passed,
+and the runtime reported catalog-bootstrap schema 1. The same
 disposable native-credential smoke then launched the packaged executable, joined the
 published DNS seed, authenticated API version 1 with one configured manifest, wrote no
 `control-api.key`, and shut down the owned process. Clean-runner Linux/macOS sidecar
 results and GPU-specific bundle policy remain open.
+
+## First-rung model qualification harness
+
+The former TinyLlama-specific local swarm smoke is now manifest-driven. For a supplied
+`ModelManifest v1`, it derives the exact repository, immutable revision, block count,
+DHT namespace, dtype, attention implementation, and artifact verifier from the
+manifest; defaults to serving every declared block; and releases the distributed
+client and workers before loading the stock reference to bound peak memory for larger
+models. The legacy unmanifested TinyLlama path remains available for device bring-up.
+
+The `qualify_model_manifest.py` runner adds a bounded JSON evidence contract. It
+requires successful manifested-route completion and exact stock token parity rather
+than trusting a subprocess exit code. Its optional failover stage also requires an
+observed selected-worker interruption and measured recovery. Reports explicitly list
+the multi-machine, cross-platform, edge-envelope, and public-worker gates they cannot
+prove and never claim complete release qualification.
+
+On 2026-08-23, the new Windows CPU runner served all eight TinyLlama blocks and passed
+exact stock parity. A second requested stage started two complete signed replicas,
+interrupted the selected worker, recovered in 3.172 seconds, and produced
+`[[1,16644,31844,260,1496,2789,3557,21075,31843,1100]]`, exactly matching the stock
+model. The CI-sized offline suite, including the new report/parser/command tests,
+passed 247 tests with seven expected skips after adding the exact candidate pin,
+Hub-cache inference, and mapped-storage regression gates.
+
+The first primary candidate pins official `Qwen/Qwen3-1.7B` commit
+`70d244cc86ccca08cf5af4e1e306ecf908b1ad5e` as an ungated Apache-2.0 bfloat16/eager
+profile with manifest digest
+`sha256:aef22f8678f9c5dcc5315913cf1cf584fa9e6c2fba8d064f715d78d823c9f056`. The runner
+audited all eight artifacts and 4,079,422,995 declared bytes, served all 28 blocks on
+Windows CPU, and produced `[[9707,25,358,2776]]`, exactly matching the stock eager
+model. A two-replica run interrupted the selected worker, recovered in 4.484 seconds,
+and preserved the same exact IDs.
+
+The first Qwen load also found and fixed a larger-model Windows defect: same-dtype
+block tensors kept their complete safetensors shard mapping, accumulating one 3.44 GB
+mapping per block until the process failed while loading block 25. The loader now
+copies only the selected block tensors into owned CPU storage before closing the file
+mapping. A regression test checks storage independence, and the TinyLlama parity plus
+focused loader/model suites passed before the full Qwen rerun. The candidate manifest
+is still not catalog approval: multi-machine, cross-platform, edge, and public-route
+evidence plus the first-rung standby qualification remain open.
 
 ## Desktop milestone: shell decision
 

--- a/docs/REVIVAL_TEST_RESULTS.md
+++ b/docs/REVIVAL_TEST_RESULTS.md
@@ -15,7 +15,7 @@ test harnesses are `scripts/smoke_tinyllama_local_swarm.py` and
 | 2. Real multi-machine swarm | Complete | A private Fly swarm reached explicit `0:8` coverage with two replicas per block; a selected `4:8` Machine was killed during generation, the client rerouted and replayed its prefix, and both the recovered request and a cache-cleanup request passed exact parity | None for this milestone; broader-model recovery remains follow-up work |
 | 3. Public protocol identity and content integrity | Complete | Content-derived manifests, signed expiring worker announcements, PeerID/TLS binding, replay/range/profile checks, signed intent leases, dual-signed rotation, revocation, deterministic interruption tests, real Hub HTTP 206 resume on Windows and macOS, signed Windows parity/failover, signed Fly cross-Machine parity, hosted macOS signed parity, and prior Fly poison rejection are proven | None |
 | 4. Unified local node and multi-model OpenAI API | Complete | Exact multi-manifest selection, artifact-free unloaded discovery, cancellation-safe lazy loading and LRU residency, isolated supervised workers, labeled hash-only key CRUD, authenticated controls, reproducible edge measurements, official OpenAI Python client compatibility, clean restart/key reuse, and real external two-model Fly parity are proven | None for this milestone; every additional selectable model still needs its own published edge envelope |
-| 5. Desktop application and contribution controls | In progress | ADR 0002 selects PySide 6; clean production package/UI smokes pass on Windows, Linux, and macOS; OpenAI and control authorities are separate; the node can read the desktop's native credential directly; source-level lifecycle tests cover startup, authenticated readiness, collisions, backoff, reconnect, migration retirement, and owned shutdown; and the strict signed-catalog foundation covers independent signing keys, thresholds, expiry, rollback, exact manifests, and elastic-rung promotion gates | The real node sidecar and catalog are not bundled or remotely fetched; qualified public manifests, real native-store package integration, contribution policies and budgets, startup/RSS and crash-isolation measurements, signing, updates, root rotation, accessibility, and installer gates remain |
+| 5. Desktop application and contribution controls | In progress | ADR 0002 selects PySide 6; clean production package/UI smokes pass on Windows, Linux, and macOS; OpenAI and control authorities are separate; the production build now stages an independently frozen node sidecar and smokes its node and worker entry points; a packaged Windows run used Credential Manager, joined the public DNS seed, authenticated readiness, and shut down cleanly; and the strict signed-catalog foundation covers independent signing keys, thresholds, expiry, rollback, exact manifests, and elastic-rung promotion gates | The initial catalog is not bundled or remotely fetched; first-install configuration, qualified public manifests, cross-platform native-store package promotion, contribution policies and budgets, startup/RSS and crash-isolation measurements, signing, updates, root rotation, accessibility, and installer gates remain |
 
 ## Desktop milestone: control authority separation
 
@@ -77,10 +77,12 @@ The source supervisor checks the configured loopback port before spawning, refus
 replace an unknown service, launches the standalone node with native-store identifiers
 but no secret, waits for authenticated readiness, applies exponential backoff capped at
 30 seconds, and terminates only its owned process. A failed periodic status refresh now
-drops the stale client so the next refresh re-enters lifecycle recovery. Twenty-one
-desktop tests and twenty-five focused node/key tests pass. The package still excludes
-model, DHT, and worker runtimes and does not yet stage a node sidecar, so this is not a
-claim that a clean packaged installation can run inference.
+drops the stale client so the next refresh re-enters lifecycle recovery. Twenty-two
+desktop tests and the focused node/key tests pass. The package still excludes model,
+DHT, and worker runtimes from the GUI executable itself. Its product bundle now stages
+those dependencies in a separate frozen node directory and verifies the node and worker
+entry points. The missing signed catalog and first-install configuration mean this is
+still not a claim that a clean packaged installation can run inference.
 
 The real Windows source smoke used a disposable Credential Manager service/account and
 an isolated loopback port. The desktop launched the installed `drift node`, the node
@@ -89,6 +91,16 @@ loaded the same native key, joined via
 and returned authenticated API version 1 status for one manifest. No
 `control-api.key` appeared in the temporary data directory. The supervisor then stopped
 its owned process and deleted the disposable native credential.
+
+The subsequent Windows product build created a 1,841,600,397-byte, 4,810-file frozen
+node directory inside a 1,967,229,026-byte, 5,154-file unsigned product bundle. Its
+runtime contract imported DRIFT 2.3.0.dev2, Torch 2.6.0 CPU, Transformers 5.13.0,
+Hivemind 1.1.12, FastAPI, Uvicorn, the Windows keyring backend, and the packaged
+`p2pd.exe`; both `node` and frozen contribution-worker dispatch passed. The same
+disposable native-credential smoke then launched the packaged executable, joined the
+published DNS seed, authenticated API version 1 with one configured manifest, wrote no
+`control-api.key`, and shut down the owned process. Clean-runner Linux/macOS sidecar
+results and GPU-specific bundle policy remain open.
 
 ## Desktop milestone: shell decision
 

--- a/manifests/candidates/qwen3-1.7b-bfloat16-eager.json
+++ b/manifests/candidates/qwen3-1.7b-bfloat16-eager.json
@@ -1,0 +1,79 @@
+{
+  "schema_version": 1,
+  "name": "Qwen3 1.7B",
+  "aliases": [
+    "qwen3-1.7b"
+  ],
+  "source": {
+    "repository": "Qwen/Qwen3-1.7B",
+    "revision": "70d244cc86ccca08cf5af4e1e306ecf908b1ad5e"
+  },
+  "model": {
+    "architecture": "Qwen3ForCausalLM",
+    "num_blocks": 28,
+    "context_length": 40960,
+    "license": "apache-2.0",
+    "gated": false
+  },
+  "runtime": {
+    "implementation": "drift",
+    "minimum_version": "2.3.0.dev0",
+    "maximum_version_exclusive": "2.4.0",
+    "protocol_version": 1,
+    "tensor_schema": "hidden-states-v1",
+    "attention_implementation": "eager",
+    "dtype": "bfloat16",
+    "quantization": "none",
+    "adapter_profile": "none"
+  },
+  "artifacts": [
+    {
+      "role": "config",
+      "path": "config.json",
+      "sha256": "1ddb5b89ebc90dcb417a45c213d818577e65976454d29385c8f6140771d95197",
+      "size": 726
+    },
+    {
+      "role": "tokenizer",
+      "path": "merges.txt",
+      "sha256": "8831e4f1a044471340f7c0a83d7bd71306a5b867e95fd870f74d0c5308a904d5",
+      "size": 1671853
+    },
+    {
+      "role": "weight",
+      "path": "model-00001-of-00002.safetensors",
+      "sha256": "169ad53ec313c3a34b06c0809216e4fc072cce444a5d4ff2b59690d064130ed5",
+      "size": 3441185608
+    },
+    {
+      "role": "weight",
+      "path": "model-00002-of-00002.safetensors",
+      "sha256": "912becff8d60672aa8628ef08c05898d9adf17c2ad4ae3caf99b065622fdeff9",
+      "size": 622329984
+    },
+    {
+      "role": "weight_index",
+      "path": "model.safetensors.index.json",
+      "sha256": "0d660e94b165eb912669a5249dff44b83188c4777a07ddb9611fb78d91b0578d",
+      "size": 25605
+    },
+    {
+      "role": "tokenizer",
+      "path": "tokenizer.json",
+      "sha256": "aeb13307a71acd8fe81861d94ad54ab689df773318809eed3cbe794b4492dae4",
+      "size": 11422654
+    },
+    {
+      "role": "tokenizer",
+      "path": "tokenizer_config.json",
+      "sha256": "d5d09f07b48c3086c508b30d1c9114bd1189145b74e982a265350c923acd8101",
+      "size": 9732
+    },
+    {
+      "role": "tokenizer",
+      "path": "vocab.json",
+      "sha256": "ca10d7e9fb3ed18575dd1e277a2579c16d108e32f27439684afa0e10b1440910",
+      "size": 2776833
+    }
+  ]
+}

--- a/scripts/qualify_model_manifest.py
+++ b/scripts/qualify_model_manifest.py
@@ -1,0 +1,358 @@
+"""Produce a machine-readable local qualification report for one exact manifest.
+
+This runner deliberately covers only gates that can be reproduced on one machine:
+strict manifest/artifact validation, a complete manifested route, stock-model token
+parity, and optional in-generation replica failover. Multi-machine, cross-platform,
+resource-envelope, and public-worker evidence remain separate release gates.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Sequence
+
+import drift
+from drift.model_manifest import ManifestError, ModelManifest
+
+LOCAL_QUALIFICATION_SCHEMA_VERSION = 1
+_PARITY_MARKER = "distributed output matches the stock model exactly"
+_SUCCESS_MARKER = "manifested local swarm qualification ok"
+_MAX_CAPTURE_CHARACTERS = 24_000
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Validate one exact model manifest and record local distributed parity/failover evidence",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("manifest", type=Path, help="Exact ModelManifest v1 candidate")
+    parser.add_argument(
+        "--artifact-root",
+        type=Path,
+        help="Complete publisher snapshot; every declared artifact is hashed before the swarm starts",
+    )
+    parser.add_argument("--cache-dir", type=Path, help="Shared immutable model cache for the qualification run")
+    parser.add_argument("--device", default="cpu", help="Worker-block and stock-reference torch device")
+    parser.add_argument("--prompt", default="Hello")
+    parser.add_argument("--new-tokens", type=int, default=3)
+    parser.add_argument("--timeout", type=float, default=900, help="Per-smoke timeout in seconds")
+    parser.add_argument("--cache", choices=("contiguous", "paged"), default="contiguous")
+    parser.add_argument("--page-size", type=int, default=16)
+    parser.add_argument(
+        "--with-failover",
+        action="store_true",
+        help="also start two full replicas, interrupt the selected worker, and require exact parity",
+    )
+    parser.add_argument("--failover-tokens", type=int, default=8)
+    parser.add_argument(
+        "--manifest-only",
+        action="store_true",
+        help="validate the manifest/artifacts without starting a local swarm; report remains explicitly partial",
+    )
+    parser.add_argument("--output", type=Path, help="Write the report atomically; otherwise print JSON")
+    return parser
+
+
+def _absolute(path: Path) -> Path:
+    return Path(os.path.abspath(os.fspath(path.expanduser())))
+
+
+def _bounded_capture(value: str) -> str:
+    if len(value) <= _MAX_CAPTURE_CHARACTERS:
+        return value
+    return "[earlier output truncated]\n" + value[-_MAX_CAPTURE_CHARACTERS:]
+
+
+def infer_hub_cache_dir(artifact_root: Path) -> Path | None:
+    """Recognize ``<hub>/models--org--repo/snapshots/<commit>`` without guessing elsewhere."""
+    parents = artifact_root.parents
+    if (
+        len(parents) >= 3
+        and parents[0].name == "snapshots"
+        and parents[1].name.startswith("models--")
+        and parents[2].name == "hub"
+    ):
+        return parents[2]
+    return None
+
+
+def extract_smoke_evidence(stdout: str, *, failover: bool) -> dict[str, Any]:
+    evidence: dict[str, Any] = {
+        "stock_token_parity": _PARITY_MARKER in stdout,
+        "manifested_route_completed": _SUCCESS_MARKER in stdout,
+    }
+    for line in stdout.splitlines():
+        if line.startswith("output_ids="):
+            try:
+                evidence["distributed_output_ids"] = json.loads(line.split("=", 1)[1])
+            except json.JSONDecodeError:
+                evidence["distributed_output_ids_unparsed"] = line.split("=", 1)[1]
+        elif line.startswith("reference_output_ids="):
+            try:
+                evidence["reference_output_ids"] = json.loads(line.split("=", 1)[1])
+            except json.JSONDecodeError:
+                evidence["reference_output_ids_unparsed"] = line.split("=", 1)[1]
+        elif line.startswith("failover_recovery_seconds="):
+            try:
+                evidence["failover_recovery_seconds"] = float(line.split("=", 1)[1])
+            except ValueError:
+                evidence["failover_recovery_seconds_unparsed"] = line.split("=", 1)[1]
+        elif line.startswith("client_input_embeddings_placement="):
+            evidence["client_input_embeddings_placement"] = line.split("=", 1)[1]
+        elif line.startswith("client_lm_head_placement="):
+            evidence["client_lm_head_placement"] = line.split("=", 1)[1]
+    if failover:
+        evidence["selected_worker_interrupted"] = "interrupting selected worker" in stdout
+        evidence["recovery_observed"] = "failover_recovery_seconds" in evidence
+    return evidence
+
+
+def smoke_evidence_passed(evidence: dict[str, Any], *, failover: bool) -> bool:
+    required = evidence.get("stock_token_parity") is True and evidence.get("manifested_route_completed") is True
+    if failover:
+        required = (
+            required
+            and evidence.get("selected_worker_interrupted") is True
+            and evidence.get("recovery_observed") is True
+        )
+    return required
+
+
+def build_smoke_command(
+    manifest_path: Path,
+    *,
+    artifact_root: Path | None,
+    cache_dir: Path | None,
+    device: str,
+    prompt: str,
+    new_tokens: int,
+    timeout: float,
+    cache: str,
+    page_size: int,
+    failover: bool,
+    failover_tokens: int,
+) -> list[str]:
+    smoke = Path(__file__).resolve().with_name("smoke_manifest_local_swarm.py")
+    command = [
+        sys.executable,
+        str(smoke),
+        "--model-manifest",
+        str(manifest_path),
+        "--device",
+        device,
+        "--prompt",
+        prompt,
+        "--new-tokens",
+        str(new_tokens),
+        "--timeout",
+        str(timeout),
+        "--cache",
+        cache,
+        "--page-size",
+        str(page_size),
+    ]
+    if artifact_root is not None:
+        command.extend(("--artifact-root", str(artifact_root)))
+    if cache_dir is not None:
+        command.extend(("--cache-dir", str(cache_dir)))
+    if failover:
+        command.extend(("--test-failover", "--failover-tokens", str(failover_tokens)))
+    return command
+
+
+def run_smoke_stage(name: str, command: Sequence[str], *, timeout: float, failover: bool) -> dict[str, Any]:
+    started = time.perf_counter()
+    environment = os.environ.copy()
+    environment["PYTHONUNBUFFERED"] = "1"
+    try:
+        completed = subprocess.run(
+            list(command),
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout + 60,
+            env=environment,
+            check=False,
+        )
+        stdout, stderr = completed.stdout, completed.stderr
+        evidence = extract_smoke_evidence(stdout, failover=failover)
+        passed = completed.returncode == 0 and smoke_evidence_passed(evidence, failover=failover)
+        return {
+            "name": name,
+            "status": "passed" if passed else "failed",
+            "duration_seconds": round(time.perf_counter() - started, 6),
+            "return_code": completed.returncode,
+            "command": list(command),
+            "evidence": evidence,
+            "stdout": _bounded_capture(stdout),
+            "stderr": _bounded_capture(stderr),
+        }
+    except subprocess.TimeoutExpired as exc:
+        stdout = exc.stdout.decode("utf-8", errors="replace") if isinstance(exc.stdout, bytes) else exc.stdout or ""
+        stderr = exc.stderr.decode("utf-8", errors="replace") if isinstance(exc.stderr, bytes) else exc.stderr or ""
+        return {
+            "name": name,
+            "status": "failed",
+            "duration_seconds": round(time.perf_counter() - started, 6),
+            "return_code": None,
+            "command": list(command),
+            "evidence": {"timeout_seconds": timeout + 60},
+            "stdout": _bounded_capture(stdout),
+            "stderr": _bounded_capture(stderr),
+        }
+
+
+def _write_report(path: Path, report: dict[str, Any]) -> None:
+    path = _absolute(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    try:
+        with temporary.open("w", encoding="utf-8", newline="\n") as stream:
+            json.dump(report, stream, ensure_ascii=False, allow_nan=False, indent=2, sort_keys=True)
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+    finally:
+        try:
+            temporary.unlink()
+        except OSError:
+            pass
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if not args.prompt:
+        parser.error("--prompt must be non-empty")
+    if args.new_tokens < 1:
+        parser.error("--new-tokens must be at least 1")
+    if args.failover_tokens < 2:
+        parser.error("--failover-tokens must be at least 2")
+    if args.timeout <= 0:
+        parser.error("--timeout must be positive")
+    if args.page_size <= 0:
+        parser.error("--page-size must be positive")
+    if args.manifest_only and args.with_failover:
+        parser.error("--manifest-only conflicts with --with-failover")
+
+    manifest_path = _absolute(args.manifest)
+    artifact_root = _absolute(args.artifact_root) if args.artifact_root is not None else None
+    cache_dir = _absolute(args.cache_dir) if args.cache_dir is not None else None
+    cache_dir_source = "argument" if cache_dir is not None else None
+    if cache_dir is None and artifact_root is not None:
+        cache_dir = infer_hub_cache_dir(artifact_root)
+        if cache_dir is not None:
+            cache_dir_source = "inferred_hub_snapshot"
+
+    validation_started = time.perf_counter()
+    try:
+        manifest = ModelManifest.load(manifest_path)
+        manifest.validate_runtime(drift.__version__)
+        if artifact_root is not None:
+            manifest.verify_artifacts(artifact_root)
+    except (ManifestError, OSError) as exc:
+        parser.error(str(exc))
+    validation_stage = {
+        "name": "manifest_and_artifacts",
+        "status": "passed",
+        "duration_seconds": round(time.perf_counter() - validation_started, 6),
+        "evidence": {
+            "manifest_digest": manifest.digest_id,
+            "artifacts_verified": artifact_root is not None,
+            "artifact_count": len(manifest.artifacts),
+            "declared_artifact_bytes": sum(artifact.size for artifact in manifest.artifacts),
+        },
+    }
+
+    report: dict[str, Any] = {
+        "schema_version": LOCAL_QUALIFICATION_SCHEMA_VERSION,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "scope": "single-machine-local",
+        "model": {
+            "name": manifest.name,
+            "aliases": list(manifest.aliases),
+            "repository": manifest.source.repository,
+            "revision": manifest.source.revision,
+            "manifest_digest": manifest.digest_id,
+            "architecture": manifest.model.architecture,
+            "num_blocks": manifest.model.num_blocks,
+            "license": manifest.model.license,
+            "gated": manifest.model.gated,
+            "runtime": manifest.runtime.to_dict(),
+        },
+        "environment": {
+            "python": platform.python_version(),
+            "platform": platform.platform(),
+            "drift": drift.__version__,
+        },
+        "requested": {
+            "artifact_verification": artifact_root is not None,
+            "local_parity": not args.manifest_only,
+            "local_failover": args.with_failover,
+            "device": args.device,
+            "cache": args.cache,
+            "artifact_root": str(artifact_root) if artifact_root is not None else None,
+            "runtime_cache_dir": str(cache_dir) if cache_dir is not None else None,
+            "runtime_cache_dir_source": cache_dir_source,
+        },
+        "stages": [validation_stage],
+        "not_covered": [
+            "multi-machine routing and interruption recovery",
+            "cross-platform CPU/CUDA/MPS matrix",
+            "cold-client resource envelope",
+            "public-worker route redundancy and soak",
+        ],
+    }
+
+    if not args.manifest_only:
+        base_command = dict(
+            manifest_path=manifest_path,
+            artifact_root=artifact_root,
+            cache_dir=cache_dir,
+            device=args.device,
+            prompt=args.prompt,
+            new_tokens=args.new_tokens,
+            timeout=args.timeout,
+            cache=args.cache,
+            page_size=args.page_size,
+            failover_tokens=args.failover_tokens,
+        )
+        parity = run_smoke_stage(
+            "local_distributed_stock_parity",
+            build_smoke_command(**base_command, failover=False),
+            timeout=args.timeout,
+            failover=False,
+        )
+        report["stages"].append(parity)
+        if parity["status"] == "passed" and args.with_failover:
+            report["stages"].append(
+                run_smoke_stage(
+                    "local_in_generation_failover",
+                    build_smoke_command(**base_command, failover=True),
+                    timeout=args.timeout,
+                    failover=True,
+                )
+            )
+
+    report["result"] = "passed" if all(stage["status"] == "passed" for stage in report["stages"]) else "failed"
+    report["complete_release_qualification"] = False
+    if args.output is not None:
+        _write_report(args.output, report)
+    else:
+        json.dump(report, sys.stdout, ensure_ascii=False, allow_nan=False, indent=2, sort_keys=True)
+        sys.stdout.write("\n")
+    return 0 if report["result"] == "passed" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/smoke_desktop_managed_node.py
+++ b/scripts/smoke_desktop_managed_node.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import argparse
 import json
 import socket
 import sys
@@ -27,6 +28,20 @@ def _unused_loopback_port() -> int:
 
 
 def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--node-command",
+        type=Path,
+        help="Packaged CommunityAI-Node executable to supervise instead of the source drift command",
+    )
+    args = parser.parse_args()
+    node_command = None
+    if args.node_command is not None:
+        executable = args.node_command.expanduser().resolve()
+        if not executable.is_file():
+            parser.error(f"node executable does not exist: {executable}")
+        node_command = (str(executable),)
+
     service = f"org.communityai.desktop.smoke.{uuid.uuid4().hex}"
     account = "local-node-control-v1"
     store = NativeCredentialStore(service, account)
@@ -61,6 +76,7 @@ def main() -> int:
             store,
             config_path=config_path,
             data_dir=root / "data",
+            node_command=node_command,
             startup_timeout=45,
         )
         try:

--- a/scripts/smoke_manifest_local_swarm.py
+++ b/scripts/smoke_manifest_local_swarm.py
@@ -1,0 +1,6 @@
+"""Public entry point for the model-agnostic local manifested-swarm smoke."""
+
+from smoke_tinyllama_local_swarm import main
+
+if __name__ == "__main__":
+    main()

--- a/scripts/smoke_tinyllama_local_swarm.py
+++ b/scripts/smoke_tinyllama_local_swarm.py
@@ -1,8 +1,12 @@
-"""Run a one-machine TinyLlama private swarm smoke test.
+"""Run a one-machine manifested-model private swarm qualification smoke.
 
-This starts one local DHT peer that hosts all blocks for Maykeye/TinyLLama-v0,
-connects a client through that peer's DHT address, and generates a few tokens.
-It is intended for Windows/XPU bring-up but also works on CPU/CUDA with --device.
+With ``--model-manifest``, the repository, immutable revision, block count, runtime
+profile, and DHT namespace all come from the manifest. Without a manifest the script
+retains its historical Maykeye/TinyLLama-v0 bring-up default.
+
+The smoke starts one local DHT peer that hosts the requested blocks, connects a client
+through that peer's DHT address, and generates a few tokens. It is intended for
+Windows/XPU bring-up but also works on CPU/CUDA with --device.
 ``--device`` selects the worker-block and stock-reference device; the distributed
 client's embeddings and language-model head deliberately remain on their default
 local device, whose actual placement is logged and dtype-checked after loading.
@@ -16,6 +20,7 @@ from __future__ import annotations
 
 import argparse
 import faulthandler
+import gc
 import shutil
 import tempfile
 import time
@@ -41,8 +46,8 @@ from drift.utils.dht import get_remote_module_infos
 from drift.utils.hardware import normalize_device
 from drift.utils.misc import get_size_in_bytes
 
-MODEL = "Maykeye/TinyLLama-v0"
-DHT_PREFIX = "_windows_xpu_tinyllama_v0_smoke"
+DEFAULT_MODEL = "Maykeye/TinyLLama-v0"
+DEFAULT_DHT_PREFIX = "_windows_xpu_tinyllama_v0_smoke"
 
 
 def log(message: str) -> None:
@@ -54,6 +59,8 @@ def parse_block_indices(value: str) -> list[int]:
         start_block, end_block = [int(index.strip()) for index in value.split(":")]
     except Exception as exc:
         raise ValueError("--block-indices must be start:end, e.g. 0:8") from exc
+    if start_block < 0 or end_block <= start_block:
+        raise ValueError("--block-indices must name a non-empty, non-negative start:end range")
     return list(range(start_block, end_block))
 
 
@@ -66,6 +73,34 @@ def log_local_component_placement(name: str, module: torch.nn.Module, expected_d
     log(f"{name}_placement=devices={devices},dtypes={dtypes}")
     if any(parameter.dtype != expected_dtype for parameter in parameters):
         raise AssertionError(f"{name} did not load entirely as {expected_dtype}: observed dtypes={dtypes}")
+
+
+def close_distributed_client(model) -> None:
+    if model is None:
+        return
+    try:
+        sequence_manager = model.transformer.h.sequence_manager
+    except AttributeError:
+        return
+    try:
+        sequence_manager.shutdown()
+    finally:
+        client_dht = getattr(sequence_manager, "dht", None)
+        if client_dht is not None and client_dht.is_alive():
+            client_dht.shutdown()
+
+
+def stop_workers(containers: list, worker_dhts: list) -> None:
+    for container in reversed(containers):
+        if container.is_alive():
+            container.shutdown()
+            container.join(timeout=10)
+    containers.clear()
+    for worker_dht in reversed(worker_dhts):
+        if worker_dht.is_alive():
+            worker_dht.shutdown()
+            worker_dht.join()
+    worker_dhts.clear()
 
 
 def wait_for_dht_announcement(
@@ -97,17 +132,27 @@ def wait_for_dht_announcement(
     raise TimeoutError("hosted blocks were not announced in the local DHT")
 
 
-def main() -> None:
-    parser = argparse.ArgumentParser()
+def main(argv=None) -> None:
+    parser = argparse.ArgumentParser(
+        description="Qualify one exact manifested model through a local distributed route and stock parity"
+    )
     parser.add_argument(
         "--device",
         default="xpu",
         help="device for served transformer blocks and the stock reference; client embeddings/head stay local",
     )
     parser.add_argument("--timeout", type=float, default=240)
-    parser.add_argument("--block-indices", default="0:8")
+    parser.add_argument(
+        "--block-indices",
+        default=None,
+        help="contiguous start:end range to serve; defaults to every manifested transformer block",
+    )
     parser.add_argument("--torch-dtype", default=None, choices=DTYPE_MAP.keys())
     parser.add_argument("--model-manifest", help="Run the smoke through a verified ModelManifest v1")
+    parser.add_argument("--artifact-root", help="Use and verify a complete local publisher snapshot")
+    parser.add_argument("--cache-dir", help="Hugging Face/manifest cache used by workers, client, and reference")
+    parser.add_argument("--prompt", default="Hello")
+    parser.add_argument("--new-tokens", type=int, default=3)
     parser.add_argument("--cache", default="contiguous", choices=["contiguous", "paged"])
     parser.add_argument("--page-size", type=int, default=16)
     parser.add_argument(
@@ -121,34 +166,47 @@ def main() -> None:
         action="store_true",
         help="skip the stock-model token parity check (faster, but does not verify numerical correctness)",
     )
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     manifest = None
     artifact_verifier = None
     revision = None
-    dht_prefix = DHT_PREFIX
+    model_name = DEFAULT_MODEL
+    dht_prefix = DEFAULT_DHT_PREFIX
     if args.model_manifest:
         manifest = ModelManifest.load(args.model_manifest)
         manifest.validate_runtime(drift.__version__)
+        model_name = manifest.source.repository
         revision, dht_prefix = resolve_manifest_loading(
             manifest,
-            model_name_or_path=MODEL,
+            model_name_or_path=model_name,
             revision=None,
             dht_prefix=None,
         )
         if manifest.runtime.quantization != "none":
-            raise ValueError("The TinyLlama smoke currently supports only manifest quantization='none'")
+            raise ValueError("The local qualification smoke currently supports only manifest quantization='none'")
         if args.torch_dtype is None:
             args.torch_dtype = manifest.runtime.dtype
         elif args.torch_dtype != manifest.runtime.dtype:
             raise ValueError(
                 f"--torch-dtype {args.torch_dtype!r} conflicts with manifest dtype {manifest.runtime.dtype!r}"
             )
-        artifact_verifier = ManifestArtifactVerifier(manifest, MODEL, revision)
+        artifact_verifier = ManifestArtifactVerifier(
+            manifest,
+            model_name,
+            revision,
+            artifact_root=args.artifact_root,
+            cache_dir=args.cache_dir,
+        )
         config_source = artifact_verifier.ensure_startup_metadata(include_tokenizer=True)
     else:
         args.torch_dtype = args.torch_dtype or "bfloat16"
-        config_source = MODEL
+        config_source = model_name
+
+    if not args.prompt:
+        raise ValueError("--prompt must be non-empty")
+    if args.new_tokens < 1:
+        raise ValueError("--new-tokens must be at least 1")
 
     faulthandler.dump_traceback_later(args.timeout, exit=True)
 
@@ -159,14 +217,15 @@ def main() -> None:
     else:
         log(f"torch={torch.__version__}, device={device}")
 
-    block_indices = parse_block_indices(args.block_indices)
-    log(f"initializing local DHT for blocks={block_indices}")
-    identity_dir = Path(tempfile.mkdtemp(prefix="drift-smoke-identities-")) if manifest is not None else None
+    requested_block_indices = parse_block_indices(args.block_indices) if args.block_indices is not None else None
+    expected_block_count = manifest.model.num_blocks if manifest is not None else 8
+    dht_worker_count = len(requested_block_indices) if requested_block_indices is not None else expected_block_count
+    identity_dir = Path(tempfile.mkdtemp(prefix="drift-qualification-identities-")) if manifest is not None else None
     bootstrap_identity_path = identity_dir / "bootstrap.key" if identity_dir is not None else None
     dht = DHT(
         initial_peers=[],
         start=True,
-        num_workers=len(block_indices),
+        num_workers=dht_worker_count,
         use_relay=False,
         use_auto_relay=False,
         client_mode=False,
@@ -176,6 +235,7 @@ def main() -> None:
     )
     containers = []
     worker_dhts = []
+    model = None
 
     try:
         peers = [str(addr) for addr in dht.get_visible_maddrs()]
@@ -189,7 +249,17 @@ def main() -> None:
         )
         if manifest is not None:
             manifest.validate_model_config(block_config)
-        block_config._attn_implementation = "eager"
+            if manifest.runtime.attention_implementation != "auto":
+                block_config._attn_implementation = manifest.runtime.attention_implementation
+        else:
+            block_config._attn_implementation = "eager"
+        block_indices = requested_block_indices or list(range(block_config.num_hidden_layers))
+        if block_indices[-1] >= block_config.num_hidden_layers:
+            raise ValueError(
+                f"--block-indices ends at {block_indices[-1] + 1}, but the model has "
+                f"{block_config.num_hidden_layers} blocks"
+            )
+        log(f"initializing local DHT for model={model_name} blocks={block_indices}")
         torch_dtype = resolve_block_dtype(block_config, DTYPE_MAP[args.torch_dtype])
         log(f"torch_dtype={torch_dtype}")
         attn_cache_tokens = 128
@@ -229,13 +299,13 @@ def main() -> None:
                 quant_type=QuantType.NONE.name.lower(),
                 using_relay=False,
             )
-            model_info = ModelInfo(num_blocks=block_config.num_hidden_layers, repository=MODEL)
+            model_info = ModelInfo(num_blocks=block_config.num_hidden_layers, repository=model_name)
 
             log(f"starting module container replica={replica_index}")
             container = ModuleContainer.create(
                 dht=serving_dht,
                 dht_prefix=dht_prefix,
-                converted_model_name_or_path=MODEL,
+                converted_model_name_or_path=model_name,
                 block_config=block_config,
                 attn_cache_bytes=attn_cache_bytes,
                 server_info=server_info,
@@ -250,7 +320,7 @@ def main() -> None:
                 page_size=args.page_size,
                 inference_max_length=64,
                 torch_dtype=torch_dtype,
-                cache_dir=None,
+                cache_dir=args.cache_dir,
                 max_disk_space=None,
                 device=device,
                 compression=CompressionType.NONE,
@@ -286,9 +356,10 @@ def main() -> None:
 
         log("loading client")
         tokenizer = AutoTokenizer.from_pretrained(
-            artifact_verifier.snapshot_root if artifact_verifier is not None else MODEL,
+            artifact_verifier.snapshot_root if artifact_verifier is not None else model_name,
             revision=None if manifest is not None else revision,
             local_files_only=manifest is not None,
+            cache_dir=args.cache_dir,
         )
         model_kwargs = dict(
             dht_prefix=dht_prefix,
@@ -305,13 +376,13 @@ def main() -> None:
         )
         if artifact_verifier is not None:
             model_kwargs["artifact_verifier"] = artifact_verifier
-        model = AutoDistributedModelForCausalLM.from_pretrained(MODEL, **model_kwargs)
+        model = AutoDistributedModelForCausalLM.from_pretrained(model_name, **model_kwargs)
         log_local_component_placement("client_input_embeddings", model.get_input_embeddings(), torch_dtype)
         log_local_component_placement("client_lm_head", model.get_output_embeddings(), torch_dtype)
 
         log("generating")
-        inputs = tokenizer("Hello", return_tensors="pt")["input_ids"]
-        generated_tokens = args.failover_tokens if args.test_failover else 3
+        inputs = tokenizer(args.prompt, return_tensors="pt")["input_ids"]
+        generated_tokens = args.failover_tokens if args.test_failover else args.new_tokens
         if args.test_failover:
             if generated_tokens < 2:
                 raise ValueError("--failover-tokens must be at least 2")
@@ -355,10 +426,27 @@ def main() -> None:
         log(f"decoded={tokenizer.decode(outputs[0])!r}")
 
         if not args.skip_reference:
+            log("releasing distributed client and workers before loading the stock reference")
+            close_distributed_client(model)
+            model = None
+            stop_workers(containers, worker_dhts)
+            gc.collect()
             log("loading stock local model for token parity check")
-            reference_model = AutoModelForCausalLM.from_pretrained(MODEL, revision=revision, dtype=torch_dtype).to(
-                device
-            )
+            if artifact_verifier is not None:
+                for artifact in manifest.artifacts_for_roles({"weight", "weight_index"}):
+                    artifact_verifier.ensure_path(artifact.path, allowed_roles={"weight", "weight_index"})
+            reference_kwargs = {
+                "revision": None if artifact_verifier is not None else revision,
+                "dtype": torch_dtype,
+                "local_files_only": artifact_verifier is not None,
+                "cache_dir": args.cache_dir,
+            }
+            if manifest is not None and manifest.runtime.attention_implementation != "auto":
+                reference_kwargs["attn_implementation"] = manifest.runtime.attention_implementation
+            reference_model = AutoModelForCausalLM.from_pretrained(
+                artifact_verifier.snapshot_root if artifact_verifier is not None else model_name,
+                **reference_kwargs,
+            ).to(device)
             reference_model.eval()
             with torch.inference_mode():
                 if args.test_failover:
@@ -380,17 +468,11 @@ def main() -> None:
             log(f"reference_output_ids={reference_outputs.tolist()}")
             log("distributed output matches the stock model exactly")
 
-        log("tinyllama local swarm smoke ok")
+        log(f"manifested local swarm qualification ok model={model_name}")
     finally:
         log("shutting down")
-        for container in reversed(containers):
-            if container.is_alive():
-                container.shutdown()
-                container.join(timeout=10)
-        for worker_dht in reversed(worker_dhts):
-            if worker_dht.is_alive():
-                worker_dht.shutdown()
-                worker_dht.join()
+        close_distributed_client(model)
+        stop_workers(containers, worker_dhts)
         dht.shutdown()
         dht.join()
         if identity_dir is not None:

--- a/src/drift/cli/__main__.py
+++ b/src/drift/cli/__main__.py
@@ -6,6 +6,7 @@
     drift dht ...                   A standalone lightweight DHT bootstrap peer
     drift api <model> ...           An OpenAI-compatible HTTP API backed by the swarm
     drift node <manifest> ...       A persistent authenticated localhost gateway
+    drift bootstrap <config>        Install a verified first-run model catalog
     drift edge-benchmark <manifest> Measure client-only edge resource use
     drift manifest <file>           Validate and inspect a ModelManifest v1
     drift catalog ...               Create and verify signed model catalogs
@@ -17,7 +18,19 @@ name and delegates. Also runnable as ``python -m drift.cli``.
 
 import sys
 
-_COMMANDS = ("up", "down", "server", "dht", "api", "node", "edge-benchmark", "manifest", "catalog", "identity")
+_COMMANDS = (
+    "up",
+    "down",
+    "server",
+    "dht",
+    "api",
+    "node",
+    "bootstrap",
+    "edge-benchmark",
+    "manifest",
+    "catalog",
+    "identity",
+)
 
 _USAGE = """usage: drift <command> [options]
 
@@ -30,6 +43,7 @@ commands:
   dht       Run a standalone DHT bootstrap peer
   api       Serve an OpenAI-compatible HTTP API backed by the swarm (requires drift[api])
   node      Run a persistent authenticated localhost gateway (requires drift[api])
+  bootstrap Install a threshold-signed catalog as a first-run node configuration
   edge-benchmark
             Measure manifested client storage, memory, and generation latency (requires drift[benchmark])
   manifest  Validate and inspect a content-addressed ModelManifest v1
@@ -63,6 +77,8 @@ def main() -> int:
         from drift.cli.run_api import main as run
     elif command == "node":
         from drift.cli.run_node import main as run
+    elif command == "bootstrap":
+        from drift.cli.run_bootstrap import main as run
     elif command == "edge-benchmark":
         from drift.cli.run_edge_benchmark import main as run
     elif command == "manifest":

--- a/src/drift/cli/run_bootstrap.py
+++ b/src/drift/cli/run_bootstrap.py
@@ -1,0 +1,35 @@
+"""Provision a first-install node config from a threshold-signed model catalog."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from drift.node.catalog_bootstrap import CatalogBootstrapError, bootstrap_node_from_catalog
+
+DEFAULT_NODE_DATA_DIR = Path.home() / ".drift" / "node"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="drift bootstrap",
+        description="Install a verified signed catalog as a first-run node configuration",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("bootstrap_config", type=Path, help="Trusted release bootstrap JSON")
+    parser.add_argument("--data_dir", type=Path, default=DEFAULT_NODE_DATA_DIR)
+    parser.add_argument("--node_config", type=Path, help="Generated NodeConfig v1 path")
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+    data_dir = args.data_dir.expanduser().resolve()
+    config_path = (args.node_config or data_dir / "node-config.json").expanduser().resolve()
+    try:
+        result = bootstrap_node_from_catalog(args.bootstrap_config, data_dir=data_dir, config_path=config_path)
+    except CatalogBootstrapError as exc:
+        parser.error(str(exc))
+    print(json.dumps(result.to_dict(), sort_keys=True))

--- a/src/drift/cli/run_catalog.py
+++ b/src/drift/cli/run_catalog.py
@@ -22,6 +22,7 @@ from drift.model_catalog import (
     SignedModelCatalog,
     _load_strict_json,
 )
+from drift.node.catalog_bootstrap import CatalogBootstrapConfig, CatalogBootstrapError
 
 
 def _write_json(path: str, value: Mapping[str, Any], *, force: bool) -> None:
@@ -109,6 +110,20 @@ def build_parser() -> argparse.ArgumentParser:
     sign.add_argument("--output", required=True)
     sign.add_argument("--force", action="store_true")
 
+    bootstrap = commands.add_parser(
+        "bootstrap-config", help="Build the trusted release input for first-install catalog fetching"
+    )
+    bootstrap.add_argument("--root", required=True, help="Catalog trust-root JSON")
+    bootstrap.add_argument(
+        "--catalog-mirror", action="append", required=True, help="HTTPS signed-catalog URL; repeat for mirrors"
+    )
+    bootstrap.add_argument(
+        "--initial-peer", action="append", required=True, help="Public libp2p seed multiaddress; repeat for seeds"
+    )
+    bootstrap.add_argument("--max-loaded-models", type=int, default=1)
+    bootstrap.add_argument("--output", required=True)
+    bootstrap.add_argument("--force", action="store_true")
+
     verify = commands.add_parser("verify", help="Verify signatures, expiry, and optional rollback state")
     verify.add_argument("catalog")
     verify.add_argument("--root", required=True)
@@ -168,6 +183,19 @@ def main() -> None:
             envelope = envelope.add_signature(CatalogSigningKey.load(args.key))
             _write_json(args.output, envelope.to_dict(), force=args.force)
             _write_status(f"signed catalog sequence {envelope.signed.sequence}", json_output=args.output)
+        elif args.catalog_command == "bootstrap-config":
+            _require_distinct_paths(("trust root", args.root), ("bootstrap output", args.output))
+            bootstrap = CatalogBootstrapConfig.from_dict(
+                {
+                    "schema_version": 1,
+                    "trust_root": CatalogTrustRoot.load(args.root).to_dict(),
+                    "catalog_mirrors": args.catalog_mirror,
+                    "initial_peers": args.initial_peer,
+                    "max_loaded_models": args.max_loaded_models,
+                }
+            )
+            _write_json(args.output, bootstrap.to_dict(), force=args.force)
+            _write_status(f"created catalog bootstrap for {bootstrap.trust_root.catalog_id}", json_output=args.output)
         else:
             if args.state:
                 _require_distinct_paths(
@@ -183,7 +211,7 @@ def main() -> None:
                 f"valid catalog {catalog.catalog_id} sequence {catalog.sequence}: "
                 f"{len(catalog.rungs)} rung(s), {len(catalog.models)} model(s), digest {catalog.digest}"
             )
-    except ModelCatalogError as exc:
+    except (ModelCatalogError, CatalogBootstrapError) as exc:
         parser.error(str(exc))
 
 

--- a/src/drift/cli/run_node.py
+++ b/src/drift/cli/run_node.py
@@ -7,8 +7,6 @@ import math
 import sys
 from pathlib import Path
 
-from hivemind.utils.logging import get_logger, use_hivemind_log_handler
-
 import drift
 from drift.model_manifest import ManifestError, ModelManifest
 from drift.node.config import NODE_CONFIG_SCHEMA_VERSION, NodeConfig, NodeConfigError, NodeModelConfig
@@ -24,6 +22,7 @@ from drift.node.native_credentials import (
 )
 from drift.node.worker_supervisor import WorkerLaunch, WorkerSupervisor
 from drift.utils.process_lifetime import tie_child_processes_to_this_process
+from hivemind.utils.logging import get_logger, use_hivemind_log_handler
 
 use_hivemind_log_handler("in_root_logger")
 logger = get_logger(__name__)
@@ -238,11 +237,14 @@ def _build_worker_supervisor(
         if worker.public_ip is not None and worker.port is None:
             raise NodeConfigError(f"worker {worker.worker_id!r} public_ip requires port")
 
+        if getattr(sys, "frozen", False):
+            # desktop/launch_node.py dispatches this mode inside the packaged
+            # sidecar; a frozen executable cannot be reinvoked with ``-m``.
+            server_command = [sys.executable, "server"]
+        else:
+            server_command = [sys.executable, "-m", "drift.cli", "server"]
         command = [
-            sys.executable,
-            "-m",
-            "drift.cli",
-            "server",
+            *server_command,
             manifest.source.repository,
             "--model_manifest",
             str(model_config.manifest_path),
@@ -340,7 +342,6 @@ def main() -> None:
 
     try:
         import uvicorn
-
         from drift.node.server import create_node_app
     except ImportError as exc:
         raise SystemExit(f"drift node requires the 'api' extra: pip install drift[api] ({exc})") from exc

--- a/src/drift/cli/run_node.py
+++ b/src/drift/cli/run_node.py
@@ -7,6 +7,8 @@ import math
 import sys
 from pathlib import Path
 
+from hivemind.utils.logging import get_logger, use_hivemind_log_handler
+
 import drift
 from drift.model_manifest import ManifestError, ModelManifest
 from drift.node.config import NODE_CONFIG_SCHEMA_VERSION, NodeConfig, NodeConfigError, NodeModelConfig
@@ -22,7 +24,6 @@ from drift.node.native_credentials import (
 )
 from drift.node.worker_supervisor import WorkerLaunch, WorkerSupervisor
 from drift.utils.process_lifetime import tie_child_processes_to_this_process
-from hivemind.utils.logging import get_logger, use_hivemind_log_handler
 
 use_hivemind_log_handler("in_root_logger")
 logger = get_logger(__name__)
@@ -342,6 +343,7 @@ def main() -> None:
 
     try:
         import uvicorn
+
         from drift.node.server import create_node_app
     except ImportError as exc:
         raise SystemExit(f"drift node requires the 'api' extra: pip install drift[api] ({exc})") from exc

--- a/src/drift/node/catalog_bootstrap.py
+++ b/src/drift/node/catalog_bootstrap.py
@@ -1,0 +1,497 @@
+"""Install a verified model catalog as a first-run local-node configuration.
+
+The desktop deliberately does not parse catalogs or model manifests.  It invokes
+this module inside the standalone node runtime, where the catalog trust root and
+manifest implementation already live.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import secrets
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Dict, Mapping, Optional, Tuple
+from urllib.parse import urlsplit
+
+from drift.model_catalog import (
+    CatalogRollbackGuard,
+    CatalogTrustRoot,
+    ModelCatalog,
+    ModelCatalogError,
+    SignedModelCatalog,
+)
+from drift.model_manifest import ManifestError, ModelManifest
+from drift.node.config import NODE_CONFIG_SCHEMA_VERSION, NodeConfig, NodeConfigError
+
+CATALOG_BOOTSTRAP_SCHEMA_VERSION = 1
+MAX_CATALOG_BYTES = 4 * 1024 * 1024
+MAX_MANIFEST_BYTES = 8 * 1024 * 1024
+DEFAULT_FETCH_TIMEOUT = (5.0, 20.0)
+
+
+class CatalogBootstrapError(RuntimeError):
+    """A first-install catalog could not be authenticated and installed."""
+
+
+def _absolute_path(path: Path | str) -> Path:
+    """Make a path absolute without following its final symbolic link."""
+    return Path(os.path.abspath(os.fspath(Path(path).expanduser())))
+
+
+def _require_mapping(value: Any, field: str) -> Mapping[str, Any]:
+    if not isinstance(value, dict):
+        raise CatalogBootstrapError(f"{field} must be a JSON object")
+    return value
+
+
+def _require_fields(
+    value: Mapping[str, Any], field: str, *, required: Tuple[str, ...], optional: Tuple[str, ...] = ()
+) -> None:
+    actual = set(value)
+    missing = set(required) - actual
+    unknown = actual - set(required) - set(optional)
+    if missing:
+        raise CatalogBootstrapError(f"{field} is missing required field(s): {', '.join(sorted(missing))}")
+    if unknown:
+        raise CatalogBootstrapError(f"{field} has unknown field(s): {', '.join(sorted(unknown))}")
+
+
+def _require_positive_int(value: Any, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise CatalogBootstrapError(f"{field} must be an integer >= 1")
+    return value
+
+
+def _require_string_list(value: Any, field: str) -> Tuple[str, ...]:
+    if not isinstance(value, list) or not value:
+        raise CatalogBootstrapError(f"{field} must be a non-empty JSON array")
+    result = []
+    for index, item in enumerate(value):
+        if not isinstance(item, str) or not item.strip():
+            raise CatalogBootstrapError(f"{field}[{index}] must be a non-empty string")
+        result.append(item)
+    if len(set(result)) != len(result):
+        raise CatalogBootstrapError(f"{field} must not contain duplicates")
+    return tuple(result)
+
+
+def _require_https_urls(value: Any, field: str) -> Tuple[str, ...]:
+    result = _require_string_list(value, field)
+    for index, url in enumerate(result):
+        parsed = urlsplit(url)
+        if (
+            parsed.scheme != "https"
+            or not parsed.netloc
+            or parsed.username
+            or parsed.password
+            or parsed.query
+            or parsed.fragment
+        ):
+            raise CatalogBootstrapError(
+                f"{field}[{index}] must be an absolute HTTPS URL without credentials, query, or fragment"
+            )
+    return result
+
+
+def _require_initial_peers(value: Any) -> Tuple[str, ...]:
+    peers = _require_string_list(value, "initial_peers")
+    for index, peer in enumerate(peers):
+        if len(peer) > 2048 or not peer.startswith("/") or "/p2p/" not in peer:
+            raise CatalogBootstrapError(f"initial_peers[{index}] must be a bounded libp2p multiaddress")
+        if any(character in peer for character in "\r\n\x00"):
+            raise CatalogBootstrapError(f"initial_peers[{index}] contains a forbidden control character")
+    return peers
+
+
+def _load_strict_json(source: str, *, field: str) -> Mapping[str, Any]:
+    def reject_duplicate_keys(pairs):
+        result = {}
+        for key, value in pairs:
+            if key in result:
+                raise CatalogBootstrapError(f"{field} contains duplicate object key {key!r}")
+            result[key] = value
+        return result
+
+    def reject_non_finite(value):
+        raise CatalogBootstrapError(f"{field} contains non-finite number {value}")
+
+    try:
+        value = json.loads(source, object_pairs_hook=reject_duplicate_keys, parse_constant=reject_non_finite)
+    except json.JSONDecodeError as exc:
+        raise CatalogBootstrapError(f"Invalid {field} JSON: {exc}") from exc
+    return _require_mapping(value, field)
+
+
+@dataclass(frozen=True)
+class CatalogBootstrapConfig:
+    """Immutable release inputs used to establish first-install trust and discovery."""
+
+    schema_version: int
+    trust_root: CatalogTrustRoot
+    catalog_mirrors: Tuple[str, ...]
+    initial_peers: Tuple[str, ...]
+    max_loaded_models: int = 1
+
+    @classmethod
+    def from_dict(cls, source: Mapping[str, Any]) -> "CatalogBootstrapConfig":
+        source = _require_mapping(source, "catalog bootstrap config")
+        _require_fields(
+            source,
+            "catalog bootstrap config",
+            required=("schema_version", "trust_root", "catalog_mirrors", "initial_peers"),
+            optional=("max_loaded_models",),
+        )
+        schema_version = _require_positive_int(source["schema_version"], "schema_version")
+        if schema_version != CATALOG_BOOTSTRAP_SCHEMA_VERSION:
+            raise CatalogBootstrapError(
+                f"Unsupported catalog bootstrap schema version {schema_version}; "
+                f"expected {CATALOG_BOOTSTRAP_SCHEMA_VERSION}"
+            )
+        try:
+            trust_root = CatalogTrustRoot.from_dict(_require_mapping(source["trust_root"], "trust_root"))
+        except ModelCatalogError as exc:
+            raise CatalogBootstrapError(f"Invalid catalog trust root: {exc}") from exc
+        return cls(
+            schema_version=schema_version,
+            trust_root=trust_root,
+            catalog_mirrors=_require_https_urls(source["catalog_mirrors"], "catalog_mirrors"),
+            initial_peers=_require_initial_peers(source["initial_peers"]),
+            max_loaded_models=_require_positive_int(source.get("max_loaded_models", 1), "max_loaded_models"),
+        )
+
+    @classmethod
+    def from_json(cls, source: str) -> "CatalogBootstrapConfig":
+        return cls.from_dict(_load_strict_json(source, field="catalog bootstrap config"))
+
+    @classmethod
+    def load(cls, path: Path | str) -> "CatalogBootstrapConfig":
+        resolved = _absolute_path(path)
+        if not resolved.is_file() or resolved.is_symlink():
+            raise CatalogBootstrapError(f"Catalog bootstrap config is missing or unsafe: {resolved}")
+        try:
+            source = resolved.read_text(encoding="utf-8")
+        except (OSError, UnicodeError) as exc:
+            raise CatalogBootstrapError(f"Could not read catalog bootstrap config {resolved}: {exc}") from exc
+        return cls.from_json(source)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "trust_root": self.trust_root.to_dict(),
+            "catalog_mirrors": list(self.catalog_mirrors),
+            "initial_peers": list(self.initial_peers),
+            "max_loaded_models": self.max_loaded_models,
+        }
+
+
+@dataclass(frozen=True)
+class CatalogBootstrapResult:
+    config_path: Path
+    catalog_id: str
+    catalog_sequence: int
+    catalog_digest: str
+    model_count: int
+    source: str
+    created: bool
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "schema_version": 1,
+            "config_path": str(self.config_path),
+            "catalog_id": self.catalog_id,
+            "catalog_sequence": self.catalog_sequence,
+            "catalog_digest": self.catalog_digest,
+            "model_count": self.model_count,
+            "source": self.source,
+            "created": self.created,
+        }
+
+
+FetchText = Callable[[str, int], str]
+
+
+def _fetch_https_text(url: str, maximum_bytes: int) -> str:
+    """Fetch one bounded HTTPS document without redirects or environment proxies."""
+    try:
+        import requests
+    except ImportError as exc:  # pragma: no cover - root runtime always declares requests
+        raise CatalogBootstrapError("The node runtime is missing its HTTPS client") from exc
+
+    session = requests.Session()
+    session.trust_env = False
+    try:
+        response = session.get(
+            url,
+            allow_redirects=False,
+            stream=True,
+            timeout=DEFAULT_FETCH_TIMEOUT,
+            headers={"Accept": "application/json", "User-Agent": "CommunityAI-Node/catalog-bootstrap-v1"},
+        )
+        if response.status_code != 200:
+            raise CatalogBootstrapError(f"HTTPS fetch returned status {response.status_code} for {url}")
+        content_length = response.headers.get("Content-Length")
+        if content_length is not None:
+            try:
+                declared_length = int(content_length)
+            except ValueError as exc:
+                raise CatalogBootstrapError(f"HTTPS response has an invalid Content-Length for {url}") from exc
+            if declared_length < 0 or declared_length > maximum_bytes:
+                raise CatalogBootstrapError(f"HTTPS response exceeds the size limit for {url}")
+        body = bytearray()
+        for chunk in response.iter_content(chunk_size=64 * 1024):
+            body.extend(chunk)
+            if len(body) > maximum_bytes:
+                raise CatalogBootstrapError(f"HTTPS response exceeds the size limit for {url}")
+        try:
+            return bytes(body).decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise CatalogBootstrapError(f"HTTPS response is not UTF-8 JSON for {url}") from exc
+    except requests.RequestException as exc:
+        raise CatalogBootstrapError(f"HTTPS fetch failed for {url}: {exc}") from exc
+    finally:
+        session.close()
+
+
+def _atomic_write(path: Path, text: str, *, overwrite: bool) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.{secrets.token_hex(4)}.tmp")
+    try:
+        with temporary.open("x", encoding="utf-8", newline="\n") as stream:
+            stream.write(text)
+        try:
+            temporary.chmod(0o600)
+        except OSError:
+            pass
+        if not overwrite and (path.exists() or path.is_symlink()):
+            raise CatalogBootstrapError(f"Refusing to replace existing first-install file {path}")
+        os.replace(temporary, path)
+    except CatalogBootstrapError:
+        raise
+    except OSError as exc:
+        raise CatalogBootstrapError(f"Could not write first-install file {path}: {exc}") from exc
+    finally:
+        try:
+            temporary.unlink()
+        except FileNotFoundError:
+            pass
+
+
+class CatalogBootstrapInstaller:
+    """Fetch, authenticate, cache, and atomically activate a first-install catalog."""
+
+    def __init__(
+        self,
+        bootstrap: CatalogBootstrapConfig,
+        *,
+        data_dir: Path | str,
+        config_path: Path | str,
+        fetch_text: FetchText = _fetch_https_text,
+        now: Optional[float] = None,
+    ) -> None:
+        self.bootstrap = bootstrap
+        self.data_dir = Path(data_dir).expanduser().resolve()
+        self.config_path = _absolute_path(config_path)
+        self.fetch_text = fetch_text
+        self.now = now
+        self.catalog_dir = self.data_dir / "catalogs" / bootstrap.trust_root.catalog_id
+        self.cached_catalog_path = self.catalog_dir / "catalog.signed.json"
+        self.rollback_path = self.catalog_dir / "rollback-state.json"
+        self.manifest_dir = self.data_dir / "manifests"
+        self.cache_dir = self.data_dir / "model-cache"
+        self.lock_path = self.data_dir / ".catalog-bootstrap.lock"
+
+    def _existing_result(self) -> CatalogBootstrapResult:
+        try:
+            config = NodeConfig.load(self.config_path)
+        except NodeConfigError as exc:
+            raise CatalogBootstrapError(f"Existing node configuration is invalid: {exc}") from exc
+        return CatalogBootstrapResult(
+            config_path=self.config_path,
+            catalog_id=self.bootstrap.trust_root.catalog_id,
+            catalog_sequence=0,
+            catalog_digest="",
+            model_count=len(config.models),
+            source="existing-config",
+            created=False,
+        )
+
+    def _load_catalog(self, source: str, rendered: str, guard: CatalogRollbackGuard) -> ModelCatalog:
+        try:
+            envelope = SignedModelCatalog.from_json(rendered)
+            return envelope.verify(self.bootstrap.trust_root, now=self.now, rollback_guard=guard)
+        except ModelCatalogError as exc:
+            raise CatalogBootstrapError(f"Rejected model catalog from {source}: {exc}") from exc
+
+    def _install_manifests(self, catalog: ModelCatalog) -> Tuple[Path, ...]:
+        installed = []
+        selectors: Dict[str, str] = {}
+        for model in catalog.models:
+            errors = []
+            manifest = None
+            expected_path = self.manifest_dir / f"{model.manifest_digest.removeprefix('sha256:')}.json"
+            if expected_path.is_file() and not expected_path.is_symlink():
+                try:
+                    candidate = ModelManifest.load(expected_path)
+                    if candidate.digest_id != model.manifest_digest:
+                        raise CatalogBootstrapError(
+                            f"cached manifest digest {candidate.digest_id} does not match {model.manifest_digest}"
+                        )
+                    manifest = candidate
+                except (CatalogBootstrapError, ManifestError) as exc:
+                    errors.append(str(exc))
+            for url in model.manifest_urls:
+                if manifest is not None:
+                    break
+                try:
+                    candidate = ModelManifest.from_json(self.fetch_text(url, MAX_MANIFEST_BYTES))
+                    if candidate.digest_id != model.manifest_digest:
+                        raise CatalogBootstrapError(
+                            f"manifest digest {candidate.digest_id} does not match catalog digest {model.manifest_digest}"
+                        )
+                    manifest = candidate
+                    break
+                except (CatalogBootstrapError, ManifestError) as exc:
+                    errors.append(str(exc))
+            if manifest is None:
+                detail = "; ".join(errors) if errors else "no manifest mirror was attempted"
+                raise CatalogBootstrapError(f"Could not install manifest {model.manifest_digest}: {detail}")
+
+            for selector in (manifest.name, *manifest.aliases):
+                folded = selector.casefold()
+                previous = selectors.get(folded)
+                if previous is not None and previous != manifest.digest_id:
+                    raise CatalogBootstrapError(
+                        f"Catalog manifests reuse model selector {selector!r} across different digests"
+                    )
+                selectors[folded] = manifest.digest_id
+
+            path = self.manifest_dir / f"{manifest.digest}.json"
+            _atomic_write(path, manifest.canonical_json() + "\n", overwrite=True)
+            installed.append(path)
+        return tuple(installed)
+
+    def _render_node_config(self, manifest_paths: Tuple[Path, ...]) -> str:
+        models = []
+        for path in manifest_paths:
+            digest = path.stem
+            models.append(
+                {
+                    "manifest": str(path),
+                    "initial_peers": list(self.bootstrap.initial_peers),
+                    "cache_dir": str(self.cache_dir / digest),
+                }
+            )
+        source = {
+            "schema_version": NODE_CONFIG_SCHEMA_VERSION,
+            "max_loaded_models": self.bootstrap.max_loaded_models,
+            "models": models,
+            "workers": [],
+        }
+        try:
+            NodeConfig.from_dict(source, base_dir=self.config_path.parent)
+        except NodeConfigError as exc:  # pragma: no cover - defensive invariant
+            raise CatalogBootstrapError(f"Generated node configuration is invalid: {exc}") from exc
+        return json.dumps(source, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+
+    def _try_candidate(
+        self, source: str, rendered: str, persisted_guard: CatalogRollbackGuard
+    ) -> CatalogBootstrapResult:
+        guard = CatalogRollbackGuard.from_dict(persisted_guard.to_dict())
+        catalog = self._load_catalog(source, rendered, guard)
+        manifest_paths = self._install_manifests(catalog)
+        config_text = self._render_node_config(manifest_paths)
+
+        _atomic_write(
+            self.cached_catalog_path,
+            json.dumps(SignedModelCatalog.from_json(rendered).to_dict(), ensure_ascii=False, indent=2, sort_keys=True)
+            + "\n",
+            overwrite=True,
+        )
+        guard.save(self.rollback_path)
+        _atomic_write(self.config_path, config_text, overwrite=False)
+        return CatalogBootstrapResult(
+            config_path=self.config_path,
+            catalog_id=catalog.catalog_id,
+            catalog_sequence=catalog.sequence,
+            catalog_digest=catalog.digest,
+            model_count=len(manifest_paths),
+            source=source,
+            created=True,
+        )
+
+    def install(self) -> CatalogBootstrapResult:
+        if self.config_path.is_symlink():
+            raise CatalogBootstrapError(f"Refusing unsafe node configuration symlink {self.config_path}")
+        if self.config_path.is_file():
+            return self._existing_result()
+
+        self.data_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            descriptor = os.open(self.lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+        except FileExistsError as exc:
+            raise CatalogBootstrapError("Another first-install catalog bootstrap is already in progress") from exc
+        except OSError as exc:
+            raise CatalogBootstrapError(f"Could not lock catalog bootstrap in {self.data_dir}: {exc}") from exc
+
+        os.close(descriptor)
+        try:
+            if self.config_path.is_file() and not self.config_path.is_symlink():
+                return self._existing_result()
+            try:
+                persisted_guard = CatalogRollbackGuard.load(self.rollback_path)
+            except ModelCatalogError as exc:
+                raise CatalogBootstrapError(f"Could not load catalog rollback protection: {exc}") from exc
+
+            errors = []
+            for url in self.bootstrap.catalog_mirrors:
+                try:
+                    rendered = self.fetch_text(url, MAX_CATALOG_BYTES)
+                    return self._try_candidate(url, rendered, persisted_guard)
+                except CatalogBootstrapError as exc:
+                    errors.append(str(exc))
+                    # _try_candidate persists rollback state before activating the
+                    # node config. Reload it before considering another mirror so
+                    # an activation I/O failure can never enable a downgrade.
+                    try:
+                        persisted_guard = CatalogRollbackGuard.load(self.rollback_path)
+                    except ModelCatalogError as guard_exc:
+                        raise CatalogBootstrapError(
+                            f"Could not reload catalog rollback protection: {guard_exc}"
+                        ) from guard_exc
+            if self.cached_catalog_path.is_file() and not self.cached_catalog_path.is_symlink():
+                try:
+                    rendered = self.cached_catalog_path.read_text(encoding="utf-8")
+                    return self._try_candidate(
+                        "last-known-good cache",
+                        rendered,
+                        persisted_guard,
+                    )
+                except (OSError, UnicodeError, CatalogBootstrapError) as exc:
+                    errors.append(f"Could not use last-known-good catalog: {exc}")
+            detail = "; ".join(errors) if errors else "no catalog source was available"
+            raise CatalogBootstrapError(f"No trusted usable model catalog could be installed: {detail}")
+        finally:
+            try:
+                self.lock_path.unlink()
+            except FileNotFoundError:
+                pass
+
+
+def bootstrap_node_from_catalog(
+    bootstrap_config: Path | str,
+    *,
+    data_dir: Path | str,
+    config_path: Path | str,
+    fetch_text: FetchText = _fetch_https_text,
+    now: Optional[float] = None,
+) -> CatalogBootstrapResult:
+    bootstrap = CatalogBootstrapConfig.load(bootstrap_config)
+    return CatalogBootstrapInstaller(
+        bootstrap,
+        data_dir=data_dir,
+        config_path=config_path,
+        fetch_text=fetch_text,
+        now=now,
+    ).install()

--- a/src/drift/server/from_pretrained.py
+++ b/src/drift/server/from_pretrained.py
@@ -331,6 +331,16 @@ def _load_state_dict_from_local_file(path: str, *, block_prefix: Optional[str] =
 
     if path.endswith(".safetensors"):
         with safetensors.safe_open(path, framework="pt", device="cpu") as f:
-            return {key: f.get_tensor(key) for key in f.keys() if block_prefix is None or key.startswith(block_prefix)}
+            # ``get_tensor`` returns a view backed by the file mapping. A manifested worker loads one
+            # block at a time, so retaining those views can retain one mapping of the complete shard
+            # per block. Large same-dtype checkpoints exhausted Windows commit/virtual memory long
+            # before their actual selected block tensors filled RAM. Copy only the selected tensors
+            # while the mapping is open; the caller then owns ordinary CPU storage and the complete
+            # shard mapping can close before the next block is loaded.
+            return {
+                key: f.get_tensor(key).clone()
+                for key in f.keys()
+                if block_prefix is None or key.startswith(block_prefix)
+            }
 
     raise ValueError(f"Unknown weight format: {path}")

--- a/tests/test_catalog_bootstrap.py
+++ b/tests/test_catalog_bootstrap.py
@@ -1,0 +1,253 @@
+import json
+
+import pytest
+
+from drift.model_catalog import CATALOG_SCHEMA_VERSION, CatalogSigningKey, ModelCatalog, SignedModelCatalog
+from drift.model_manifest import ModelManifest
+from drift.node.catalog_bootstrap import (
+    MAX_CATALOG_BYTES,
+    MAX_MANIFEST_BYTES,
+    CatalogBootstrapConfig,
+    CatalogBootstrapError,
+    bootstrap_node_from_catalog,
+)
+from drift.node.config import NodeConfig
+
+NOW = 2_000_000_000.0
+PEER = "/dns4/bootstrap.communityai.example/tcp/31337/p2p/QmBootstrap"
+
+
+def _manifest(name: str, alias: str) -> ModelManifest:
+    source = ModelManifest.load("tests/data/model_manifest_v1_vector.json").to_dict()
+    source["name"] = name
+    source["aliases"] = [alias]
+    return ModelManifest.from_dict(source)
+
+
+def _rung() -> dict:
+    return {
+        "id": "1-2b",
+        "order": 1,
+        "minimum_replicas": 2,
+        "minimum_independent_routes": 2,
+        "minimum_surviving_replicas": 1,
+        "minimum_soak_seconds": 60,
+        "maximum_observation_age_seconds": 30,
+        "maximum_p95_first_token_ms": 2_000,
+        "minimum_tokens_per_minute": 60,
+    }
+
+
+def _release_documents(*, sequence: int = 1):
+    primary = _manifest("Primary Test", "primary-test")
+    standby = _manifest("Standby Test", "standby-test")
+    models = []
+    manifest_documents = {}
+    for role, manifest in (("primary", primary), ("standby", standby)):
+        url = f"https://models.example/{manifest.digest}.json"
+        manifest_documents[url] = manifest.canonical_json()
+        models.append(
+            {
+                "manifest_digest": manifest.digest_id,
+                "manifest_urls": [url],
+                "rung": "1-2b",
+                "role": role,
+                "total_parameters": 1_000_000_000,
+                "active_parameters": 1_000_000_000,
+                "weight_bytes": 2_000_000_000,
+            }
+        )
+    catalog = ModelCatalog.from_dict(
+        {
+            "catalog_id": "communityai-test",
+            "sequence": sequence,
+            "issued_at_ms": int((NOW - 60) * 1000),
+            "expires_at_ms": int((NOW + 3600) * 1000),
+            "rungs": [_rung()],
+            "models": models,
+        }
+    )
+    key = CatalogSigningKey.generate()
+    envelope = SignedModelCatalog(CATALOG_SCHEMA_VERSION, catalog, ()).add_signature(key)
+    bootstrap = {
+        "schema_version": 1,
+        "trust_root": {
+            "schema_version": 1,
+            "catalog_id": catalog.catalog_id,
+            "threshold": 1,
+            "keys": [key.trusted_key.to_dict()],
+        },
+        "catalog_mirrors": ["https://catalog-one.example/catalog.json", "https://catalog-two.example/catalog.json"],
+        "initial_peers": [PEER],
+        "max_loaded_models": 1,
+    }
+    return bootstrap, envelope, manifest_documents
+
+
+def _write_bootstrap(tmp_path, source) -> object:
+    path = tmp_path / "bootstrap.json"
+    path.write_text(json.dumps(source), encoding="utf-8")
+    return path
+
+
+def test_bootstrap_installs_verified_manifests_and_atomic_node_config(tmp_path):
+    bootstrap, envelope, manifests = _release_documents()
+    bootstrap_path = _write_bootstrap(tmp_path, bootstrap)
+    catalog_text = json.dumps(envelope.to_dict())
+    calls = []
+
+    def fetch(url, maximum_bytes):
+        calls.append((url, maximum_bytes))
+        if url == bootstrap["catalog_mirrors"][0]:
+            raise CatalogBootstrapError("first mirror unavailable")
+        if url == bootstrap["catalog_mirrors"][1]:
+            return catalog_text
+        return manifests[url]
+
+    data_dir = tmp_path / "data"
+    config_path = data_dir / "node-config.json"
+    result = bootstrap_node_from_catalog(
+        bootstrap_path,
+        data_dir=data_dir,
+        config_path=config_path,
+        fetch_text=fetch,
+        now=NOW,
+    )
+
+    assert result.created is True
+    assert result.catalog_sequence == 1
+    assert result.model_count == 2
+    assert result.source == bootstrap["catalog_mirrors"][1]
+    config = NodeConfig.load(config_path)
+    assert len(config.models) == 2
+    assert all(model.initial_peers == (PEER,) for model in config.models)
+    assert all(model.manifest_path.parent == (data_dir / "manifests").resolve() for model in config.models)
+    assert (data_dir / "catalogs" / "communityai-test" / "catalog.signed.json").is_file()
+    assert (data_dir / "catalogs" / "communityai-test" / "rollback-state.json").is_file()
+    assert calls[0] == (bootstrap["catalog_mirrors"][0], MAX_CATALOG_BYTES)
+    assert any(limit == MAX_MANIFEST_BYTES for _, limit in calls)
+    assert not (data_dir / ".catalog-bootstrap.lock").exists()
+
+
+def test_existing_config_is_preserved_without_network_access(tmp_path):
+    bootstrap, _, _ = _release_documents()
+    bootstrap_path = _write_bootstrap(tmp_path, bootstrap)
+    config_path = tmp_path / "node-config.json"
+    existing = {
+        "schema_version": 1,
+        "models": [{"manifest": "existing.json", "initial_peers": [PEER]}],
+    }
+    rendered = json.dumps(existing) + "\n"
+    config_path.write_text(rendered, encoding="utf-8")
+
+    result = bootstrap_node_from_catalog(
+        bootstrap_path,
+        data_dir=tmp_path / "data",
+        config_path=config_path,
+        fetch_text=lambda *_: pytest.fail("existing config must not fetch"),
+        now=NOW,
+    )
+
+    assert result.created is False
+    assert result.source == "existing-config"
+    assert config_path.read_text(encoding="utf-8") == rendered
+
+
+def test_bootstrap_refuses_symbolic_link_inputs_and_activation_targets(tmp_path):
+    bootstrap, _, _ = _release_documents()
+    real_bootstrap = _write_bootstrap(tmp_path, bootstrap)
+    linked_bootstrap = tmp_path / "linked-bootstrap.json"
+    try:
+        linked_bootstrap.symlink_to(real_bootstrap)
+    except OSError:
+        pytest.skip("symbolic links are unavailable on this test host")
+
+    with pytest.raises(CatalogBootstrapError, match="missing or unsafe"):
+        CatalogBootstrapConfig.load(linked_bootstrap)
+
+    real_config = tmp_path / "real-node-config.json"
+    real_config.write_text("{}\n", encoding="utf-8")
+    linked_config = tmp_path / "linked-node-config.json"
+    linked_config.symlink_to(real_config)
+    with pytest.raises(CatalogBootstrapError, match="configuration symlink"):
+        bootstrap_node_from_catalog(
+            real_bootstrap,
+            data_dir=tmp_path / "data",
+            config_path=linked_config,
+            fetch_text=lambda *_: pytest.fail("unsafe target must not fetch"),
+            now=NOW,
+        )
+
+
+def test_last_known_good_catalog_and_manifests_support_offline_reprovision(tmp_path):
+    bootstrap, envelope, manifests = _release_documents()
+    bootstrap_path = _write_bootstrap(tmp_path, bootstrap)
+    catalog_text = json.dumps(envelope.to_dict())
+
+    def online_fetch(url, _maximum_bytes):
+        if url in bootstrap["catalog_mirrors"]:
+            return catalog_text
+        return manifests[url]
+
+    data_dir = tmp_path / "data"
+    config_path = data_dir / "node-config.json"
+    bootstrap_node_from_catalog(
+        bootstrap_path, data_dir=data_dir, config_path=config_path, fetch_text=online_fetch, now=NOW
+    )
+    config_path.unlink()
+
+    result = bootstrap_node_from_catalog(
+        bootstrap_path,
+        data_dir=data_dir,
+        config_path=config_path,
+        fetch_text=lambda *_: (_ for _ in ()).throw(CatalogBootstrapError("offline")),
+        now=NOW,
+    )
+
+    assert result.created is True
+    assert result.source == "last-known-good cache"
+    assert NodeConfig.load(config_path).models
+
+
+def test_tampered_catalog_and_wrong_manifest_digest_fail_without_activation(tmp_path):
+    bootstrap, envelope, manifests = _release_documents()
+    bootstrap["catalog_mirrors"] = [bootstrap["catalog_mirrors"][0]]
+    bootstrap_path = _write_bootstrap(tmp_path, bootstrap)
+    tampered = envelope.to_dict()
+    tampered["signed"]["models"][0]["weight_bytes"] += 1
+    config_path = tmp_path / "data" / "node-config.json"
+
+    with pytest.raises(CatalogBootstrapError, match="No trusted usable.*signature"):
+        bootstrap_node_from_catalog(
+            bootstrap_path,
+            data_dir=tmp_path / "data",
+            config_path=config_path,
+            fetch_text=lambda url, _: json.dumps(tampered) if "catalog" in url else manifests[url],
+            now=NOW,
+        )
+    assert not config_path.exists()
+
+    wrong_manifest = _manifest("Wrong Model", "wrong-model").canonical_json()
+    with pytest.raises(CatalogBootstrapError, match="does not match catalog digest"):
+        bootstrap_node_from_catalog(
+            bootstrap_path,
+            data_dir=tmp_path / "other-data",
+            config_path=tmp_path / "other-data" / "node-config.json",
+            fetch_text=lambda url, _: json.dumps(envelope.to_dict()) if "catalog" in url else wrong_manifest,
+            now=NOW,
+        )
+
+
+@pytest.mark.parametrize(
+    "mutation, message",
+    [
+        (lambda value: value.update({"unknown": True}), "unknown field"),
+        (lambda value: value.update({"catalog_mirrors": ["http://unsafe.example/catalog"]}), "HTTPS"),
+        (lambda value: value.update({"initial_peers": ["not-a-multiaddr"]}), "multiaddress"),
+    ],
+)
+def test_bootstrap_config_is_strict(mutation, message):
+    bootstrap, _, _ = _release_documents()
+    mutation(bootstrap)
+    with pytest.raises(CatalogBootstrapError, match=message):
+        CatalogBootstrapConfig.from_dict(bootstrap)

--- a/tests/test_loading_diagnostics.py
+++ b/tests/test_loading_diagnostics.py
@@ -4,7 +4,7 @@ import torch
 from torch import nn
 
 from drift.client.lm_head import LMHead
-from drift.server.from_pretrained import _find_unconsumed_checkpoint_keys
+from drift.server.from_pretrained import _find_unconsumed_checkpoint_keys, _load_state_dict_from_local_file
 from drift.utils.asyncio import patch_hivemind_task_cleanup, safe_cancel_task_if_running
 
 
@@ -24,6 +24,37 @@ def test_legacy_rotary_frequency_is_derived_but_other_state_stays_strict():
         "mystery_scale",
         "self_attn.rotary_emb.trained_scale",
     ]
+
+
+def test_safetensors_block_load_copies_selected_tensors_out_of_the_file_mapping(monkeypatch):
+    selected = torch.arange(4, dtype=torch.float32)
+    unrelated = torch.ones(2)
+
+    class FakeSafeOpen:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc_info):
+            return None
+
+        def keys(self):
+            return ("layers.0.weight", "layers.1.weight")
+
+        def get_tensor(self, key):
+            return selected if key == "layers.0.weight" else unrelated
+
+    monkeypatch.setattr(
+        "drift.server.from_pretrained.safetensors.safe_open",
+        lambda *args, **kwargs: FakeSafeOpen(),
+    )
+
+    loaded = _load_state_dict_from_local_file("model.safetensors", block_prefix="layers.0.")
+
+    assert set(loaded) == {"layers.0.weight"}
+    assert torch.equal(loaded["layers.0.weight"], selected)
+    assert loaded["layers.0.weight"].data_ptr() != selected.data_ptr()
+    selected.add_(100)
+    assert torch.equal(loaded["layers.0.weight"], torch.arange(4, dtype=torch.float32))
 
 
 def test_chunked_lm_head_warning_reports_actual_dtype_once(monkeypatch):

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -19,6 +19,7 @@ from drift.model_catalog import (
     SignedModelCatalog,
     select_highest_eligible_model,
 )
+from drift.node.catalog_bootstrap import CatalogBootstrapConfig
 
 NOW = 2_000_000_000.0
 
@@ -308,6 +309,7 @@ def test_catalog_cli_keygen_root_sign_verify_and_rollback_state(tmp_path, monkey
     public_key = tmp_path / "catalog.pub.json"
     trust_root = tmp_path / "root.json"
     signed = tmp_path / "catalog.signed.json"
+    bootstrap = tmp_path / "catalog-bootstrap.json"
     state = tmp_path / "state.json"
     source = catalog_dict()
     current = time.time()
@@ -333,10 +335,22 @@ def test_catalog_cli_keygen_root_sign_verify_and_rollback_state(tmp_path, monkey
         str(trust_root),
     )
     run("sign", str(payload), "--key", str(private_key), "--output", str(signed))
+    run(
+        "bootstrap-config",
+        "--root",
+        str(trust_root),
+        "--catalog-mirror",
+        "https://catalog.example/catalog.signed.json",
+        "--initial-peer",
+        "/dns4/bootstrap.example/tcp/31337/p2p/QmExample",
+        "--output",
+        str(bootstrap),
+    )
     output = run("verify", str(signed), "--root", str(trust_root), "--state", str(state))
 
     assert "valid catalog communityai-test sequence 1" in output
     assert CatalogRollbackGuard.load(state).latest["communityai-test"][0] == 1
+    assert CatalogBootstrapConfig.load(bootstrap).trust_root.catalog_id == "communityai-test"
 
 
 def test_catalog_cli_never_overwrites_a_signing_input(tmp_path, monkeypatch):

--- a/tests/test_model_manifest.py
+++ b/tests/test_model_manifest.py
@@ -15,6 +15,29 @@ from drift.model_manifest import (
 from drift.server.handler import TransformerConnectionHandler
 
 
+def test_qwen3_first_rung_candidate_is_exactly_pinned():
+    candidate = Path(__file__).resolve().parents[1] / "manifests" / "candidates" / "qwen3-1.7b-bfloat16-eager.json"
+    manifest = ModelManifest.load(candidate)
+
+    assert manifest.name == "Qwen3 1.7B"
+    assert manifest.aliases == ("qwen3-1.7b",)
+    assert manifest.source.repository == "Qwen/Qwen3-1.7B"
+    assert manifest.source.revision == "70d244cc86ccca08cf5af4e1e306ecf908b1ad5e"
+    assert manifest.model.architecture == "Qwen3ForCausalLM"
+    assert manifest.model.num_blocks == 28
+    assert manifest.model.license == "apache-2.0"
+    assert manifest.model.gated is False
+    assert manifest.runtime.dtype == "bfloat16"
+    assert manifest.runtime.attention_implementation == "eager"
+    assert manifest.runtime.quantization == "none"
+    assert manifest.digest_id == "sha256:aef22f8678f9c5dcc5315913cf1cf584fa9e6c2fba8d064f715d78d823c9f056"
+    assert sum(artifact.size for artifact in manifest.artifacts) == 4_079_422_995
+    assert {artifact.path: artifact.sha256 for artifact in manifest.artifacts if artifact.role == "weight"} == {
+        "model-00001-of-00002.safetensors": "169ad53ec313c3a34b06c0809216e4fc072cce444a5d4ff2b59690d064130ed5",
+        "model-00002-of-00002.safetensors": "912becff8d60672aa8628ef08c05898d9adf17c2ad4ae3caf99b065622fdeff9",
+    }
+
+
 def manifest_dict():
     return {
         "schema_version": 1,

--- a/tests/test_node_config.py
+++ b/tests/test_node_config.py
@@ -3,7 +3,6 @@ import sys
 from pathlib import Path
 
 import pytest
-
 from drift.cli.run_node import _build_model_manager, _build_worker_supervisor
 from drift.model_manifest import ModelManifest
 from drift.node.config import NODE_CONFIG_SCHEMA_VERSION, NodeConfig, NodeConfigError, NodeModelConfig, WorkerConfig
@@ -184,4 +183,10 @@ def test_worker_supervisor_command_is_pinned_to_configured_manifest(monkeypatch,
     assert "provider-token" not in launch.command
     assert launch.environment == (("HF_TOKEN", "provider-token"),)
     supervisor.shutdown()
+
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    frozen_supervisor = _build_worker_supervisor(config, manager, token=None)
+    assert frozen_supervisor.launches[0].command[:2] == (sys.executable, "server")
+    assert "-m" not in frozen_supervisor.launches[0].command
+    frozen_supervisor.shutdown()
     manager.shutdown()

--- a/tests/test_node_config.py
+++ b/tests/test_node_config.py
@@ -3,6 +3,7 @@ import sys
 from pathlib import Path
 
 import pytest
+
 from drift.cli.run_node import _build_model_manager, _build_worker_supervisor
 from drift.model_manifest import ModelManifest
 from drift.node.config import NODE_CONFIG_SCHEMA_VERSION, NodeConfig, NodeConfigError, NodeModelConfig, WorkerConfig

--- a/tests/test_qualification_harness.py
+++ b/tests/test_qualification_harness.py
@@ -1,0 +1,98 @@
+import json
+from pathlib import Path
+
+from scripts.qualify_model_manifest import (
+    build_smoke_command,
+    extract_smoke_evidence,
+    infer_hub_cache_dir,
+    main,
+    smoke_evidence_passed,
+)
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+VECTOR_MANIFEST = REPOSITORY_ROOT / "tests" / "data" / "model_manifest_v1_vector.json"
+
+
+def test_extract_smoke_evidence_requires_exact_parity_and_completion():
+    output = "\n".join(
+        (
+            "client_input_embeddings_placement=devices=['cpu'],dtypes=['float32']",
+            "client_lm_head_placement=devices=['cpu'],dtypes=['float32']",
+            "output_ids=[[1, 2, 3]]",
+            "reference_output_ids=[[1, 2, 3]]",
+            "distributed output matches the stock model exactly",
+            "manifested local swarm qualification ok model=org/model",
+        )
+    )
+
+    evidence = extract_smoke_evidence(output, failover=False)
+
+    assert smoke_evidence_passed(evidence, failover=False)
+    assert evidence["distributed_output_ids"] == [[1, 2, 3]]
+    assert evidence["reference_output_ids"] == [[1, 2, 3]]
+    assert evidence["client_input_embeddings_placement"] == "devices=['cpu'],dtypes=['float32']"
+
+
+def test_failover_evidence_requires_an_interrupted_worker_and_recovery_measurement():
+    parity_only = "\n".join(
+        (
+            "distributed output matches the stock model exactly",
+            "manifested local swarm qualification ok model=org/model",
+        )
+    )
+    assert not smoke_evidence_passed(extract_smoke_evidence(parity_only, failover=True), failover=True)
+
+    recovered = parity_only + "\ninterrupting selected worker replica=0 peer=peer\nfailover_recovery_seconds=3.125"
+    evidence = extract_smoke_evidence(recovered, failover=True)
+    assert smoke_evidence_passed(evidence, failover=True)
+    assert evidence["failover_recovery_seconds"] == 3.125
+
+
+def test_smoke_command_is_manifest_driven_and_contains_no_provider_secret(tmp_path):
+    manifest = tmp_path / "qwen.json"
+    artifact_root = tmp_path / "snapshot"
+    cache_dir = tmp_path / "cache"
+
+    command = build_smoke_command(
+        manifest,
+        artifact_root=artifact_root,
+        cache_dir=cache_dir,
+        device="cpu",
+        prompt="Hello",
+        new_tokens=3,
+        timeout=120,
+        cache="paged",
+        page_size=8,
+        failover=True,
+        failover_tokens=6,
+    )
+
+    assert "--model-manifest" in command
+    assert str(manifest) in command
+    assert str(artifact_root) in command
+    assert str(cache_dir) in command
+    assert "--test-failover" in command
+    assert "--token" not in command
+    assert "Maykeye/TinyLLama-v0" not in command
+
+
+def test_hub_snapshot_cache_is_inferred_narrowly(tmp_path):
+    hub = tmp_path / "hub"
+    snapshot = hub / "models--Qwen--Qwen3-1.7B" / "snapshots" / ("a" * 40)
+    ordinary_snapshot = tmp_path / "publisher-snapshot"
+
+    assert infer_hub_cache_dir(snapshot) == hub
+    assert infer_hub_cache_dir(ordinary_snapshot) is None
+
+
+def test_manifest_only_report_is_explicitly_partial(tmp_path):
+    output = tmp_path / "qualification.json"
+
+    assert main([str(VECTOR_MANIFEST), "--manifest-only", "--output", str(output)]) == 0
+
+    report = json.loads(output.read_text(encoding="utf-8"))
+    assert report["result"] == "passed"
+    assert report["complete_release_qualification"] is False
+    assert report["requested"]["local_parity"] is False
+    assert report["stages"][0]["evidence"]["manifest_digest"].startswith("sha256:")
+    assert "multi-machine routing and interruption recovery" in report["not_covered"]


### PR DESCRIPTION
## Summary

- bundle and smoke a separately frozen desktop node sidecar
- add strict signed-catalog bootstrap consumption and first-install configuration
- add the model-agnostic qualification harness and pinned Qwen3 1.7B candidate
- record the completed evidence and remaining release gates

## Validation

- `247 passed, 7 skipped` in the CI-equivalent offline core suite
- `24 passed` in the desktop source suite