### PR TITLE
Record Qwen edge envelope and simplify manifested worker startup

### DIFF
--- a/docs/MODEL_MANIFEST_V1.md
+++ b/docs/MODEL_MANIFEST_V1.md
@@ -125,7 +125,8 @@ document. The full 256 bits are retained in the DHT prefix.
 
 Both worker and API processes accept `--model_manifest <path>`. Manifest mode:
 
-- requires the requested repository to match `source.repository`;
+- derives the repository from `source.repository` when the worker command omits it,
+  and rejects a conflicting explicitly requested repository;
 - replaces an omitted revision with the pinned commit and rejects a conflicting
   `--revision`;
 - derives the DHT prefix and rejects a conflicting `--dht_prefix`;

--- a/docs/MODEL_QUALIFICATION_V1.md
+++ b/docs/MODEL_QUALIFICATION_V1.md
@@ -3,9 +3,10 @@
 Status: the model-agnostic single-machine harness is implemented. The first-rung
 primary candidate is pinned in
 [`manifests/candidates/qwen3-1.7b-bfloat16-eager.json`](../manifests/candidates/qwen3-1.7b-bfloat16-eager.json),
-and has passed full-artifact audit, local Windows CPU parity, and selected-worker
-interruption recovery. A candidate manifest is not catalog approval. The remaining
-evidence below must be attached before its digest enters a signed production catalog.
+and has passed full-artifact audit, local Windows CPU parity, selected-worker
+interruption recovery, and the Windows CPU cold-client edge envelope. A candidate
+manifest is not catalog approval. The remaining evidence below must be attached before
+its digest enters a signed production catalog.
 
 ## Candidate identity
 
@@ -59,6 +60,23 @@ seconds, and produced the same exact stock IDs. Before inference, the runner has
 4,079,422,995 declared bytes. It inferred the Hub cache root from the audited immutable
 snapshot and recorded that provenance in the report.
 
+A separate Windows CPU edge run at source commit
+`fe49406a2daaf3b864f77296e4669a2608e572e8` used DRIFT 2.3.0.dev2,
+Transformers 5.13.0, Torch 2.6.0+cpu, an empty dedicated client cache, and one
+full-range manifested worker with PeerID
+`QmUybXtFVfJzBejSEJ3wTRe9rV9TnuQaXsAdguyQxXHihy`. After all 4,079,422,995
+declared artifact bytes were verified, the dedicated cache had grown by
+4,079,449,800 bytes. The client loaded 622,329,856 unique bytes for the tied input
+embeddings and output head and measured a 1,040,101,376-byte process-tree peak RSS
+delta. The cold load took 2,574.943 seconds at the available network rate;
+after load, first token took 2.079 seconds and the remaining decode ran at 1.738
+tokens per second. Eight generated tokens completed through route `0:28`. The
+bounded result is retained in
+[`qwen3-1.7b-bfloat16-eager-windows-cpu-edge.json`](evidence/qwen3-1.7b-bfloat16-eager-windows-cpu-edge.json).
+The client closed its DHT and the separately owned worker process tree was stopped;
+its loopback port was verified closed. This is Windows CPU evidence only and does
+not claim the remaining device or platform envelopes.
+
 The first full-model attempt exposed that same-dtype block tensors returned by
 `safetensors.safe_open` retained a mapping of the complete 3.44 GB shard for every
 loaded block. Windows exhausted commit/virtual memory and the native process failed
@@ -84,7 +102,7 @@ machine cannot prove the public release gates.
 | Local interruption recovery | Two complete signed replicas, selected-worker stop, activation replay, exact stock parity | Implemented as `--with-failover` |
 | Multi-machine parity and recovery | Split route and redundant route on separate machines; selected process killed during generation | External run required |
 | Cross-platform execution | Claimed CPU/CUDA/MPS profiles tested without silently changing dtype or attention | External matrix required |
-| Edge envelope | Cold cache growth, local embedding/head bytes, RSS/accelerator peaks, load/first-token/decode timing | `drift edge-benchmark` run required |
+| Edge envelope | Cold cache growth, local embedding/head bytes, RSS/accelerator peaks, load/first-token/decode timing | Windows CPU complete; other claimed device classes require external runs |
 | Public availability | Target bottleneck replicas, independent complete routes, largest-peer-loss survival, fresh measurements and soak | Public workers required |
 | Catalog approval | Primary and standby qualified, threshold signatures, mirrors and release bootstrap published | Release process required |
 

--- a/docs/REVIVAL.md
+++ b/docs/REVIVAL.md
@@ -61,10 +61,11 @@ public release input without moving trust code into the GUI. The model-agnostic
 qualification path now pins the official Qwen3 1.7B primary candidate as exact digest
 `sha256:aef22f8678f9c5dcc5315913cf1cf584fa9e6c2fba8d064f715d78d823c9f056`; all 28
 blocks passed full-artifact Windows CPU parity and two-replica selected-worker recovery.
-That local evidence does not yet make the candidate catalog-approved. The remaining
-primary matrix, standby manifest, signed catalog distribution, release bootstrap, and
-actual model workers are not yet published. Those qualification, publication, and real
-packaged clean-install inference gates are the immediate objective.
+Its cold-client Windows CPU edge envelope is also measured. That local evidence does
+not yet make the candidate catalog-approved. The remaining primary matrix, standby
+manifest, signed catalog distribution, release bootstrap, and actual model workers are
+not yet published. Those qualification, publication, and real packaged clean-install
+inference gates are the immediate objective.
 Contribution policies and budgets, accessibility and resource measurements, and signed
 installer/update/rollback validation follow. Milestones 6 through 8 remain planned
 after this desktop foundation.
@@ -714,8 +715,10 @@ implementation.
    audited all 4,079,422,995 declared bytes, served all 28 blocks, matched stock token IDs
    exactly, and recovered through a surviving full replica in 4.484 seconds. The run also
    fixed a safetensors loader defect that retained a complete large-shard mapping per
-   same-dtype block. Multi-machine, other-platform, edge-envelope, public-route, and
-   standby evidence remain open as specified in
+   same-dtype block. A separate cold-client Windows CPU route then measured the exact
+   model's cache, local embedding/head, RSS, first-token, and decode envelope.
+   Multi-machine, other-platform and device-class edge, public-route, and standby
+   evidence remain open as specified in
    [`MODEL_QUALIFICATION_V1.md`](MODEL_QUALIFICATION_V1.md).
 
    **Next implementation sequence.** Complete the Qwen3 primary's external qualification

--- a/docs/REVIVAL_TEST_RESULTS.md
+++ b/docs/REVIVAL_TEST_RESULTS.md
@@ -159,14 +159,23 @@ Windows CPU, and produced `[[9707,25,358,2776]]`, exactly matching the stock eag
 model. A two-replica run interrupted the selected worker, recovered in 4.484 seconds,
 and preserved the same exact IDs.
 
+A separate cold-client Windows CPU run connected to one full-range signed worker and
+completed the Qwen edge benchmark from an empty cache. After the 4,079,422,995
+declared artifact bytes were verified, the cache had grown by 4,079,449,800 bytes.
+The client loaded 622,329,856 unique bytes for the tied local embedding/head,
+measured a 1,040,101,376-byte process-tree peak RSS delta, reached first token in
+2.079 seconds after the cold load, and decoded subsequent tokens at 1.738 tokens per
+second. The bounded JSON evidence is retained in
+[`qwen3-1.7b-bfloat16-eager-windows-cpu-edge.json`](evidence/qwen3-1.7b-bfloat16-eager-windows-cpu-edge.json).
+
 The first Qwen load also found and fixed a larger-model Windows defect: same-dtype
 block tensors kept their complete safetensors shard mapping, accumulating one 3.44 GB
 mapping per block until the process failed while loading block 25. The loader now
 copies only the selected block tensors into owned CPU storage before closing the file
 mapping. A regression test checks storage independence, and the TinyLlama parity plus
 focused loader/model suites passed before the full Qwen rerun. The candidate manifest
-is still not catalog approval: multi-machine, cross-platform, edge, and public-route
-evidence plus the first-rung standby qualification remain open.
+is still not catalog approval: multi-machine, cross-platform, remaining device-class
+edge, and public-route evidence plus the first-rung standby qualification remain open.
 
 ## Desktop milestone: shell decision
 

--- a/docs/evidence/qwen3-1.7b-bfloat16-eager-windows-cpu-edge.json
+++ b/docs/evidence/qwen3-1.7b-bfloat16-eager-windows-cpu-edge.json
@@ -1,0 +1,80 @@
+{
+  "latency": {
+    "decode_seconds_after_first_token": 4.027199400006793,
+    "decode_tokens_per_second": 1.738180632423662,
+    "first_token_seconds": 2.0788238000823185,
+    "load_seconds": 2574.9430878000567,
+    "total_generation_seconds": 6.108027000096627
+  },
+  "measured_at_unix": 1787516227,
+  "memory": {
+    "accelerators": {},
+    "client_components": {
+      "components": {
+        "input_embeddings": {
+          "devices": [
+            "cpu"
+          ],
+          "dtypes": [
+            "bfloat16"
+          ],
+          "parameter_bytes": 622329856,
+          "parameter_count": 311164928
+        },
+        "output_head": {
+          "devices": [
+            "cpu"
+          ],
+          "dtypes": [
+            "bfloat16"
+          ],
+          "parameter_bytes": 622329856,
+          "parameter_count": 311164928
+        }
+      },
+      "unique_parameter_bytes": 622329856
+    },
+    "process_tree_rss_baseline_bytes": 341151744,
+    "process_tree_rss_loaded_bytes": 799625216,
+    "process_tree_rss_peak_bytes": 1381253120,
+    "process_tree_rss_peak_delta_bytes": 1040101376
+  },
+  "model": {
+    "dtype": "bfloat16",
+    "id": "Qwen3 1.7B",
+    "manifest_digest": "sha256:aef22f8678f9c5dcc5315913cf1cf584fa9e6c2fba8d064f715d78d823c9f056",
+    "repository": "Qwen/Qwen3-1.7B",
+    "revision": "70d244cc86ccca08cf5af4e1e306ecf908b1ad5e"
+  },
+  "runtime": {
+    "drift": "2.3.0.dev2",
+    "platform": "Windows-10-10.0.19045-SP0",
+    "python": "3.12.9",
+    "torch": "2.6.0+cpu"
+  },
+  "schema_version": 1,
+  "storage": {
+    "cache_bytes_after": 4079449800,
+    "cache_bytes_before": 0,
+    "cache_growth_bytes": 4079449800,
+    "cold_start": true
+  },
+  "workload": {
+    "decoded": "Hello: I'm trying to understand the concept",
+    "generated_tokens": 8,
+    "output_ids": [
+      9707,
+      25,
+      358,
+      2776,
+      4460,
+      311,
+      3535,
+      279,
+      7286
+    ],
+    "prompt": "Hello",
+    "prompt_tokens": 1,
+    "requested_new_tokens": 8
+  }
+}

--- a/src/drift/cli/run_server.py
+++ b/src/drift/cli/run_server.py
@@ -66,7 +66,7 @@ def build_parser() -> configargparse.ArgParser:
                                       formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add('-c', '--config', required=False, is_config_file=True, help='config file path')
 
-    group = parser.add_mutually_exclusive_group(required=True)
+    group = parser.add_mutually_exclusive_group(required=False)
     group.add_argument('--converted_model_name_or_path', type=str, default=None,
                        help="path or name of a pretrained model, converted with cli/convert_model.py")
     group.add_argument('model', nargs='?', type=str, help="same as --converted_model_name_or_path")
@@ -244,12 +244,14 @@ def server_from_args(args: dict) -> Server:
     # Arm this before anything can spawn a p2pd, so a hard-killed server does not orphan its daemons
     tie_child_processes_to_this_process()
 
-    args["converted_model_name_or_path"] = args.pop("model") or args["converted_model_name_or_path"]
-
+    requested_model = args.pop("model") or args["converted_model_name_or_path"]
     manifest_path = args.pop("model_manifest")
     if manifest_path is not None:
         manifest = ModelManifest.load(manifest_path)
         manifest.validate_runtime(drift.__version__)
+        if requested_model is None:
+            requested_model = manifest.source.repository
+        args["converted_model_name_or_path"] = requested_model
         args["revision"], args["dht_prefix"] = resolve_manifest_loading(
             manifest,
             model_name_or_path=args["converted_model_name_or_path"],
@@ -286,8 +288,12 @@ def server_from_args(args: dict) -> Server:
             raise ManifestError(
                 "--identity_path is required with --model_manifest so announcements use a stable libp2p signer"
             )
-    elif args.get("revocation_files"):
-        raise ManifestError("--revocation_file is only valid with --model_manifest")
+    else:
+        if requested_model is None:
+            raise ManifestError("a model is required unless --model_manifest supplies its exact repository")
+        args["converted_model_name_or_path"] = requested_model
+        if args.get("revocation_files"):
+            raise ManifestError("--revocation_file is only valid with --model_manifest")
 
     host_maddrs = args.pop("host_maddrs")
     port = args.pop("port")
@@ -358,12 +364,11 @@ def main():
     args = vars(parser.parse_args())
     args.pop("config", None)
 
-    model_name = args.get("model") or args.get("converted_model_name_or_path")
     try:
         server = server_from_args(args)
     except ManifestError as exc:
         parser.error(str(exc))
-    serve(server, model=model_name)
+    serve(server, model=server.converted_model_name_or_path)
 
 
 if __name__ == "__main__":

--- a/src/drift/cli/run_up.py
+++ b/src/drift/cli/run_up.py
@@ -69,6 +69,7 @@ def main():
         server = server_from_args(args)
     except ManifestError as exc:
         parser.error(str(exc))
+    model_name = server.converted_model_name_or_path
 
     def _on_ready(srv):
         if is_first_node:

--- a/tests/test_model_manifest.py
+++ b/tests/test_model_manifest.py
@@ -532,6 +532,46 @@ def test_server_cli_applies_manifest_profile(tmp_path, monkeypatch):
     assert resolved["model_manifest"].digest == resolved["dht_prefix"].removeprefix("drift-m1-")
 
 
+def test_server_cli_derives_repository_from_manifest(tmp_path, monkeypatch):
+    from drift.cli import run_server
+
+    path = tmp_path / "manifest.json"
+    path.write_text(json.dumps(manifest_dict()), encoding="utf-8")
+    args = vars(
+        run_server.build_parser().parse_args(
+            [
+                "--new_swarm",
+                "--model_manifest",
+                str(path),
+                "--identity_path",
+                str(tmp_path / "worker.key"),
+                "--increase_file_limit",
+                "0",
+            ]
+        )
+    )
+    args.pop("config", None)
+
+    monkeypatch.setattr(run_server, "tie_child_processes_to_this_process", lambda: None)
+    monkeypatch.setattr(run_server, "log_version", lambda: None)
+    monkeypatch.setattr(run_server, "Server", lambda **kwargs: kwargs)
+    resolved = run_server.server_from_args(args)
+
+    assert resolved["converted_model_name_or_path"] == "org/tiny-test"
+    assert resolved["revision"] == "a" * 40
+
+
+def test_server_cli_requires_model_without_manifest(monkeypatch):
+    from drift.cli import run_server
+
+    args = vars(run_server.build_parser().parse_args(["--new_swarm", "--increase_file_limit", "0"]))
+    args.pop("config", None)
+    monkeypatch.setattr(run_server, "tie_child_processes_to_this_process", lambda: None)
+
+    with pytest.raises(ManifestError, match="model is required unless --model_manifest"):
+        run_server.server_from_args(args)
+
+
 def test_manifested_server_requires_persistent_identity(tmp_path, monkeypatch):
     from drift.cli import run_server
 


### PR DESCRIPTION
## Summary

- allow `drift server` and `drift up` to derive the exact repository from `--model_manifest`
- preserve legacy validation when neither a model nor manifest is supplied
- record the Qwen3 1.7B Windows CPU cold-client edge envelope as bounded JSON evidence
- keep multi-machine, cross-platform/device, public-route, and standby qualification gates explicitly open

## Validation

- `249 passed, 7 skipped` in the CI-equivalent offline core suite
- `24 passed` in the desktop source suite
- pinned isort and black checks pass
- live Windows CPU edge run completed through a signed full-range `0:28` route and the owned worker port was verified closed afterward

## External prerequisite

The planned `google/gemma-3-1b-it` standby is pinned upstream at commit `dcc83ea841ab6100d6b47a070329e1ba4cf78752`, but this machine cannot fetch its gated artifacts until the Hugging Face account accepts Google's Gemma usage terms.